### PR TITLE
[FEAT] 공통 Input 및 Textarea 컴포넌트 구현 (#83)

### DIFF
--- a/src/pages/user/Apply/components/ApplicantionForm/index.styled.ts
+++ b/src/pages/user/Apply/components/ApplicantionForm/index.styled.ts
@@ -1,21 +1,5 @@
 import styled from '@emotion/styled';
 
-type InputProps = {
-  width?: string;
-  height?: string;
-  padding?: string;
-};
-
-export const TextInput = styled.input<InputProps>(({ theme, width, height, padding }) => ({
-  borderRadius: '10px',
-  border: `1px solid ${theme.colors.gray200}`,
-  backgroundColor: theme.colors.gray100,
-  width: width || '100%',
-  height: height || '30px',
-  padding: padding || '0 10px',
-  textAlign: 'left',
-}));
-
 type OptionInputProps = {
   type: 'checkbox' | 'radio';
 };
@@ -31,14 +15,4 @@ export const OptionInput = styled.input<OptionInputProps>(({ theme, type }) => (
     backgroundColor: theme.colors.primary,
     borderColor: theme.colors.primary,
   },
-}));
-
-export const TextAreaInput = styled.textarea<InputProps>(({ theme, width, height, padding }) => ({
-  borderRadius: '10px',
-  border: `1px solid ${theme.colors.gray200}`,
-  backgroundColor: theme.colors.gray100,
-  width: width || '100%',
-  height: height || '30px',
-  padding: padding || '10px 10px',
-  textAlign: 'left',
 }));

--- a/src/pages/user/Apply/components/ApplicantionForm/index.styled.ts
+++ b/src/pages/user/Apply/components/ApplicantionForm/index.styled.ts
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { theme } from '@/styles/theme';
 
 type OptionInputProps = {
   type: 'checkbox' | 'radio';
@@ -15,4 +16,64 @@ export const OptionInput = styled.input<OptionInputProps>(({ theme, type }) => (
     backgroundColor: theme.colors.primary,
     borderColor: theme.colors.primary,
   },
+}));
+
+export const UserInfoWrapper = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  justifyContent: 'flex-start',
+  gap: 60,
+  padding: 40,
+  border: `1px none ${theme.colors.gray200}`,
+  borderRadius: '1rem',
+  boxShadow: theme.shadow.md,
+});
+
+export const FormFiled = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+});
+
+export const Label = styled.label(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+  fontWeight: theme.font.weight.medium,
+}));
+
+export const QuestionWrapper = styled.div({
+  width: '48rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 60,
+  padding: 40,
+  border: `1px none ${theme.colors.gray200}`,
+  borderRadius: '1rem',
+  boxShadow: theme.shadow.md,
+});
+
+export const ChoiceFormFiled = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: 40,
+  gap: 10,
+  border: `1px none ${theme.colors.gray200}`,
+  borderRadius: '1rem',
+  boxShadow: theme.shadow.md,
+});
+
+export const FormContainer = styled.main({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '60px',
+  alignItems: 'center',
+});
+
+export const ErrorMessage = styled.span(({ theme }) => ({
+  color: theme.colors.warning,
+  fontSize: theme.font.size.xs,
+  padding: 0,
 }));

--- a/src/pages/user/Apply/components/ApplicantionForm/index.tsx
+++ b/src/pages/user/Apply/components/ApplicantionForm/index.tsx
@@ -3,9 +3,11 @@ import styled from '@emotion/styled';
 import { theme } from '@/styles/theme';
 import type { FormInputs, Question } from '@/pages/user/Apply/type/apply';
 import { Button } from '@/shared/components/Button';
-import { OptionInput, TextAreaInput, TextInput } from './index.styled';
+import { OptionInput } from './index.styled';
 import { useParams } from 'react-router-dom';
 import { postApplicationForm } from '@/pages/user/Apply/api/apply';
