### PR TITLE
[REFACTOR] API Hook 반환 타입 제네릭으로 표준화 및 개선 (#77)

### DIFF
--- a/src/pages/admin/ApplicationDetail/Page.tsx
+++ b/src/pages/admin/ApplicationDetail/Page.tsx
@@ -9,10 +9,12 @@ import { useParams } from 'react-router-dom';
 export const ApplicationDetailPage = () => {
   const { clubId, applicantId } = useParams();
 
-  const { detailApplicants, isError, isLoading, updateStatus } = useDetailApplications(
-    Number(clubId),
-    Number(applicantId),
-  );
+  const {
+    data: detailApplicants,
+    isError,
+    isLoading,
+    updateStatus,
+  } = useDetailApplications(Number(clubId), Number(applicantId));
 
   if (isLoading) return <div> 로딩중</div>;
   if (isError) return <div>데이터를 불러오는 중 에러가 발생했습니다.</div>;

--- a/src/pages/admin/ApplicationDetail/Page.tsx
+++ b/src/pages/admin/ApplicationDetail/Page.tsx
@@ -11,13 +11,13 @@ export const ApplicationDetailPage = () => {
 
   const {
     data: detailApplicants,
-    isError,
     isLoading,
+    error,
     updateStatus,
   } = useDetailApplications(Number(clubId), Number(applicantId));
 
   if (isLoading) return <div> 로딩중</div>;
-  if (isError) return <div>데이터를 불러오는 중 에러가 발생했습니다.</div>;
+  if (error) return <div>에러발생 : {error.message}</div>;
 
   return (
     <Layout>

--- a/src/pages/admin/ApplicationDetail/hooks/useDetailApplication.ts
+++ b/src/pages/admin/ApplicationDetail/hooks/useDetailApplication.ts
@@ -4,13 +4,11 @@ import {
   updateApplicationStatus,
 } from '@/pages/admin/ApplicationDetail/api/detailApplication';
 import type { DetailApplication } from '@/pages/admin/ApplicationDetail/types/detailApplication';
+import type { UseApiQueryResult } from '@/types/useApiQueryResult';
 
-interface UseDetailApplicationResult {
-  detailApplicants: DetailApplication | null;
-  isLoading: boolean;
-  isError: boolean;
+type UseDetailApplicationResult = UseApiQueryResult<DetailApplication | null> & {
   updateStatus: (status: DetailApplication['status']) => void;
-}
+};
 
 export const useDetailApplications = (
   clubId: number,
@@ -46,9 +44,9 @@ export const useDetailApplications = (
   });
 
   return {
-    detailApplicants: data || null,
-    isLoading: isLoading,
-    isError: isError,
+    data: data || null,
+    isLoading,
+    isError,
     updateStatus,
   };
 };

--- a/src/pages/admin/ApplicationDetail/hooks/useDetailApplication.ts
+++ b/src/pages/admin/ApplicationDetail/hooks/useDetailApplication.ts
@@ -16,7 +16,7 @@ export const useDetailApplications = (
 ): UseDetailApplicationResult => {
   const queryClient = useQueryClient();
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: ['detailApplications', clubId, applicantId],
     queryFn: () => fetchDetailApplication(clubId!, applicantId!),
     staleTime: 1000 * 60 * 5,
@@ -46,7 +46,7 @@ export const useDetailApplications = (
   return {
     data: data || null,
     isLoading,
-    isError,
+    error,
     updateStatus,
   };
 };

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/ApplicantList.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/ApplicantList.tsx
@@ -13,7 +13,7 @@ type Props = {
 export const ApplicantList = ({ filterOption }: Props) => {
   const navigate = useNavigate();
 
-  const { applicants, isLoading, isError } = useApplicants(1, filterOption);
+  const { data: applicants, isLoading, isError } = useApplicants(1, filterOption);
 
   if (isLoading) return <LoadingSpinner />;
   if (isError) {

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/ApplicantList.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/ApplicantList.tsx
@@ -13,12 +13,10 @@ type Props = {
 export const ApplicantList = ({ filterOption }: Props) => {
   const navigate = useNavigate();
 
-  const { data: applicants, isLoading, isError } = useApplicants(1, filterOption);
+  const { data: applicants, isLoading, error } = useApplicants(1, filterOption);
 
   if (isLoading) return <LoadingSpinner />;
-  if (isError) {
-    return <div>데이터를 불러오는 중 에러가 발생했습니다.</div>;
-  }
+  if (error) return <div>에러발생 : {error.message}</div>;
 
   const handleItemClick = (applicantId: number) => {
     const clubId = 1;

--- a/src/pages/admin/Dashboard/hooks/useApplicants.ts
+++ b/src/pages/admin/Dashboard/hooks/useApplicants.ts
@@ -4,17 +4,12 @@ import type {
   ApplicantData,
   ApplicationFilterOption,
 } from '@/pages/admin/Dashboard/types/dashboard';
-
-interface useApplicantsResult {
-  applicants: ApplicantData[];
-  isLoading: boolean;
-  isError: boolean;
-}
+import type { UseApiQueryResult } from '@/types/useApiQueryResult';
 
 export const useApplicants = (
   clubId: number,
   status?: ApplicationFilterOption,
-): useApplicantsResult => {
+): UseApiQueryResult<ApplicantData[]> => {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['applicants', clubId, status],
     queryFn: () => fetchApplicants(clubId, status),
@@ -22,8 +17,8 @@ export const useApplicants = (
   });
 
   return {
-    applicants: data || [],
-    isLoading: isLoading,
-    isError: isError,
+    data: data || [],
+    isLoading,
+    isError,
   };
 };

--- a/src/pages/admin/Dashboard/hooks/useApplicants.ts
+++ b/src/pages/admin/Dashboard/hooks/useApplicants.ts
@@ -10,7 +10,7 @@ export const useApplicants = (
   clubId: number,
   status?: ApplicationFilterOption,
 ): UseApiQueryResult<ApplicantData[]> => {
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: ['applicants', clubId, status],
     queryFn: () => fetchApplicants(clubId, status),
     staleTime: 1000 * 60 * 2,
@@ -19,6 +19,6 @@ export const useApplicants = (
   return {
     data: data || [],
     isLoading,
-    isError,
+    error,
   };
 };

--- a/src/pages/user/Main/components/ClubListSection/index.tsx
+++ b/src/pages/user/Main/components/ClubListSection/index.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export const ClubListSection = ({ filter, searchText }: Props) => {
-  const { clubs, isLoading, error } = useClub(filter);
+  const { data: clubs, isLoading, error } = useClub(filter);
 
   if (isLoading) return <div>로딩중입니다...</div>;
   if (error) return <div>에러발생 : {error.message}</div>;

--- a/src/pages/user/Main/hook/useClub.ts
+++ b/src/pages/user/Main/hook/useClub.ts
@@ -2,21 +2,16 @@ import { type ClubResponse, getClubsByCategory } from '@/pages/user/Main/api/clu
 import { useQuery } from '@tanstack/react-query';
 import type { ClubCategory } from '@/pages/user/Main/constant/clubCategory.ts';
 import type { Club } from '@/pages/user/Main/types/club';
+import type { UseApiQueryResult } from '@/types/useApiQueryResult';
 
-export interface UseClubResult {
-  clubs: Club[];
-  error?: Error | null;
-  isLoading: boolean;
-}
-
-export const useClub = (filter: ClubCategory): UseClubResult => {
+export const useClub = (filter: ClubCategory): UseApiQueryResult<Club[]> => {
   const { data, isLoading, error } = useQuery<ClubResponse>({
     queryKey: ['clubData', filter],
     queryFn: () => getClubsByCategory(filter),
   });
   return {
-    clubs: data?.clubs || [],
-    error: error,
-    isLoading: isLoading,
+    data: data?.clubs || [],
+    error,
+    isLoading,
   };
 };

--- a/src/pages/user/Main/hook/useClub.ts
+++ b/src/pages/user/Main/hook/useClub.ts
@@ -11,7 +11,7 @@ export const useClub = (filter: ClubCategory): UseApiQueryResult<Club[]> => {
   });
   return {
     data: data?.clubs || [],
-    error,
     isLoading,
+    error,
   };
 };

--- a/src/types/useApiQueryResult.ts
+++ b/src/types/useApiQueryResult.ts
@@ -1,0 +1,6 @@
+export interface UseApiQueryResult<T> {
+  data: T;
+  error?: Error | null;
+  isLoading: boolean;
+  isError?: boolean;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #77 

## 📝작업 내용

기존에 각 API 호출 커스텀 훅마다 개별적으로 선언되던 반환 값 인터페이스의 중복 문제를 해결하고, 프로젝트 전반의 코드 일관성 및 재사용성을 높이기 위해 제네릭을 도입하여 타입을 표준화했습니다.

### **제네릭 타입 UseApiQueryResult<T> 도입**
```js
export interface UseApiQueryResult<T> {
  data: T;
  error?: Error | null;
  isLoading: boolean;
  isError?: boolean;
}
```
혹시 몰라 기존 isError도 임시로 포함 

### **API Hook 반환 값 isError를 error로 변경**
기존 Admin 페이지에서 사용하던 반환 값 isError를 error로 변경 -> 실제 에러 메시지 노출 연동

### **API Hook 반환 객체 순서 변경**
```js
  return {
    data: data || [],
    isLoading,
    error,
  };
```
return 객체 속성 순서를 data, isLoading, error로 변경 -> 구조분해할당 시 가독성 향상