### PR TITLE
[FEAT] ClubDetailLayout 공통컴포넌트로 분리#48

### DIFF
--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -1,9 +1,9 @@
-import styled from '@emotion/styled';
 import { ClubHeaderSection } from './components/ClubHeaderSection';
 import { ClubActivityPhotosSection } from './components/ClubActivityPhotosSection';
 import { ClubDescriptionSection } from './components/ClubDescriptionSection';
 import { ClubReviewsSection } from './components/ClubReviewsSection';
 import { ClubInfoSidebarSection } from './components/ClubInfoSidebarSection';
+import { Layout, ContentLeft, ContentRight } from '@/shared/components/ClubDetailLayout';
 
 export const ClubDetailPage = () => {
   return (
@@ -20,65 +20,3 @@ export const ClubDetailPage = () => {
     </Layout>
   );
 };
-
-const Layout = styled.main(({ theme }) => ({
-  backgroundColor: theme.colors.bgBlue,
-  minHeight: '100vh',
-  padding: '2.6rem 3rem',
-  display: 'flex',
-  gap: '1.5rem',
-  flexWrap: 'wrap',
-  justifyContent: 'center',
-  maxWidth: '1200px',
-  margin: '0 auto',
-
-  [`@media (max-width: ${theme.breakpoints.web})`]: {
-    padding: '1.5rem',
-  },
-  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    flexDirection: 'column',
-    padding: '1rem',
-  },
-}));
-
-const ContentLeft = styled.div(({ theme }) => ({
-  flex: '1 1 0',
-  backgroundColor: theme.colors.bg,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '1.5rem',
-  padding: '1.5rem',
-  boxSizing: 'border-box',
-  minWidth: '25rem',
-  borderRadius: theme.radius.lg,
-  minHeight: '20rem',
-
-  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    minWidth: '100%',
-    padding: '1rem',
-  },
-}));
-
-const ContentRight = styled.div(({ theme }) => ({
-  flex: '0 0 25rem',
-  backgroundColor: theme.colors.bg,
-  padding: '1.5rem',
-  boxSizing: 'border-box',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '1rem',
-  borderRadius: theme.radius.lg,
-  height: 'auto',
-  alignSelf: 'flex-start',
-
-  [`@media (max-width: ${theme.breakpoints.web})`]: {
-    flex: '1 1 100%',
-    maxWidth: '31.25rem',
-    margin: '1.5rem auto 0 auto',
-  },
-  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    maxWidth: '100%',
-    margin: '1rem 0 0 0',
-    padding: '1rem',
-  },
-}));

--- a/src/shared/components/ClubDetailLayout/index.tsx
+++ b/src/shared/components/ClubDetailLayout/index.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled';
+
+export const Layout = styled.main(({ theme }) => ({
+  backgroundColor: theme.colors.bgBlue,
+  minHeight: '100vh',
+  padding: '2.6rem 3rem',
+  display: 'flex',
+  gap: '1.5rem',
+  flexWrap: 'wrap',
+  justifyContent: 'center',
+  maxWidth: '1200px',
+  margin: '0 auto',
+
+  [`@media (max-width: ${theme.breakpoints.web})`]: {
+    padding: '1.5rem',
+  },
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    flexDirection: 'column',
+    padding: '1rem',
+  },
+}));
+
+export const ContentLeft = styled.div(({ theme }) => ({
+  flex: '1 1 0',
+  backgroundColor: theme.colors.bg,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+  padding: '1.5rem',
+  boxSizing: 'border-box',
+  minWidth: '25rem',
+  borderRadius: theme.radius.lg,
+  minHeight: '20rem',
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    minWidth: '100%',
+    padding: '1rem',
+  },
+}));
+
+export const ContentRight = styled.div(({ theme }) => ({
+  flex: '0 0 25rem',
+  backgroundColor: theme.colors.bg,
+  padding: '1.5rem',
+  boxSizing: 'border-box',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  borderRadius: theme.radius.lg,
+  height: 'auto',
+  alignSelf: 'flex-start',
+
+  [`@media (max-width: ${theme.breakpoints.web})`]: {
+    flex: '1 1 100%',
+    maxWidth: '31.25rem',
+    margin: '1.5rem auto 0 auto',
+  },
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    maxWidth: '100%',
+    margin: '1rem 0 0 0',
+    padding: '1rem',
+  },
+}));


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #48 

## 📝작업 내용

> 동아리 상세페이지(user)와 수정 페이지(admin)에서 동일한 레이아웃을 재사용할 수 있도록
Layout, ContentLeft, ContentRight를 ClubDetailLayout이라는 공통컴포넌트로 분리했습니다.

- shared 컴포넌트에 ClubDetailLayout 생성
- 동아리 상세페이지에서 Layout, ContentLeft, ContentRight를 분리하여 공통컴포넌트 활용
- ClubHeaderSection은.. 수정여부를 아직 잘 모르겠어서 고민 중이며 일단 기존 구조 유지했습니당

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 동아리 이름, 분과를 상세페이지에서 수정할 수 없게 할까요? 이에대해 말씀주시면 감사하겠습니당