+import { OutlineInputField } from '@/shared/components/Form/InputField/OutlineInputField';
+import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/OutlineTextareaField';
 
 type Props = {
   questions: Question[];
@@ -43,19 +45,15 @@ export const ApplicationForm = ({ questions }: Props) => {
         <UserInfoWrapper>
           <FormFiled>
             <Label>이름</Label>
-            <TextInput
-              type='text'
+            <OutlineInputField
               placeholder='이름을 입력하세요.'
-              width='12rem'
               {...register('name', { required: true })}
             />
             {errors.name && <ErrorMessage>이름을 입력하세요</ErrorMessage>}
           </FormFiled>
           <FormFiled>
             <Label>학번</Label>
-            <TextInput
-              type='text'
-              width='12rem'
+            <OutlineInputField
               placeholder='학번을 입력하세요.'
               {...register('studentId', {
                 required: '학번을 입력하세요.',
@@ -70,20 +68,16 @@ export const ApplicationForm = ({ questions }: Props) => {
           </FormFiled>
           <FormFiled>
             <Label>학과</Label>
-            <TextInput
-              type='text'
+            <OutlineInputField
               placeholder='학과를 입력하세요.'
-              width='12rem'
               {...register('department', { required: '학과를 입력하세요.' })}
             />
             {<ErrorMessage>{errors.department?.message}</ErrorMessage>}
           </FormFiled>
           <FormFiled>
             <Label>전화번호</Label>
-            <TextInput
-              type='text'
+            <OutlineInputField
               placeholder='010-0000-0000'
-              width='24rem'
               {...register('phoneNumber', {
                 required: '전화번호를 입력하세요.',
                 pattern: {
@@ -98,10 +92,8 @@ export const ApplicationForm = ({ questions }: Props) => {
           </FormFiled>
           <FormFiled>
             <Label>이메일</Label>
-            <TextInput
-              type='text'
+            <OutlineInputField
               placeholder='이메일을 입력하세요.'
-              width='24rem'
               {...register('email', {
                 required: '이메일을 입력하세요.',
                 pattern: {
@@ -135,10 +127,8 @@ export const ApplicationForm = ({ questions }: Props) => {
                 ))}
 
               {field.questionType === 'TEXT' && (
-                <TextAreaInput
+                <OutlineTextareaField
                   placeholder='1000자 미만으로 입력하세요.'
-                  width='48rem'
-                  height='15rem'
                   {...register(`answers.${index}`)}
                 />
               )}
@@ -181,6 +171,7 @@ const Label = styled.label(({ theme }) => ({
 }));
 
 const QuestionWrapper = styled.div({
+  width: '48rem',
   display: 'flex',
   flexDirection: 'column',
   gap: 60,

--- a/src/pages/user/Apply/components/ApplicantionForm/index.tsx
+++ b/src/pages/user/Apply/components/ApplicantionForm/index.tsx
@@ -1,13 +1,11 @@
 import { useForm } from 'react-hook-form';
-import styled from '@emotion/styled';
-import { theme } from '@/styles/theme';
 import type { FormInputs, Question } from '@/pages/user/Apply/type/apply';
 import { Button } from '@/shared/components/Button';
-import { OptionInput } from './index.styled';
 import { useParams } from 'react-router-dom';
 import { postApplicationForm } from '@/pages/user/Apply/api/apply';
 import { OutlineInputField } from '@/shared/components/Form/InputField/OutlineInputField';
 import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/OutlineTextareaField';
+import * as S from './index.styled';
 
 type Props = {
   questions: Question[];
@@ -41,18 +39,18 @@ export const ApplicationForm = ({ questions }: Props) => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <FormContainer>
-        <UserInfoWrapper>
-          <FormFiled>
-            <Label>이름</Label>
+      <S.FormContainer>
+        <S.UserInfoWrapper>
+          <S.FormFiled>
+            <S.Label>이름</S.Label>
             <OutlineInputField
               placeholder='이름을 입력하세요.'
               {...register('name', { required: true })}
             />
-            {errors.name && <ErrorMessage>이름을 입력하세요</ErrorMessage>}
-          </FormFiled>
-          <FormFiled>
-            <Label>학번</Label>
+            {errors.name && <S.ErrorMessage>이름을 입력하세요</S.ErrorMessage>}
+          </S.FormFiled>
+          <S.FormFiled>
+            <S.Label>학번</S.Label>
             <OutlineInputField
               placeholder='학번을 입력하세요.'
               {...register('studentId', {
@@ -64,18 +62,18 @@ export const ApplicationForm = ({ questions }: Props) => {
                 },
               })}
             />
-            {<ErrorMessage>{errors.studentId?.message}</ErrorMessage>}
-          </FormFiled>
-          <FormFiled>
-            <Label>학과</Label>
+            {<S.ErrorMessage>{errors.studentId?.message}</S.ErrorMessage>}
+          </S.FormFiled>
+          <S.FormFiled>
+            <S.Label>학과</S.Label>
             <OutlineInputField
               placeholder='학과를 입력하세요.'
               {...register('department', { required: '학과를 입력하세요.' })}
             />
-            {<ErrorMessage>{errors.department?.message}</ErrorMessage>}
-          </FormFiled>
-          <FormFiled>
-            <Label>전화번호</Label>
+            {<S.ErrorMessage>{errors.department?.message}</S.ErrorMessage>}
+          </S.FormFiled>
+          <S.FormFiled>
+            <S.Label>전화번호</S.Label>
             <OutlineInputField
               placeholder='010-0000-0000'
               {...register('phoneNumber', {
@@ -87,11 +85,11 @@ export const ApplicationForm = ({ questions }: Props) => {
               })}
             />
             {errors.phoneNumber?.message && (
-              <ErrorMessage>{errors.phoneNumber.message}</ErrorMessage>
+              <S.ErrorMessage>{errors.phoneNumber.message}</S.ErrorMessage>
             )}
-          </FormFiled>
-          <FormFiled>
-            <Label>이메일</Label>
+          </S.FormFiled>
+          <S.FormFiled>
+            <S.Label>이메일</S.Label>
             <OutlineInputField
               placeholder='이메일을 입력하세요.'
               {...register('email', {
@@ -102,28 +100,32 @@ export const ApplicationForm = ({ questions }: Props) => {
                 },
               })}
             />
-            {errors.email && <ErrorMessage>{errors.email.message}</ErrorMessage>}
-          </FormFiled>
-        </UserInfoWrapper>
-        <QuestionWrapper>
+            {errors.email && <S.ErrorMessage>{errors.email.message}</S.ErrorMessage>}
+          </S.FormFiled>
+        </S.UserInfoWrapper>
+        <S.QuestionWrapper>
           {questions.map((field, index) => (
-            <ChoiceFormFiled key={field.questionNum}>
-              <Label>{field.question}</Label>
+            <S.ChoiceFormFiled key={field.questionNum}>
+              <S.Label>{field.question}</S.Label>
 
               {field.questionType === 'CHECKBOX' &&
                 field.optionList?.map((option, optIndex) => (
-                  <Label key={optIndex}>
-                    <OptionInput type='checkbox' value={option} {...register(`answers.${index}`)} />
+                  <S.Label key={optIndex}>
+                    <S.OptionInput
+                      type='checkbox'
+                      value={option}
+                      {...register(`answers.${index}`)}
+                    />
                     {option}
-                  </Label>
+                  </S.Label>
                 ))}
 
               {field.questionType === 'RADIO' &&
                 field.optionList?.map((option, optIndex) => (
-                  <Label key={optIndex}>
-                    <OptionInput type='radio' value={option} {...register(`answers.${index}`)} />
+                  <S.Label key={optIndex}>
+                    <S.OptionInput type='radio' value={option} {...register(`answers.${index}`)} />
                     {option}
-                  </Label>
+                  </S.Label>
                 ))}
 
               {field.questionType === 'TEXT' && (
@@ -132,74 +134,14 @@ export const ApplicationForm = ({ questions }: Props) => {
                   {...register(`answers.${index}`)}
                 />
               )}
-            </ChoiceFormFiled>
+            </S.ChoiceFormFiled>
           ))}
-        </QuestionWrapper>
+        </S.QuestionWrapper>
 
         <Button type='submit'>{isSubmitting ? '제출중...' : '제출하기'}</Button>
         {/* 제출 완료 후 toast 알림 적용 부분*/}
         {isSubmitSuccessful && <span>제출 성공!</span>}
-      </FormContainer>
+      </S.FormContainer>
     </form>
   );
 };
-
-const UserInfoWrapper = styled.div({
-  display: 'flex',
-  flexDirection: 'row',
-  flexWrap: 'wrap',
-  alignItems: 'center',
-  justifyContent: 'flex-start',
-  gap: 60,
-  padding: 40,
-  border: `1px none ${theme.colors.gray200}`,
-  borderRadius: '1rem',
-  boxShadow: theme.shadow.md,
-});
-
-const FormFiled = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 10,
-});
-
-const Label = styled.label(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '4px',
-  fontWeight: theme.font.weight.medium,
-}));
-
-const QuestionWrapper = styled.div({
-  width: '48rem',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 60,
-  padding: 40,
-  border: `1px none ${theme.colors.gray200}`,
-  borderRadius: '1rem',
-  boxShadow: theme.shadow.md,
-});
-
-const ChoiceFormFiled = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  padding: 40,
-  gap: 10,
-  border: `1px none ${theme.colors.gray200}`,
-  borderRadius: '1rem',
-  boxShadow: theme.shadow.md,
-});
-
-const FormContainer = styled.main({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '60px',
-  alignItems: 'center',
-});
-
-const ErrorMessage = styled.span(({ theme }) => ({
-  color: theme.colors.warning,
-  fontSize: theme.font.size.xs,
-  padding: 0,
-}));

--- a/src/shared/components/Form/InputField/OutlineInputField.tsx
+++ b/src/shared/components/Form/InputField/OutlineInputField.tsx
@@ -1,0 +1,43 @@
+import { Text } from '@/shared/components/Text';
+import styled from '@emotion/styled';
+
+type Props = {
+  invalid?: boolean;
+  message?: string;
+} & React.InputHTMLAttributes<HTMLInputElement>;
+
+export const OutlineInputField = ({ invalid, message, ...props }: Props) => {
+  return (
+    <>
+      <Input invalid={invalid} {...props} />
+      {message && (
+        <Text size={'xs'} color={invalid ? '#fa342c' : '#b0b3ba'}>
+          {message}
+        </Text>
+      )}
+    </>
+  );
+};
+
+const Input = styled.input<Pick<Props, 'invalid'>>(({ theme, invalid }) => ({
+  width: '100%',
+  border: `1px solid ${theme.colors.border}`,
+  borderRadius: theme.radius.md,
+  fontSize: theme.font.size.base,
+  padding: '8px 12px',
+  lineHeight: 1.6,
+  resize: 'vertical',
+  transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
+  marginBottom: '0.3rem',
+
+  '&:focus': {
+    outline: 'none',
+    borderColor: theme.colors.primary,
+  },
+
+  '&::placeholder': {
+    color: theme.colors.textSecondary,
+  },
+
+  borderColor: invalid ? theme.colors.error : theme.colors.gray200,
+}));

--- a/src/shared/components/Form/InputField/UnderlineInputField.tsx
+++ b/src/shared/components/Form/InputField/UnderlineInputField.tsx
@@ -1,0 +1,43 @@
+import { Text } from '@/shared/components/Text';
+import styled from '@emotion/styled';
+
+type Props = {
+  invalid?: boolean;
+  message?: string;
+} & React.InputHTMLAttributes<HTMLInputElement>;
+
+export const UnderlineInputField = ({ invalid, message, ...props }: Props) => {
+  return (
+    <>
+      <Input invalid={invalid} {...props} />
+      {message && (
+        <Text size={'xs'} color={invalid ? '#fa342c' : '#b0b3ba'}>
+          {message}
+        </Text>
+      )}
+    </>
+  );
+};
+
+const Input = styled.input<Pick<Props, 'invalid'>>(({ theme, invalid }) => ({
+  width: '100%',
+  border: 'none',
+  borderBottom: `1px solid ${theme.colors.gray300}`,
+  fontSize: theme.font.size.sm,
+  padding: '7.5px 12px',
+  flex: 1,
+  textAlign: 'center',
+  transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
+  marginBottom: '0.3rem',
+
+  '&:focus': {
+    outline: 'none',
+    borderBottom: `1px solid ${theme.colors.primary}`,
+  },
+
+  '&::placeholder': {
+    color: theme.colors.gray400,
+  },
+
+  borderColor: invalid ? theme.colors.error : theme.colors.gray200,
+}));

--- a/src/shared/components/Form/TextAreaField/OutlineTextareaField.tsx
+++ b/src/shared/components/Form/TextAreaField/OutlineTextareaField.tsx
@@ -1,0 +1,44 @@
+import { Text } from '@/shared/components/Text';
+import styled from '@emotion/styled';
+
+type Props = {
+  invalid?: boolean;
+  message?: string;
+} & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const OutlineTextareaField = ({ invalid, message, ...props }: Props) => {
+  return (
+    <>
+      <Input invalid={invalid} {...props} />
+      {message && (
+        <Text size={'xs'} color={invalid ? '#fa342c' : '#b0b3ba'}>
+          {message}
+        </Text>
+      )}
+    </>
+  );
+};
+
+const Input = styled.textarea<Pick<Props, 'invalid'>>(({ theme, invalid }) => ({
+  width: '100%',
+  border: `1px solid ${theme.colors.border}`,
+  borderRadius: theme.radius.md,
+  fontSize: theme.font.size.base,
+  padding: '8px 12px',
+  lineHeight: 1.6,
+  resize: 'vertical',
+  transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
+  marginBottom: '0.3rem',
+  minHeight: '8rem',
+
+  '&:focus': {
+    outline: 'none',
+    borderColor: theme.colors.primary,
+  },
+
+  '&::placeholder': {
+    color: theme.colors.textSecondary,
+  },
+
+  borderColor: invalid ? theme.colors.error : theme.colors.gray200,
+}));


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #83 

## 📝작업 내용
프로젝트 전반에 걸쳐 중복으로 사용되던 Input 및 Textarea 관련 코드를 제거하고, 재사용 가능한 공통 컴포넌트 3종을 구현

### **1. 공통 컴포넌트 3종 개발**
- OutlineInputField: 일반적인 테두리 스타일의 Input 컴포넌트
<img width="411" height="58" alt="image" src="https://github.com/user-attachments/assets/dfaac3bc-618d-40fa-bfa7-8723f8a72c33" />

- UnderlineInputField: 수정 모드 등에서 사용될 밑줄 스타일의 Input 컴포넌트
<img width="634" height="63" alt="image" src="https://github.com/user-attachments/assets/4b5a1f65-0606-40bf-b14d-8dc63dda9465" />

- OutlineTextareaField: 여러 줄 입력이 가능한 테두리 스타일의 Textarea 컴포넌트
<img width="728" height="159" alt="image" src="https://github.com/user-attachments/assets/59f7b9f3-04f7-41e4-88b4-751d91811aca" />

### **2. 기존 코드 교체**
- 지원하기 페이지에서 사용되던 기존의 개별 inputField 및 Textarea 구현을 새로운 공통 컴포넌트로 모두 교체
- S. 네이밍 적용


## 💬리뷰 요구사항
> 지원서 상세페이지 수정이 머지되면 사용해주세요! 남은 댓글 및 후기 기능에서도 활용될 예정입니다.
