### PR TITLE
[REFACTOR] 상세페이지들의 route & API 구조 (#87)

### DIFF
--- a/src/constants/routerPath.ts
+++ b/src/constants/routerPath.ts
@@ -1,7 +1,7 @@
 export const ROUTE_PATH = {
+  MAIN: '/',
   DASHBOARD: 'club/dashboard',
   APPLICATIONDETAIL: 'clubs/:clubId/applicants/:applicantId',
-  MAIN: '/',
   CLUBDETAIL: 'clubs/:clubId',
   CLUBEDIT: 'clubs/:clubId/edit',
   CLUBAPPLICATION: 'club/:id/apply',

--- a/src/constants/routerPath.ts
+++ b/src/constants/routerPath.ts
@@ -2,7 +2,7 @@ export const ROUTE_PATH = {
   DASHBOARD: 'club/dashboard',
   APPLICATIONDETAIL: 'clubs/:clubId/applicants/:applicantId',
   MAIN: '/',
-  CLUBDETAIL: 'club/:id',
+  CLUBDETAIL: 'club/:clubId',
   CLUBEDIT: 'clubs/:clubId/edit',
   CLUBAPPLICATION: 'club/:id/apply',
 };

--- a/src/constants/routerPath.ts
+++ b/src/constants/routerPath.ts
@@ -2,7 +2,7 @@ export const ROUTE_PATH = {
   DASHBOARD: 'club/dashboard',
   APPLICATIONDETAIL: 'clubs/:clubId/applicants/:applicantId',
   MAIN: '/',
-  CLUBDETAIL: 'club/:clubId',
+  CLUBDETAIL: 'clubs/:clubId',
   CLUBEDIT: 'clubs/:clubId/edit',
   CLUBAPPLICATION: 'club/:id/apply',
 };

--- a/src/pages/admin/ClubDetailEdit/components/ClubDescriptionEditSection/index.tsx
+++ b/src/pages/admin/ClubDetailEdit/components/ClubDescriptionEditSection/index.tsx
@@ -6,7 +6,7 @@ import { mockClubDetail } from '../mock';
 export const ClubDescriptionEditSection = () => {
   const [introduce, setIntroduce] = useState(mockClubDetail.introductionOverview);
   const [activity, setActivity] = useState(mockClubDetail.introductionActivity);
-  const [wannabe, setWannabe] = useState(mockClubDetail.introductionIdeal);
+  const [ideal, setIdeal] = useState(mockClubDetail.introductionIdeal);
 
   return (
     <DescriptionContainer>
@@ -17,7 +17,7 @@ export const ClubDescriptionEditSection = () => {
       <InputArea value={activity} onChange={(e) => setActivity(e.target.value)} />
 
       <SectionTitle>모집하는 사람</SectionTitle>
-      <InputArea value={wannabe} onChange={(e) => setWannabe(e.target.value)} />
+      <InputArea value={ideal} onChange={(e) => setIdeal(e.target.value)} />
     </DescriptionContainer>
   );
 };

--- a/src/pages/admin/ClubDetailEdit/components/ClubDescriptionEditSection/index.tsx
+++ b/src/pages/admin/ClubDetailEdit/components/ClubDescriptionEditSection/index.tsx
@@ -4,9 +4,9 @@ import { useState } from 'react';
 import { mockClubDetail } from '../mock';
 
 export const ClubDescriptionEditSection = () => {
-  const [introduce, setIntroduce] = useState(mockClubDetail.introductionIntroduce);
+  const [introduce, setIntroduce] = useState(mockClubDetail.introductionOverview);
   const [activity, setActivity] = useState(mockClubDetail.introductionActivity);
-  const [wannabe, setWannabe] = useState(mockClubDetail.introductionWannabe);
+  const [wannabe, setWannabe] = useState(mockClubDetail.introductionIdeal);
 
   return (
     <DescriptionContainer>

--- a/src/pages/admin/ClubDetailEdit/components/ClubInfoSidebarEditSection/index.tsx
+++ b/src/pages/admin/ClubDetailEdit/components/ClubInfoSidebarEditSection/index.tsx
@@ -27,7 +27,6 @@ export const ClubInfoSidebarEditSection = () => {
   );
   const [applicationNotices, setApplicationNotices] = useState(initialApplicationNotices);
 
-
   const renderEditableItem = (
     label: string,
     value: string,
@@ -103,8 +102,12 @@ export const ClubInfoSidebarEditSection = () => {
 
       {renderEditableItem('정기 모임', initialRegularMeetingInfo, 'regularMeetingInfo', () => {})}
       {renderEditableItem('모집 상태', initialRecruitStatus, 'recruitStatus', () => {})}
-      {renderEditableItem('지원 시 유의사항', applicationNotices, 'applicationNotices', setApplicationNotices )}
-      
+      {renderEditableItem(
+        '지원 시 유의사항',
+        applicationNotices,
+        'applicationNotices',
+        setApplicationNotices,
+      )}
     </S.SidebarContainer>
   );
 };

--- a/src/pages/admin/ClubDetailEdit/components/ClubInfoSidebarEditSection/index.tsx
+++ b/src/pages/admin/ClubDetailEdit/components/ClubInfoSidebarEditSection/index.tsx
@@ -13,6 +13,7 @@ export const ClubInfoSidebarEditSection = () => {
     recruitEnd: initialRecruitEnd,
     regularMeetingInfo: initialRegularMeetingInfo,
     recruitStatus: initialRecruitStatus,
+    applicationNotices: initialApplicationNotices,
   } = mockClubDetail;
 
   const [presidentName, setPresidentName] = useState(initialPresidentName);
@@ -24,6 +25,8 @@ export const ClubInfoSidebarEditSection = () => {
   const [recruitEnd, setRecruitEnd] = useState<Date | null>(
     initialRecruitEnd ? new Date(initialRecruitEnd) : null,
   );
+  const [applicationNotices, setApplicationNotices] = useState(initialApplicationNotices);
+
 
   const renderEditableItem = (
     label: string,
@@ -100,7 +103,8 @@ export const ClubInfoSidebarEditSection = () => {
 
       {renderEditableItem('정기 모임', initialRegularMeetingInfo, 'regularMeetingInfo', () => {})}
       {renderEditableItem('모집 상태', initialRecruitStatus, 'recruitStatus', () => {})}
-      <S.Notice>지원 시 유의사항이 여기에 들어갑니다.</S.Notice>
+      {renderEditableItem('지원 시 유의사항', applicationNotices, 'applicationNotices', setApplicationNotices )}
+      
     </S.SidebarContainer>
   );
 };

--- a/src/pages/admin/ClubDetailEdit/components/mock.ts
+++ b/src/pages/admin/ClubDetailEdit/components/mock.ts
@@ -5,16 +5,16 @@ export type Club = {
   category: string;
   shortIntroduction: string;
   introductionImages: string[];
-  introductionOverview: string;  
+  introductionOverview: string;
   introductionActivity: string;
-  introductionIdeal: string; 
+  introductionIdeal: string;
   regularMeetingInfo: string;
   recruitStatus: string;
   presidentName: string;
   presidentPhoneNumber: string;
   recruitStart: string;
   recruitEnd: string;
-  applicationNotices: string; 
+  applicationNotices: string;
 };
 
 export const mockClubDetail: Club = {
@@ -44,5 +44,6 @@ export const mockClubDetail: Club = {
   presidentPhoneNumber: '010-9619-7677',
   recruitStart: '2025-09-03T00:00:00',
   recruitEnd: '2025-09-20T23:59:00',
-  applicationNotices: '저희 동아리는 졸업생 또는 휴학생의 경우 지원이 반려될 수 있습니다. 1~3학년만 지원 부탁드려요'
+  applicationNotices:
+    '저희 동아리는 졸업생 또는 휴학생의 경우 지원이 반려될 수 있습니다. 1~3학년만 지원 부탁드려요',
 };

--- a/src/pages/admin/ClubDetailEdit/components/mock.ts
+++ b/src/pages/admin/ClubDetailEdit/components/mock.ts
@@ -5,15 +5,16 @@ export type Club = {
   category: string;
   shortIntroduction: string;
   introductionImages: string[];
-  introductionIntroduce: string;
+  introductionOverview: string;  
   introductionActivity: string;
-  introductionWannabe: string;
+  introductionIdeal: string; 
   regularMeetingInfo: string;
   recruitStatus: string;
   presidentName: string;
   presidentPhoneNumber: string;
   recruitStart: string;
   recruitEnd: string;
+  applicationNotices: string; 
 };
 
 export const mockClubDetail: Club = {
@@ -28,13 +29,13 @@ export const mockClubDetail: Club = {
     'https://plus.unsplash.com/premium_photo-1704756437707-e9fee5c04bcf?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
     'https://plus.unsplash.com/premium_photo-1704756437647-559e43344877?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   ],
-  introductionIntroduce: `인터엑스는 사회 문제를 깊이 있게 탐구하고 이를 해결하기 위해 다양한 활동을 기획하는 동아리입니다. 
+  introductionOverview: `인터엑스는 사회 문제를 깊이 있게 탐구하고 이를 해결하기 위해 다양한 활동을 기획하는 동아리입니다. 
   회원들은 토론, 조사, 캠페인 등을 통해 실제 사회 문제를 이해하고, 문제 해결을 위한 창의적 방법을 모색합니다. 
   학문적 연구와 실질적 활동을 병행하며, 서로의 생각을 존중하고 협력하는 문화를 지향합니다.`,
   introductionActivity: `동아리 활동으로는 매주 세미나와 그룹 토론, 지역 사회 봉사활동, 캠페인 기획 및 참여 등이 있습니다. 
   회원들은 각자의 관심 분야를 살려 프로젝트를 진행하며, 발표와 보고서를 통해 성과를 공유합니다. 
   또한 외부 전문가 초청 강연을 통해 사회 문제에 대한 이해를 넓히고, 실천 가능한 해결책을 모색합니다.`,
-  introductionWannabe: `인터엑스에서는 성실하고 책임감 있는 인재를 기다립니다. 
+  introductionIdeal: `인터엑스에서는 성실하고 책임감 있는 인재를 기다립니다. 
   문제 해결에 관심이 많고 창의적 아이디어를 공유할 수 있는 사람, 
   팀원들과 협력하며 꾸준히 학습하고 성장하려는 자세를 가진 사람이라면 누구나 환영합니다.`,
   regularMeetingInfo: '매주 화요일 오후 6시',
@@ -43,4 +44,5 @@ export const mockClubDetail: Club = {
   presidentPhoneNumber: '010-9619-7677',
   recruitStart: '2025-09-03T00:00:00',
   recruitEnd: '2025-09-20T23:59:00',
+  applicationNotices: '저희 동아리는 졸업생 또는 휴학생의 경우 지원이 반려될 수 있습니다. 1~3학년만 지원 부탁드려요'
 };

--- a/src/pages/user/ClubDetail/components/ClubDescriptionSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubDescriptionSection/index.tsx
@@ -6,13 +6,13 @@ export const ClubDescriptionSection = () => {
   return (
     <DescriptionContainer>
       <SectionTitle>동아리 소개</SectionTitle>
-      <DescriptionText>{mockClubDetail.introductionIntroduce}</DescriptionText>
+      <DescriptionText>{mockClubDetail.introductionOverview}</DescriptionText>
 
       <SectionTitle>활동 내용</SectionTitle>
       <DescriptionText>{mockClubDetail.introductionActivity}</DescriptionText>
 
       <SectionTitle>모집하는 사람</SectionTitle>
-      <DescriptionText>{mockClubDetail.introductionWannabe}</DescriptionText>
+      <DescriptionText>{mockClubDetail.introductionIdeal}</DescriptionText>
     </DescriptionContainer>
   );
 };

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -13,6 +13,7 @@ export const ClubInfoSidebarSection = () => {
     recruitEnd,
     regularMeetingInfo,
     recruitStatus,
+    applicationNotices,
   } = mockClubDetail;
 
   const clubId = useParams();
@@ -28,7 +29,7 @@ export const ClubInfoSidebarSection = () => {
       <InfoItem>정기 모임: {regularMeetingInfo}</InfoItem>
       <InfoItem>모집 상태: {recruitStatus}</InfoItem>
       <Button to={`/club/${clubId.id}/apply`}>지원하기</Button>
-      <Notice>지원 시 유의사항이 여기에 들어갑니다.</Notice>
+      <Notice>{applicationNotices}</Notice>
     </SidebarContainer>
   );
 };

--- a/src/pages/user/ClubDetail/components/mock.ts
+++ b/src/pages/user/ClubDetail/components/mock.ts
@@ -5,16 +5,16 @@ export type Club = {
   category: string;
   shortIntroduction: string;
   introductionImages: string[];
-  introductionOverview: string;  
+  introductionOverview: string;
   introductionActivity: string;
-  introductionIdeal: string; 
+  introductionIdeal: string;
   regularMeetingInfo: string;
   recruitStatus: string;
   presidentName: string;
   presidentPhoneNumber: string;
   recruitStart: string;
   recruitEnd: string;
-  applicationNotices: string; 
+  applicationNotices: string;
 };
 
 export const mockClubDetail: Club = {
@@ -44,5 +44,6 @@ export const mockClubDetail: Club = {
   presidentPhoneNumber: '010-9619-7677',
   recruitStart: '2025-09-03T00:00:00',
   recruitEnd: '2025-09-20T23:59:00',
-  applicationNotices: '저희 동아리는 졸업생 또는 휴학생의 경우 지원이 반려될 수 있습니다. 1~3학년만 지원 부탁드려요'
+  applicationNotices:
+    '저희 동아리는 졸업생 또는 휴학생의 경우 지원이 반려될 수 있습니다. 1~3학년만 지원 부탁드려요',
 };

--- a/src/pages/user/ClubDetail/components/mock.ts
+++ b/src/pages/user/ClubDetail/components/mock.ts
@@ -5,15 +5,16 @@ export type Club = {
   category: string;
   shortIntroduction: string;
   introductionImages: string[];
-  introductionIntroduce: string;
+  introductionOverview: string;  
   introductionActivity: string;
-  introductionWannabe: string;
+  introductionIdeal: string; 
   regularMeetingInfo: string;
   recruitStatus: string;
   presidentName: string;
   presidentPhoneNumber: string;
   recruitStart: string;
   recruitEnd: string;
+  applicationNotices: string; 
 };
 
 export const mockClubDetail: Club = {
@@ -28,13 +29,13 @@ export const mockClubDetail: Club = {
     'https://plus.unsplash.com/premium_photo-1704756437707-e9fee5c04bcf?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
     'https://plus.unsplash.com/premium_photo-1704756437647-559e43344877?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
   ],
-  introductionIntroduce: `인터엑스는 사회 문제를 깊이 있게 탐구하고 이를 해결하기 위해 다양한 활동을 기획하는 동아리입니다. 
+  introductionOverview: `인터엑스는 사회 문제를 깊이 있게 탐구하고 이를 해결하기 위해 다양한 활동을 기획하는 동아리입니다. 
   회원들은 토론, 조사, 캠페인 등을 통해 실제 사회 문제를 이해하고, 문제 해결을 위한 창의적 방법을 모색합니다. 
   학문적 연구와 실질적 활동을 병행하며, 서로의 생각을 존중하고 협력하는 문화를 지향합니다.`,
   introductionActivity: `동아리 활동으로는 매주 세미나와 그룹 토론, 지역 사회 봉사활동, 캠페인 기획 및 참여 등이 있습니다. 
   회원들은 각자의 관심 분야를 살려 프로젝트를 진행하며, 발표와 보고서를 통해 성과를 공유합니다. 
   또한 외부 전문가 초청 강연을 통해 사회 문제에 대한 이해를 넓히고, 실천 가능한 해결책을 모색합니다.`,
-  introductionWannabe: `인터엑스에서는 성실하고 책임감 있는 인재를 기다립니다. 
+  introductionIdeal: `인터엑스에서는 성실하고 책임감 있는 인재를 기다립니다. 
   문제 해결에 관심이 많고 창의적 아이디어를 공유할 수 있는 사람, 
   팀원들과 협력하며 꾸준히 학습하고 성장하려는 자세를 가진 사람이라면 누구나 환영합니다.`,
   regularMeetingInfo: '매주 화요일 오후 6시',
@@ -43,4 +44,5 @@ export const mockClubDetail: Club = {
   presidentPhoneNumber: '010-9619-7677',
   recruitStart: '2025-09-03T00:00:00',
   recruitEnd: '2025-09-20T23:59:00',
+  applicationNotices: '저희 동아리는 졸업생 또는 휴학생의 경우 지원이 반려될 수 있습니다. 1~3학년만 지원 부탁드려요'
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #87 

## 📝 작업 내용

- `clubdetail` 라우트 → `clubs/:clubId` 구조로 변경  
  - `clubapplication` 라우트를 `clubdetail` 구조에 종속되도록 수정  
- 목데이터를 변경된 API 구조에 맞춰 수정  
  - `applicationNotices` (지원 유의사항) 필드 추가  
  - 기존 mock 응답 스키마 전반 점검 및 업데이트  
- 프론트에서 상세페이지 컴포넌트가 새로운 API 구조와 호환되도록 업데이트  

### 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
