### PR TITLE
[REFACTOR] 별점 렌더링 성능 개선 (#64)

### DIFF
--- a/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStarRating.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStarRating.tsx
@@ -1,24 +1,27 @@
+import { useMemo } from 'react';
 import styled from '@emotion/styled';
 
+const getFillPercentage = (rating: number, index: number) => {
+  if (rating >= index) return 100;
+  if (rating > index - 1) return (rating - (index - 1)) * 100;
+  return 0;
+};
+
+const STAR_INDICES = [1, 2, 3, 4, 5];
+
 export const ApplicantStarRating = ({ rating = 0 }: { rating?: number }) => {
-  const stars = [];
+  const stars = useMemo(() => {
+    return STAR_INDICES.map((i) => {
+      const fillPercentage = getFillPercentage(rating, i);
 
-  for (let i = 1; i <= 5; i++) {
-    let fillPercentage = 0;
-
-    if (rating >= i) {
-      fillPercentage = 100;
-    } else if (rating > i - 1) {
-      fillPercentage = (rating - (i - 1)) * 100;
-    }
-
-    stars.push(
-      <StarWrapper key={i}>
-        <StarEmpty>★</StarEmpty>
-        <StarFilled fillPercentage={fillPercentage}>★</StarFilled>
-      </StarWrapper>,
-    );
-  }
+      return (
+        <StarWrapper key={i}>
+          <StarEmpty>★</StarEmpty>
+          <StarFilled fillPercentage={fillPercentage}>★</StarFilled>
+        </StarWrapper>
+      );
+    });
+  }, [rating]);
 
   return <StarContainer>{stars}</StarContainer>;
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #64 

## 📝작업 내용

- 별 배열을 생성하는 로직을 `useMemo` 훅으로 감싸고, 의존성 배열에 `[rating]`을 설정했습니다.
-`rating` prop이 변경될 때만 별 계산 로직이 실행됩니다.
- 가독성 향상을 위해 기존 `for` 루프 구문을 `.map`을 사용하는 방식으로 변경했습니다.

