### PR TITLE
[FIX] 공통 버튼컴포넌트 삭제된 기능 및 기능 추가 (#28)

### DIFF
--- a/src/shared/components/Button/index.tsx
+++ b/src/shared/components/Button/index.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import styled from '@emotion/styled';
 import type { ReactNode } from 'react';
 
-type Variant = 'primary' | 'primaryLight' | 'primaryOutline';
+type Variant = 'light' | 'outline';
 
 type Props = {
   children: ReactNode;
@@ -20,7 +20,7 @@ export const Button = ({
   to,
   disabled,
   type = 'button',
-  variant = 'primary',
+  variant,
   width,
 }: Props) => {
   if (to) {
@@ -32,13 +32,7 @@ export const Button = ({
   }
 
   return (
-    <StyledButton
-      onClick={onClick}
-      $disabled={disabled}
-      $variant={variant}
-      $width={width}
-      type={type}
-    >
+    <StyledButton onClick={onClick} $disabled={disabled} $variant={variant} $width={width} type={type}>
       {children}
     </StyledButton>
   );
@@ -46,39 +40,39 @@ export const Button = ({
 
 type StyledProps = {
   $disabled?: boolean;
-  $variant: Variant;
+  $variant?: Variant;
   $width?: string;
 };
 
-const getVariantStyles = (theme: any, variant: Variant, disabled?: boolean) => {
-  switch (variant) {
-    case 'primaryLight':
-      return {
-        backgroundColor: disabled ? theme?.colors?.gray200 : theme?.colors?.primary100,
-        color: theme?.colors?.primary700,
-        '&:hover': {
-          backgroundColor: disabled ? theme?.colors?.gray200 : theme?.colors?.primary200,
-        },
-      };
-    case 'primaryOutline':
-      return {
-        backgroundColor: '#fff',
-        color: theme?.colors?.primary,
-        border: `1px solid ${theme?.colors?.primary}`,
-        '&:hover': {
-          backgroundColor: disabled ? '#fff' : theme?.colors?.primary100,
-        },
-      };
-    case 'primary':
-    default:
-      return {
-        backgroundColor: disabled ? theme?.colors?.gray400 : theme?.colors?.primary,
-        color: '#fff',
-        '&:hover': {
-          backgroundColor: disabled ? theme?.colors?.gray400 : theme?.colors?.primary700,
-        },
-      };
+const getVariantStyles = (theme: any, variant?: Variant, disabled?: boolean) => {
+  if (variant === 'light') {
+    return {
+      backgroundColor: disabled ? theme?.colors?.gray200 : theme?.colors?.primary100,
+      color: theme?.colors?.primary700,
+      '&:hover': {
+        backgroundColor: disabled ? theme?.colors?.gray200 : theme?.colors?.primary200,
+      },
+    };
   }
+
+  if (variant === 'outline') {
+    return {
+      backgroundColor: '#fff',
+      color: theme?.colors?.primary,
+      border: `1px solid ${theme?.colors?.primary}`,
+      '&:hover': {
+        backgroundColor: disabled ? '#fff' : theme?.colors?.primary100,
+      },
+    };
+  }
+
+  return {
+    backgroundColor: disabled ? theme?.colors?.gray400 : theme?.colors?.primary,
+    color: '#fff',
+    '&:hover': {
+      backgroundColor: disabled ? theme?.colors?.gray400 : theme?.colors?.primary700,
+    },
+  };
 };
 
 const baseStyles = ({ theme, $disabled, $variant, $width }: StyledProps & { theme?: any }) => ({


### PR DESCRIPTION
## #️⃣연관된 이슈

> #28 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 1️⃣ 변경/삭제 된 기능 복구

항목 | 기존 버튼 | 경로 이동 이후 버튼
-- | -- | --
Link(to) 지원 | ✅ 있음 | 없음
호버 애니메이션 | ✅ background + transform | 없음
액티브 효과 | ✅ transform | 없음
비활성화 처리 | ✅ color, pointerEvents, transform | color + opacity만
기본 크기 | 고정 320px | auto / prop으로 조절


### 2️⃣ 종류 추가 / 너비 인자 추가

- 피그마 기준으로 모든 큰버튼을 대체할 수 있도록 버튼 종류를 추가했습니다. 

<img width="340" height="283" alt="스크린샷 2025-09-11 오후 8 43 05" src="https://github.com/user-attachments/assets/75ecbe77-0e51-4ae9-ae42-4281509303e0" />

```
<Button>지원하기</Button>
<Button variant="light">지원하기</Button>
<Button variant="outline">지원하기</Button>
<Button width="15rem">지원하기</Button>
<Button variant="outline" width="10rem">지원하기</Button>
```


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- prop를 다양하게 추가하셨던 것이 버튼에서 변경하고싶었던게 있으셨던 것 같아서.. 버튼이 너무 다양하면 안돼서 종류를 아예 만들고, 너비값만 특수한 상황에는 사용할 수 있도록 하였습니다.
- 현재 피그마 기준으로 모든 큰버튼을 기본 및 light 만으로 모든 화면 커버가 가능합니다.
- 통일감을 위해 고정너비를 주었기에 너비 인자는 특수 경우에만 사용하고 되도록 일반 버튼은 너비인자를 사용하지 않으시면 좋을것 같습니다! 다른 의견이 있다면 알려주세요
