### PR TITLE
[FEAT] React Query의 캐싱 적용으로 불필요한 API 호출 제거

### DIFF
--- a/src/mocks/handler/applicant.ts
+++ b/src/mocks/handler/applicant.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw';
 import { applicantRepository } from '../repositories/applicant';
+import type { DetailApplication } from '@/pages/admin/ApplicationDetail/types/detailApplication';
 
 const getApplicantsResolver = ({ request }: { request: Request }) => {
   const url = new URL(request.url);
@@ -21,5 +22,20 @@ export const applicantHandlers = [
   http.get(
     import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/applicants/:applicantId/application',
     getDetailApplicationResolver,
+  ),
+
+  http.patch(
+    import.meta.env.VITE_API_BASE_URL + '/applications/:applicationId',
+    async ({ params, request }) => {
+      const { applicationId } = params;
+      interface UpdateApplicationStatusRequest {
+        status: DetailApplication['status'];
+      }
+      const { status } = (await request.json()) as UpdateApplicationStatusRequest;
+
+      applicantRepository.updateApplicationStatus(Number(applicationId), status);
+
+      return HttpResponse.json({ status: 200 });
+    },
   ),
 ];

--- a/src/mocks/repositories/applicant.ts
+++ b/src/mocks/repositories/applicant.ts
@@ -99,4 +99,12 @@ export const applicantRepository = {
   getDetailApplication: () => {
     return detailApplication;
   },
+
+  updateApplicationStatus: (applicationId: number, status: DetailApplication['status']) => {
+    if (detailApplication.applicationId === applicationId) {
+      detailApplication.status = status;
+      return { success: true };
+    }
+    return { success: false };
+  },
 };

--- a/src/pages/admin/ApplicationDetail/Page.tsx
+++ b/src/pages/admin/ApplicationDetail/Page.tsx
@@ -9,7 +9,7 @@ import { useParams } from 'react-router-dom';
 export const ApplicationDetailPage = () => {
   const { clubId, applicantId } = useParams();
 
-  const { detailApplicants, isError, isLoading } = useDetailApplications(
+  const { detailApplicants, isError, isLoading, updateStatus } = useDetailApplications(
     Number(clubId),
     Number(applicantId),
   );
@@ -25,6 +25,7 @@ export const ApplicationDetailPage = () => {
           department={detailApplicants?.applicantInfo.department}
           status={detailApplicants?.status}
           rating={detailApplicants?.rating}
+          updateStatus={updateStatus}
         />
         <ApplicantInfoSection
           studentId={detailApplicants?.applicantInfo.studentId}

--- a/src/pages/admin/ApplicationDetail/api/detailApplication.ts
+++ b/src/pages/admin/ApplicationDetail/api/detailApplication.ts
@@ -9,3 +9,16 @@ export const fetchDetailApplication = async (
   );
   return await response.json();
 };
+
+export const updateApplicationStatus = async (
+  applicationId: number,
+  status: DetailApplication['status'],
+): Promise<void> => {
+  await fetch(import.meta.env.VITE_API_BASE_URL + `/applications/${applicationId}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ status }),
+  });
+};

--- a/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStatusToggle.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStatusToggle.tsx
@@ -5,10 +5,16 @@ import type { ApplicantStatus } from '@/pages/admin/Dashboard/types/dashboard';
 
 type Props = {
   status?: ApplicantStatus;
+  updateStatus: (status: ApplicantStatus) => void;
 };
 
-export const ApplicantStatusToggle = ({ status }: Props) => {
+export const ApplicantStatusToggle = ({ status, updateStatus }: Props) => {
   const [statusOption, setStatusOption] = useState(status);
+
+  const handleClick = (newStatus: ApplicantStatus) => {
+    setStatusOption(newStatus);
+    updateStatus(newStatus);
+  };
 
   return (
     <Container>
@@ -16,19 +22,19 @@ export const ApplicantStatusToggle = ({ status }: Props) => {
         label={'합격'}
         value={'ACCEPTED'}
         selected={statusOption === 'ACCEPTED'}
-        onClick={setStatusOption}
+        onClick={handleClick}
       />
       <ApplicantStatusButton
         label={'불합격'}
         value={'REJECTED'}
         selected={statusOption === 'REJECTED'}
-        onClick={setStatusOption}
+        onClick={handleClick}
       />
       <ApplicantStatusButton
         label={'미정'}
         value={'PENDING'}
         selected={statusOption === 'PENDING'}
-        onClick={setStatusOption}
+        onClick={handleClick}
       />
     </Container>
   );

--- a/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/index.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/index.tsx
@@ -9,9 +9,16 @@ type Props = {
   department?: string;
   status?: ApplicantStatus;
   rating?: number;
+  updateStatus: (status: ApplicantStatus) => void;
 };
 
-export const ApplicantProfileSection = ({ name, department, status, rating }: Props) => {
+export const ApplicantProfileSection = ({
+  name,
+  department,
+  status,
+  rating,
+  updateStatus,
+}: Props) => {
   return (
     <Container>
       <LeftSection>
@@ -22,7 +29,7 @@ export const ApplicantProfileSection = ({ name, department, status, rating }: Pr
         <ApplicantStarRating rating={rating} />
       </LeftSection>
       <RightSection>
-        <ApplicantStatusToggle status={status} />
+        <ApplicantStatusToggle status={status} updateStatus={updateStatus} />
       </RightSection>
     </Container>
   );

--- a/src/pages/admin/ApplicationDetail/hooks/useDetailApplication.ts
+++ b/src/pages/admin/ApplicationDetail/hooks/useDetailApplication.ts
@@ -1,25 +1,54 @@
-import { useQuery } from '@tanstack/react-query';
-import { fetchDetailApplication } from '@/pages/admin/ApplicationDetail/api/detailApplication';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchDetailApplication,
+  updateApplicationStatus,
+} from '@/pages/admin/ApplicationDetail/api/detailApplication';
 import type { DetailApplication } from '@/pages/admin/ApplicationDetail/types/detailApplication';
 
 interface UseDetailApplicationResult {
   detailApplicants: DetailApplication | null;
   isLoading: boolean;
   isError: boolean;
+  updateStatus: (status: DetailApplication['status']) => void;
 }
 
 export const useDetailApplications = (
   clubId: number,
   applicantId: number,
 ): UseDetailApplicationResult => {
+  const queryClient = useQueryClient();
+
   const { data, isLoading, isError } = useQuery({
     queryKey: ['detailApplications', clubId, applicantId],
     queryFn: () => fetchDetailApplication(clubId!, applicantId!),
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const { mutate: updateStatus } = useMutation({
+    mutationFn: (status: DetailApplication['status']) => {
+      if (!data?.applicationId) {
+        throw new Error('신청서 ID를 찾을 수 없습니다.');
+      }
+      return updateApplicationStatus(data.applicationId, status);
+    },
+    onSuccess: (_, newStatus) => {
+      queryClient.setQueryData(
+        ['detailApplications', clubId, applicantId],
+        (oldData: DetailApplication | undefined) => {
+          if (oldData) {
+            return { ...oldData, status: newStatus };
+          }
+          return oldData;
+        },
+      );
+      queryClient.invalidateQueries({ queryKey: ['applicants'] });
+    },
   });
 
   return {
     detailApplicants: data || null,
     isLoading: isLoading,
     isError: isError,
+    updateStatus,
   };
 };

--- a/src/pages/admin/Dashboard/hooks/useApplicants.ts
+++ b/src/pages/admin/Dashboard/hooks/useApplicants.ts
@@ -18,6 +18,7 @@ export const useApplicants = (
   const { data, isLoading, isError } = useQuery({
     queryKey: ['applicants', clubId, status],
     queryFn: () => fetchApplicants(clubId, status),
+    staleTime: 1000 * 60 * 2,
   });
 
   return {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #71 

## 📝 작업 내용

어드민 페이지의 불필요한 API 호출을 제거하기 위해 React Query의 캐싱을 적용하였습니다.
페이지 이동 및 사용자 행동 시 발생하는 반복적인 데이터 조회를 막고, 데이터 변경 시에는 즉각적인 UI 피드백을 제공합니다.

**1. staleTime을 이용한 캐싱 전략 도입**

- useApplicants (지원자 목록): staleTime을 2분으로 설정하여, 잦은 페이지 이동에도 불필요한 목록 API 호출이 발생하지 않도록 개선했습니다.

- useApplicantDetail (지원서 상세): staleTime을 5분으로 설정하여, 여러 지원자를 반복적으로 확인할 때 캐시를 최대한 활용하도록 최적화했습니다.

**2. setQueryData를 통한 상세 페이지 즉시 업데이트 구현**

- 지원서 상세 페이지에서 관리자가 지원자의 상태(합격/불합격 등)를 변경할 경우, mutation 성공 시 setQueryData를 사용하여 API 재요청 없이 캐시를 직접 업데이트하도록 구현했습니다.


**3. invalidateQueries를 통한 목록 데이터 정합성 보장**

- 상세 페이지에서 합/불을 변경할 시, 최신화된 목록을 제공하기 위해 invalidateQueries(['applicants'])를 함께 호출했습니다.
(2분동안 api 호출 안 하다가 합/불 상태가 변경되면 api 호출되도록)




## 📷 스크린샷 
### 캐싱 적용 전
- 불필요하게 많은 api호출
![화면 기록 2025-09-21 오전 2 52 24 (1)](https://github.com/user-attachments/assets/18d2afce-84b5-4112-8ab4-48b610ed015e)




### 캐싱 적용 후
![화면 기록 2025-09-21 오전 2 53 59](https://github.com/user-attachments/assets/13bbaebc-1240-48b9-a0b3-0c1c965ebb15)


### 상태 업데이트(합/불) 시, 최신반영을 위해 지원자 목록 api 호출

![화면 기록 2025-09-21 오전 2 55 38](https://github.com/user-attachments/assets/e931a7a7-40ad-45f8-9e65-1f957684dc14)

