### PR TITLE
[REFACTOR] SectionTitle - inline 요소 확장성 적용

### DIFF
--- a/src/shared/components/SectionTitle/index.tsx
+++ b/src/shared/components/SectionTitle/index.tsx
@@ -1,6 +1,20 @@
 import styled from '@emotion/styled';
 
-export const SectionTitle = styled.h2(({ theme }) => ({
+interface SectionTitleProps {
+  required?: boolean;
+  children: React.ReactNode;
+}
+
+export const SectionTitle = ({ required, children }: SectionTitleProps) => {
+  return (
+    <StyledTitle>
+      {children}
+      {required && <RequiredMark>*</RequiredMark>}
+    </StyledTitle>
+  );
+};
+
+const StyledTitle = styled.h2(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   fontSize: theme.font.size.lg,
@@ -8,5 +22,9 @@ export const SectionTitle = styled.h2(({ theme }) => ({
   margin: '1.5rem 0 0 0',
   color: theme.colors.textPrimary,
   width: '100%',
-  gap: '0.5rem',
+  gap: '0.25rem',
+}));
+
+const RequiredMark = styled.span(({ theme }) => ({
+  color: theme.colors.red300,
 }));


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #97 

## 📝작업 내용

> SectionTitle 컴포넌트를 기존 width 100% 유지하면서, 글씨와 함께 inline 요소(+ 버튼, 필수 표시 *)를 같은 라인에 자연스럽게 배치할 수 있도록 리팩토링했습니다.
> 
> - display: flex 적용
> - align-items: center로 수직 중앙 정렬
> - gap 추가로 글씨와 inline 요소 간격 조정
> - 기존 block 구조와 width 100% 유지

- 필요에 의한 간단한 스타일 레이아웃 변경 입니다. 

- 추가로 스타일만 가지고있는 공유컴포넌트이기에 (ClubDetailLayout에서 그랬듯이) 이름을 **index.styled.ts**로 바꾸려고 하는데, 
이 부분은 불러오기를 대거 변경하게 되기 때문에 
**지금 진행중인 이슈(92)에서**적용하겠습니다!

## 💬리뷰 요구사항(선택)
