### PR TITLE
[FEAT] 동아리 지원 페이지 - 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "msw": "^2.11.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-hook-form": "^7.62.0",
+        "react-hook-form": "^7.63.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.8.2",
         "reset-css": "^5.0.2"
@@ -5669,9 +5669,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.62.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
-      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "version": "7.63.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
+      "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "msw": "^2.11.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-hook-form": "^7.62.0",
+    "react-hook-form": "^7.63.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.8.2",
     "reset-css": "^5.0.2"

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,8 +7,8 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.11.1'
-const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
+const PACKAGE_VERSION = '2.11.2'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -71,11 +71,6 @@ addEventListener('message', async function (event) {
       break
     }
 
-    case 'MOCK_DEACTIVATE': {
-      activeClientIds.delete(clientId)
-      break
-    }
-
     case 'CLIENT_CLOSED': {
       activeClientIds.delete(clientId)
 
@@ -94,6 +89,8 @@ addEventListener('message', async function (event) {
 })
 
 addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
   // Bypass navigation requests.
   if (event.request.mode === 'navigate') {
     return
@@ -110,23 +107,29 @@ addEventListener('fetch', function (event) {
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
-  // after it's been deleted (still remains active until the next reload).
+  // after it's been terminated (still remains active until the next reload).
   if (activeClientIds.size === 0) {
     return
   }
 
   const requestId = crypto.randomUUID()
-  event.respondWith(handleRequest(event, requestId))
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
 })
 
 /**
  * @param {FetchEvent} event
  * @param {string} requestId
+ * @param {number} requestInterceptedAt
  */
-async function handleRequest(event, requestId) {
+async function handleRequest(event, requestId, requestInterceptedAt) {
   const client = await resolveMainClient(event)
   const requestCloneForEvents = event.request.clone()
-  const response = await getResponse(event, client, requestId)
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
@@ -204,7 +207,7 @@ async function resolveMainClient(event) {
  * @param {string} requestId
  * @returns {Promise<Response>}
  */
-async function getResponse(event, client, requestId) {
+async function getResponse(event, client, requestId, requestInterceptedAt) {
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
   const requestClone = event.request.clone()
@@ -255,6 +258,7 @@ async function getResponse(event, client, requestId) {
       type: 'REQUEST',
       payload: {
         id: requestId,
+        interceptedAt: requestInterceptedAt,
         ...serializedRequest,
       },
     },

--- a/src/constants/routerPath.ts
+++ b/src/constants/routerPath.ts
@@ -3,4 +3,5 @@ export const ROUTE_PATH = {
   APPLICATIONDETAIL: 'clubs/:clubId/applicants/:applicantId',
   MAIN: '/',
   CLUBDETAIL: 'club/:id',
+  CLUBAPPLICATION: 'club/:id/apply',
 };

--- a/src/mocks/handler/club.ts
+++ b/src/mocks/handler/club.ts
@@ -1,5 +1,6 @@
-import { http, HttpResponse } from 'msw';
+import { http, HttpResponse, type PathParams } from 'msw';
 import { clubRepoitory } from '../repositories/club';
+import { ApplicationRepoitory } from '@/mocks/repositories/application.ts';
 
 const getClubsResolver = ({ request }: { request: Request }) => {
   const url = new URL(request.url);
@@ -8,6 +9,19 @@ const getClubsResolver = ({ request }: { request: Request }) => {
   return HttpResponse.json({ clubs }, { status: 200 });
 };
 
+interface ClubApplicationParams extends PathParams {
+  clubId: string;
+}
+
+const getClubApplicationResolver = ({ params }: { params: ClubApplicationParams }) => {
+  const { clubId } = params;
+  const applicationFromData = ApplicationRepoitory.getClubApplication(clubId);
+  return HttpResponse.json(applicationFromData, {
+    status: 200,
+  });
+};
+
 export const clubHandlers = [
   http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/search/category', getClubsResolver),
+  http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/:Id/apply', getClubApplicationResolver),
 ];

--- a/src/mocks/repositories/application.ts
+++ b/src/mocks/repositories/application.ts
@@ -22,6 +22,7 @@ export const Application: ApplicationForm = {
       questionType: 'RADIO',
       question: '개발 경험이 있으신가요?',
       required: false,
+      optionList: ['예', '아니오'],
     },
   ],
 };

--- a/src/mocks/repositories/application.ts
+++ b/src/mocks/repositories/application.ts
@@ -1,0 +1,33 @@
+import type { ApplicationForm } from '@/pages/user/Apply/type/apply.ts';
+
+export const Application: ApplicationForm = {
+  title: '인터엑스 지원서',
+  description: '인터엑스설명설명설명설명',
+  questions: [
+    {
+      questionNum: 1,
+      questionType: 'CHECKBOX',
+      question: '면접가능요일은?',
+      required: true,
+      optionList: ['월', '화', '수', '목', '금'],
+    },
+    {
+      questionNum: 2,
+      questionType: 'TEXT',
+      question: '자기소개를 간단히 적어주세요.',
+      required: true,
+    },
+    {
+      questionNum: 3,
+      questionType: 'RADIO',
+      question: '개발 경험이 있으신가요?',
+      required: false,
+    },
+  ],
+};
+
+export const ApplicationRepoitory = {
+  getClubApplication: (Id: string) => {
+    return Application;
+  },
+};

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -5,15 +5,23 @@ import { ClubDetailPage } from '@/pages/user/ClubDetail/Page';
 import { createBrowserRouter } from 'react-router-dom';
 import { App } from '@/App.tsx';
 import { ROUTE_PATH } from '@/constants/routerPath.ts';
+import { ClubApplicatonPage } from '@/pages/user/Apply/Page.tsx';
 
-const { MAIN, CLUBDETAIL, APPLICATIONDETAIL, DASHBOARD } = ROUTE_PATH;
+const { MAIN, CLUBDETAIL, APPLICATIONDETAIL, DASHBOARD, CLUBAPPLICATION } = ROUTE_PATH;
 
 export const router = createBrowserRouter([
   {
     element: <App />,
     children: [
       { path: MAIN, element: <MainPage /> },
-      { path: CLUBDETAIL, element: <ClubDetailPage /> },
+      {
+        path: CLUBDETAIL,
+        element: <ClubDetailPage />,
+      },
+      {
+        path: CLUBAPPLICATION,
+        element: <ClubApplicatonPage />,
+      },
       {
         path: '/admin',
         children: [

--- a/src/pages/user/Apply/Page.tsx
+++ b/src/pages/user/Apply/Page.tsx
@@ -14,7 +14,7 @@ export const ClubApplicatonPage = () => {
     <Layout>
       <FormContainer>
         <ClubDescription title={formData.title} description={formData?.description ?? ''} />
-        <ApplicationForm />
+        <ApplicationForm questions={formData.questions} />
       </FormContainer>
     </Layout>
   );

--- a/src/pages/user/Apply/Page.tsx
+++ b/src/pages/user/Apply/Page.tsx
@@ -1,0 +1,53 @@
+import { ClubDescription } from '@/pages/user/Apply/components/ClubDescriptionSection/ClubDescription';
+import { useParams } from 'react-router-dom';
+import { useApplicationForm } from './hook/useApplicationForm';
+import styled from '@emotion/styled';
+
+export const ClubApplicatonPage = () => {
+  const { id } = useParams();
+  const formData = useApplicationForm(Number(id));
+
+  if (!formData) return <div>Loading...</div>;
+
+  return (
+    <Layout>
+      <FormContainer>
+        <ClubDescription
+          title={formData.title}
+          description={formData?.description ?? ''}
+        ></ClubDescription>
+      </FormContainer>
+    </Layout>
+  );
+};
+
+export const Layout = styled.main(({ theme }) => ({
+  backgroundColor: theme.colors.bgBlue,
+  minHeight: '100vh',
+  padding: '5.2rem 3rem',
+  display: 'flex',
+  gap: '1.5rem',
+  justifyContent: 'center',
+  maxWidth: '1200px',
+  margin: '0 auto',
+
+  [`@media (max-width: ${theme.breakpoints.web})`]: {
+    padding: '1.5rem',
+  },
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    flexDirection: 'column',
+    padding: '1rem',
+  },
+}));
+
+export const FormContainer = styled.div({
+  backgroundColor: 'white',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '2.6rem 3rem',
+  width: '80%',
+  maxWidth: '1200px',
+  margin: '0 auto',
+  borderRadius: '4rem',
+});

--- a/src/pages/user/Apply/Page.tsx
+++ b/src/pages/user/Apply/Page.tsx
@@ -2,6 +2,7 @@ import { ClubDescription } from '@/pages/user/Apply/components/ClubDescriptionSe
 import { useParams } from 'react-router-dom';
 import { useApplicationForm } from './hook/useApplicationForm';
 import styled from '@emotion/styled';
+import { ApplicationForm } from './components/ApplicantInfo/ApplicationForm';
 
 export const ClubApplicatonPage = () => {
   const { id } = useParams();
@@ -12,10 +13,8 @@ export const ClubApplicatonPage = () => {
   return (
     <Layout>
       <FormContainer>
-        <ClubDescription
-          title={formData.title}
-          description={formData?.description ?? ''}
-        ></ClubDescription>
+        <ClubDescription title={formData.title} description={formData?.description ?? ''} />
+        <ApplicationForm />
       </FormContainer>
     </Layout>
   );

--- a/src/pages/user/Apply/api/apply.ts
+++ b/src/pages/user/Apply/api/apply.ts
@@ -1,0 +1,6 @@
+import type { ApplicationForm } from '@/pages/user/Apply/type/apply.ts';
+
+export const fetchApplicationForm = async (Id: number): Promise<ApplicationForm> => {
+  const response = await fetch(import.meta.env.VITE_API_BASE_URL + `/clubs/${Id}/apply`);
+  return await response.json();
+};

--- a/src/pages/user/Apply/components/ApplicantInfo/ApplicationForm.tsx
+++ b/src/pages/user/Apply/components/ApplicantInfo/ApplicationForm.tsx
@@ -1,7 +1,9 @@
 import { useForm } from 'react-hook-form';
 import styled from '@emotion/styled';
 import { theme } from '@/styles/theme';
-import Input from './Input';
+import type { Question } from '../../type/apply';
+import { OptionInput, TextAreaInput, TextInput } from './Input';
+import { Button } from '@/shared/components/Button';
 
 type FormInputs = {
   name: string;
@@ -9,14 +11,30 @@ type FormInputs = {
   department: string;
   phoneNumber: string;
   email: string;
+  answers?: string[];
 };
 
-export const ApplicationForm = () => {
+type Props = {
+  questions: Question[];
+};
+
+export const ApplicationForm = ({ questions }: Props) => {
+  console.log(questions);
   const {
     register,
     handleSubmit,
     formState: { errors, isSubmitting, isSubmitSuccessful },
-  } = useForm<FormInputs>({ mode: 'onBlur' });
+  } = useForm<FormInputs>({
+    mode: 'onBlur',
+    defaultValues: {
+      name: '',
+      studentId: '',
+      department: '',
+      phoneNumber: '',
+      email: '',
+      answers: [],
+    },
+  });
 
   const onSubmit = (data: FormInputs) => {
     alert(`Name: ${data.name}`);
@@ -24,75 +42,110 @@ export const ApplicationForm = () => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <UserInfoWrapper>
-        <FormFiled>
-          <Label>이름</Label>
-          <Input
-            type='text'
-            placeholder='이름을 입력하세요.'
-            width='12rem'
-            {...register('name', { required: true })}
-          />
-          {errors.name && <span>이름을 입력하세요</span>}
-        </FormFiled>
-        <FormFiled>
-          <Label>학번</Label>
-          <Input
-            type='text'
-            width='12rem'
-            placeholder='학번을 입력하세요.'
-            {...register('studentId', {
-              required: '학번을 입력하세요.',
-              maxLength: { value: 6, message: '학번은 최대 6자리까지 입력 가능합니다.' },
-            })}
-          />
-          {<span>{errors.studentId?.message}</span>}
-        </FormFiled>
-        <FormFiled>
-          <Label>학과</Label>
-          <Input
-            type='text'
-            placeholder='학과를 입력하세요.'
-            width='12rem'
-            {...register('department', { required: '학과를 입력하세요.' })}
-          />
-          {<span>{errors.department?.message}</span>}
-        </FormFiled>
-        <FormFiled>
-          <Label>전화번호</Label>
-          <Input
-            type='text'
-            placeholder='010-0000-0000'
-            width='24rem'
-            {...register('phoneNumber', {
-              required: '전화번호를 입력하세요.',
-              pattern: {
-                value: /^\d{2,3}-\d{3,4}-\d{4}$/,
-                message: '올바른 전화번호 형식이 아닙니다.',
-              },
-            })}
-          />
-          {errors.phoneNumber?.message && <span>{errors.phoneNumber.message}</span>}
-        </FormFiled>
-        <FormFiled>
-          <Label>이메일</Label>
-          <Input
-            type='text'
-            placeholder='이메일을 입력하세요.'
-            width='24rem'
-            {...register('email', {
-              required: '이메일을 입력하세요.',
-              pattern: {
-                value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-                message: '올바른 이메일 형식이 아닙니다. 예: example@gmail.com',
-              },
-            })}
-          />
-          {errors.email && <span>{errors.email.message}</span>}
-        </FormFiled>
-      </UserInfoWrapper>
-      <button type='submit'>{isSubmitting ? 'Submitting...' : 'Submit'}</button>
-      {isSubmitSuccessful && <span>Form submitted successfully!</span>}
+      <FormContainer>
+        <UserInfoWrapper>
+          <FormFiled>
+            <Label>이름</Label>
+            <TextInput
+              type='text'
+              placeholder='이름을 입력하세요.'
+              width='12rem'
+              {...register('name', { required: true })}
+            />
+            {errors.name && <span>이름을 입력하세요</span>}
+          </FormFiled>
+          <FormFiled>
+            <Label>학번</Label>
+            <TextInput
+              type='text'
+              width='12rem'
+              placeholder='학번을 입력하세요.'
+              {...register('studentId', {
+                required: '학번을 입력하세요.',
+                maxLength: { value: 6, message: '학번은 최대 6자리까지 입력 가능합니다.' },
+              })}
+            />
+            {<span>{errors.studentId?.message}</span>}
+          </FormFiled>
+          <FormFiled>
+            <Label>학과</Label>
+            <TextInput
+              type='text'
+              placeholder='학과를 입력하세요.'
+              width='12rem'
+              {...register('department', { required: '학과를 입력하세요.' })}
+            />
+            {<span>{errors.department?.message}</span>}
+          </FormFiled>
+          <FormFiled>
+            <Label>전화번호</Label>
+            <TextInput
+              type='text'
+              placeholder='010-0000-0000'
+              width='24rem'
+              {...register('phoneNumber', {
+                required: '전화번호를 입력하세요.',
+                pattern: {
+                  value: /^\d{2,3}-\d{3,4}-\d{4}$/,
+                  message: '올바른 전화번호 형식이 아닙니다.',
+                },
+              })}
+            />
+            {errors.phoneNumber?.message && <span>{errors.phoneNumber.message}</span>}
+          </FormFiled>
+          <FormFiled>
+            <Label>이메일</Label>
+            <TextInput
+              type='text'
+              placeholder='이메일을 입력하세요.'
+              width='24rem'
+              {...register('email', {
+                required: '이메일을 입력하세요.',
+                pattern: {
+                  value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                  message: '올바른 이메일 형식이 아닙니다. 예: example@gmail.com',
+                },
+              })}
+            />
+            {errors.email && <span>{errors.email.message}</span>}
+          </FormFiled>
+        </UserInfoWrapper>
+        <QuestionWrapper>
+          {questions.map((field, index) => (
+            <ChoiceFormFiled key={field.questionNum}>
+              <Label>{field.question}</Label>
+
+              {field.questionType === 'CHECKBOX' &&
+                field.optionList?.map((option, optIndex) => (
+                  <Label key={optIndex}>
+                    <OptionInput type='checkbox' value={option} {...register(`answers.${index}`)} />
+                    {option}
+                  </Label>
+                ))}
+
+              {field.questionType === 'RADIO' &&
+                field.optionList?.map((option, optIndex) => (
+                  <Label key={optIndex}>
+                    <OptionInput type='radio' value={option} {...register(`answers.${index}`)} />
+                    {option}
+                  </Label>
+                ))}
+
+              {field.questionType === 'TEXT' && (
+                <TextAreaInput
+                  placeholder='1000자 미만으로 입력하세요.'
+                  width='48rem'
+                  height='15rem'
+                  {...register(`answers.${index}`)}
+                />
+              )}
+            </ChoiceFormFiled>
+          ))}
+        </QuestionWrapper>
+
+        <Button type='submit'>{isSubmitting ? 'Submitting...' : 'Submit'}</Button>
+        {isSubmitSuccessful && <span>Form submitted successfully!</span>}
+      </FormContainer>
     </form>
   );
 };
@@ -117,5 +170,35 @@ const FormFiled = styled.div({
 });
 
 const Label = styled.label(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
   fontWeight: theme.font.weight.medium,
 }));
+
+const QuestionWrapper = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 60,
+  padding: 40,
+  border: `1px none ${theme.colors.gray200}`,
+  borderRadius: '1rem',
+  boxShadow: theme.shadow.md,
+});
+
+const ChoiceFormFiled = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: 40,
+  gap: 10,
+  border: `1px none ${theme.colors.gray200}`,
+  borderRadius: '1rem',
+  boxShadow: theme.shadow.md,
+});
+
+const FormContainer = styled.main({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '60px',
+  alignItems: 'center',
+});

--- a/src/pages/user/Apply/components/ApplicantInfo/ApplicationForm.tsx
+++ b/src/pages/user/Apply/components/ApplicantInfo/ApplicationForm.tsx
@@ -1,0 +1,121 @@
+import { useForm } from 'react-hook-form';
+import styled from '@emotion/styled';
+import { theme } from '@/styles/theme';
+import Input from './Input';
+
+type FormInputs = {
+  name: string;
+  studentId: string;
+  department: string;
+  phoneNumber: string;
+  email: string;
+};
+
+export const ApplicationForm = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isSubmitSuccessful },
+  } = useForm<FormInputs>({ mode: 'onBlur' });
+
+  const onSubmit = (data: FormInputs) => {
+    alert(`Name: ${data.name}`);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <UserInfoWrapper>
+        <FormFiled>
+          <Label>이름</Label>
+          <Input
+            type='text'
+            placeholder='이름을 입력하세요.'
+            width='12rem'
+            {...register('name', { required: true })}
+          />
+          {errors.name && <span>이름을 입력하세요</span>}
+        </FormFiled>
+        <FormFiled>
+          <Label>학번</Label>
+          <Input
+            type='text'
+            width='12rem'
+            placeholder='학번을 입력하세요.'
+            {...register('studentId', {
+              required: '학번을 입력하세요.',
+              maxLength: { value: 6, message: '학번은 최대 6자리까지 입력 가능합니다.' },
+            })}
+          />
+          {<span>{errors.studentId?.message}</span>}
+        </FormFiled>
+        <FormFiled>
+          <Label>학과</Label>
+          <Input
+            type='text'
+            placeholder='학과를 입력하세요.'
+            width='12rem'
+            {...register('department', { required: '학과를 입력하세요.' })}
+          />
+          {<span>{errors.department?.message}</span>}
+        </FormFiled>
+        <FormFiled>
+          <Label>전화번호</Label>
+          <Input
+            type='text'
+            placeholder='010-0000-0000'
+            width='24rem'
+            {...register('phoneNumber', {
+              required: '전화번호를 입력하세요.',
+              pattern: {
+                value: /^\d{2,3}-\d{3,4}-\d{4}$/,
+                message: '올바른 전화번호 형식이 아닙니다.',
+              },
+            })}
+          />
+          {errors.phoneNumber?.message && <span>{errors.phoneNumber.message}</span>}
+        </FormFiled>
+        <FormFiled>
+          <Label>이메일</Label>
+          <Input
+            type='text'
+            placeholder='이메일을 입력하세요.'
+            width='24rem'
+            {...register('email', {
+              required: '이메일을 입력하세요.',
+              pattern: {
+                value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                message: '올바른 이메일 형식이 아닙니다. 예: example@gmail.com',
+              },
+            })}
+          />
+          {errors.email && <span>{errors.email.message}</span>}
+        </FormFiled>
+      </UserInfoWrapper>
+      <button type='submit'>{isSubmitting ? 'Submitting...' : 'Submit'}</button>
+      {isSubmitSuccessful && <span>Form submitted successfully!</span>}
+    </form>
+  );
+};
+
+const UserInfoWrapper = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  justifyContent: 'flex-start',
+  gap: 60,
+  padding: 40,
+  border: `1px none ${theme.colors.gray200}`,
+  borderRadius: '1rem',
+  boxShadow: theme.shadow.md,
+});
+
+const FormFiled = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+});
+
+const Label = styled.label(({ theme }) => ({
+  fontWeight: theme.font.weight.medium,
+}));

--- a/src/pages/user/Apply/components/ApplicantInfo/Input.ts
+++ b/src/pages/user/Apply/components/ApplicantInfo/Input.ts
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+
+type InputProps = {
+  width?: string;
+  height?: string;
+  padding?: string;
+};
+
+const Input = styled.input<InputProps>(({ theme, width, height, padding }) => ({
+  borderRadius: '10px',
+  border: `1px solid ${theme.colors.gray200}`,
+  backgroundColor: theme.colors.gray100,
+  width: width || '100%',
+  height: height || '30px',
+  padding: padding || '0 10px',
+
+  textAlign: 'left',
+}));
+
+export default Input;

--- a/src/pages/user/Apply/components/ApplicantInfo/Input.ts
+++ b/src/pages/user/Apply/components/ApplicantInfo/Input.ts
@@ -6,15 +6,39 @@ type InputProps = {
   padding?: string;
 };
 
-const Input = styled.input<InputProps>(({ theme, width, height, padding }) => ({
+export const TextInput = styled.input<InputProps>(({ theme, width, height, padding }) => ({
   borderRadius: '10px',
   border: `1px solid ${theme.colors.gray200}`,
   backgroundColor: theme.colors.gray100,
   width: width || '100%',
   height: height || '30px',
   padding: padding || '0 10px',
-
   textAlign: 'left',
 }));
 
-export default Input;
+type OptionInputProps = {
+  type: 'checkbox' | 'radio';
+};
+
+export const OptionInput = styled.input<OptionInputProps>(({ theme, type }) => ({
+  appearance: 'none',
+  width: '16px',
+  height: '16px',
+  border: `2px solid ${theme.colors.gray400}`,
+  borderRadius: type === 'radio' ? '50%' : '4px',
+  cursor: 'pointer',
+  '&:checked': {
+    backgroundColor: theme.colors.primary,
+    borderColor: theme.colors.primary,
+  },
+}));
+
+export const TextAreaInput = styled.textarea<InputProps>(({ theme, width, height, padding }) => ({
+  borderRadius: '10px',
+  border: `1px solid ${theme.colors.gray200}`,
+  backgroundColor: theme.colors.gray100,
+  width: width || '100%',
+  height: height || '30px',
+  padding: padding || '10px 10px',
+  textAlign: 'left',
+}));

--- a/src/pages/user/Apply/components/ClubDescriptionSection/ClubDescription.tsx
+++ b/src/pages/user/Apply/components/ClubDescriptionSection/ClubDescription.tsx
@@ -1,0 +1,24 @@
+import { Text } from '@/shared/components/Text';
+import styled from '@emotion/styled';
+
+type props = {
+  title: string;
+  description: string | undefined;
+};
+
+export const ClubDescription = ({ title, description }: props) => {
+  return (
+    <TextWrapper>
+      <Text size='xl' weight='bold' children={title}></Text>
+      <Text>{description}</Text>
+    </TextWrapper>
+  );
+};
+
+const TextWrapper = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 35,
+  padding: 20,
+});

--- a/src/pages/user/Apply/hook/useApplicationForm.ts
+++ b/src/pages/user/Apply/hook/useApplicationForm.ts
@@ -1,0 +1,16 @@
+import { fetchApplicationForm } from '@/pages/user/Apply/api/apply.ts';
+import { useEffect, useState } from 'react';
+import type { ApplicationForm } from '../type/apply';
+
+export const useApplicationForm = (Id: number) => {
+  const [clubApplicationForm, setclubApplicationForm] = useState<ApplicationForm | null>(null);
+
+  useEffect(() => {
+    if (!Id) return;
+    fetchApplicationForm(Id).then((res) => {
+      setclubApplicationForm(res);
+    });
+  }, [Id]);
+
+  return clubApplicationForm;
+};

--- a/src/pages/user/Apply/type/apply.ts
+++ b/src/pages/user/Apply/type/apply.ts
@@ -1,0 +1,13 @@
+export type Question = {
+  questionNum: number;
+  questionType: string;
+  question: string;
+  required: boolean;
+  optionList?: string[];
+};
+
+export type ApplicationForm = {
+  title: string;
+  description: string;
+  questions: Question[];
+};

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { Button } from '@/shared/components/Button';
 import { mockClubDetail } from '../mock';
+import { useParams } from 'react-router-dom';
 
 export const ClubInfoSidebarSection = () => {
   const {
@@ -13,8 +14,11 @@ export const ClubInfoSidebarSection = () => {
     recruitStatus,
   } = mockClubDetail;
 
+  const clubId = useParams();
+
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
+
     return `${date.getFullYear()}/${date.getMonth() + 1}/${date.getDate()}`;
   };
 
@@ -28,7 +32,7 @@ export const ClubInfoSidebarSection = () => {
       </InfoItem>
       <InfoItem>정기 모임: {regularMeetingInfo}</InfoItem>
       <InfoItem>모집 상태: {recruitStatus}</InfoItem>
-      <Button to='/'>지원하기</Button>
+      <Button to={`/club/${clubId.id}/apply`}>지원하기</Button>
       <Notice>지원 시 유의사항이 여기에 들어갑니다.</Notice>
     </SidebarContainer>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #68 

## 📝작업 내용


- react-hook-form 라이브러리 추가
- hook을 통한 동아리 지원 form 데이터 불러오기
- 동아리 지원폼의 동아리 설명 추가(상단)
<img width="625" height="94" alt="image" src="https://github.com/user-attachments/assets/7294a5f4-d94e-4d7a-bac9-08db81c826bd" />
- 인적사항(모든 form의 공통) 부분 추가
<img width="903" height="378" alt="스크린샷 2025-09-22 오전 11 35 48" src="https://github.com/user-attachments/assets/95774e1e-ab06-48b2-8ef2-e78dabf1ff30" />

- 동아리 질문 추가( text 는 textArea , radio / checkbox 는 optionList(문자열 배열)을 통해 value 표시
<img width="511" height="575" alt="스크린샷 2025-09-22 오전 11 35 59" src="https://github.com/user-attachments/assets/bed57280-c3c3-418b-9f56-202f7998e9c3" />

- check point에 브라우저가 기본으로 제공하는 UI 스타일을 제거 후 primary 색상 입히기
<img width="683" height="717" alt="스크린샷 2025-09-22 오전 11 36 32" src="https://github.com/user-attachments/assets/b7983465-e9b4-4429-b7be-32994df12469" />

etc..
- msw 세팅
- route 추가
- mockdata 응답값 수정

## 💬리뷰 요구사항(선택)
- validation 에러 메시지 style, POST api 연결 등은 크기를 고려해서 따로 올려야할 것 같습니다.
- 브라우저 기본 UI 스타일을 제공하니 check-box에서 기본 흰색의 체크표시가 사라지는 issue가 발생했네요
