### PR TITLE
[STYLE] 동아리 상세페이지& 지원서 작성 페이지 UI 개선 (#120)

### DIFF
--- a/src/pages/user/Apply/Page.tsx
+++ b/src/pages/user/Apply/Page.tsx
@@ -13,23 +13,22 @@ export const ClubApplicationPage = () => {
 
   return (
     <Layout>
-      <FormContainer>
-        <ClubDescription title={formData.title} description={formData?.description ?? ''} />
-        <ApplicationForm questions={formData.questions} />
-      </FormContainer>
+      <ClubDescription title={formData.title} description={formData?.description ?? ''} />
+      <ApplicationForm questions={formData.questions} />
     </Layout>
   );
 };
 
 export const Layout = styled.main(({ theme }) => ({
-  backgroundColor: theme.colors.bgBlue,
   minHeight: '100vh',
-  padding: '5.2rem 3rem',
   display: 'flex',
   gap: '1.5rem',
-  justifyContent: 'center',
+  flexWrap: 'wrap',
   maxWidth: '1200px',
+  width: '100%',
   margin: '0 auto',
+  padding: '0 1.5rem',
+  boxSizing: 'border-box',
 
   [`@media (max-width: ${theme.breakpoints.web})`]: {
     padding: '1.5rem',
@@ -39,15 +38,3 @@ export const Layout = styled.main(({ theme }) => ({
     padding: '1rem',
   },
 }));
-
-export const FormContainer = styled.div({
-  backgroundColor: 'white',
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  padding: '2.6rem 3rem',
-  width: '80%',
-  maxWidth: '1200px',
-  margin: '0 auto',
-  borderRadius: '4rem',
-});

--- a/src/pages/user/Apply/Page.tsx
+++ b/src/pages/user/Apply/Page.tsx
@@ -25,6 +25,7 @@ const ContentContainer = styled.div`
   width: 48rem;
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
 
   @media (max-width: 48rem) {
     width: 100%;

--- a/src/pages/user/Apply/Page.tsx
+++ b/src/pages/user/Apply/Page.tsx
@@ -13,20 +13,33 @@ export const ClubApplicationPage = () => {
 
   return (
     <Layout>
-      <ClubDescription title={formData.title} description={formData?.description ?? ''} />
-      <ApplicationForm questions={formData.questions} />
+      <ContentContainer>
+        <ClubDescription title={formData.title} description={formData?.description ?? ''} />
+        <ApplicationForm questions={formData.questions} />
+      </ContentContainer>
     </Layout>
   );
 };
 
+const ContentContainer = styled.div`
+  width: 48rem;
+  display: flex;
+  flex-direction: column;
+
+  @media (max-width: 48rem) {
+    width: 100%;
+  }
+`;
+
 export const Layout = styled.main(({ theme }) => ({
   minHeight: '100vh',
   display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
   gap: '1.5rem',
-  flexWrap: 'wrap',
   maxWidth: '1200px',
   width: '100%',
-  margin: '0 auto',
+  margin: '0 auto 4rem auto',
   padding: '0 1.5rem',
   boxSizing: 'border-box',
 
@@ -34,7 +47,6 @@ export const Layout = styled.main(({ theme }) => ({
     padding: '1.5rem',
   },
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    flexDirection: 'column',
     padding: '1rem',
   },
 }));

--- a/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
+++ b/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { theme } from '@/styles/theme';
 
 type OptionInputProps = {
   type: 'checkbox' | 'radio';
@@ -18,20 +17,30 @@ export const OptionInput = styled.input<OptionInputProps>(({ theme, type }) => (
   },
 }));
 
-export const UserInfoWrapper = styled.div({
+export const UserInfoWrapper = styled.div(({ theme }) => ({
+  width: '48rem',
   display: 'flex',
-  flexDirection: 'row',
-  flexWrap: 'wrap',
-  alignItems: 'center',
-  justifyContent: 'flex-start',
-  gap: 60,
-  padding: 40,
-});
+  flexDirection: 'column',
+  gap: '30px',
+  borderBottom: `1px solid ${theme.colors.gray200}`,
+  paddingBottom: '3rem',
+}));
 
 export const FormField = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  gap: 10,
+  gap: '10px',
+});
+
+export const FormRow = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: '2.5rem',
+  width: '100%',
+  '& > *': {
+    flex: '1 1 0',
+    minWidth: 0,
+  },
 });
 
 export const Label = styled.label(({ theme }) => ({
@@ -41,26 +50,25 @@ export const Label = styled.label(({ theme }) => ({
   fontWeight: theme.font.weight.medium,
 }));
 
-export const QuestionWrapper = styled.div({
-  width: '48rem',
+const FlexColumn = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  gap: 60,
-  padding: 40,
 });
 
-export const ChoiceFormFiled = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  padding: 40,
-  gap: 10,
+export const QuestionWrapper = styled(FlexColumn)({
+  width: '48rem',
+  gap: '3rem',
+});
+
+export const ChoiceFormFiled = styled(FlexColumn)({
+  gap: '1rem',
 });
 
 export const FormContainer = styled.main({
   display: 'flex',
   flexDirection: 'column',
-  gap: '60px',
   alignItems: 'center',
+  gap: '3rem',
 });
 
 export const ErrorMessage = styled.span(({ theme }) => ({

--- a/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
+++ b/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
@@ -18,12 +18,17 @@ export const OptionInput = styled.input<OptionInputProps>(({ theme, type }) => (
 }));
 
 export const UserInfoWrapper = styled.div(({ theme }) => ({
+  boxSizing: 'border-box',
   width: '48rem',
   display: 'flex',
   flexDirection: 'column',
   gap: '30px',
   borderBottom: `1px solid ${theme.colors.gray200}`,
   paddingBottom: '3rem',
+
+  '@media (max-width: 48rem)': {
+    width: '100%',
+  },
 }));
 
 export const FormField = styled.div({
@@ -56,8 +61,13 @@ const FlexColumn = styled.div({
 });
 
 export const QuestionWrapper = styled(FlexColumn)({
+  boxSizing: 'border-box',
   width: '48rem',
   gap: '3rem',
+
+  '@media (max-width: 48rem)': {
+    width: '100%',
+  },
 });
 
 export const ChoiceFormFiled = styled(FlexColumn)({

--- a/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
+++ b/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
@@ -26,9 +26,6 @@ export const UserInfoWrapper = styled.div({
   justifyContent: 'flex-start',
   gap: 60,
   padding: 40,
-  border: `1px none ${theme.colors.gray200}`,
-  borderRadius: '1rem',
-  boxShadow: theme.shadow.md,
 });
 
 export const FormField = styled.div({
@@ -50,9 +47,6 @@ export const QuestionWrapper = styled.div({
   flexDirection: 'column',
   gap: 60,
   padding: 40,
-  border: `1px none ${theme.colors.gray200}`,
-  borderRadius: '1rem',
-  boxShadow: theme.shadow.md,
 });
 
 export const ChoiceFormFiled = styled.div({
@@ -60,9 +54,6 @@ export const ChoiceFormFiled = styled.div({
   flexDirection: 'column',
   padding: 40,
   gap: 10,
-  border: `1px none ${theme.colors.gray200}`,
-  borderRadius: '1rem',
-  boxShadow: theme.shadow.md,
 });
 
 export const FormContainer = styled.main({

--- a/src/pages/user/Apply/components/ApplicationForm/index.tsx
+++ b/src/pages/user/Apply/components/ApplicationForm/index.tsx
@@ -37,10 +37,10 @@ export const ApplicationForm = ({ questions }: Props) => {
 
   const questionsWithIndex = questions.map((q, i) => ({ ...q, originalIndex: i }));
   const timeSlotQuestions = questionsWithIndex.filter(
-    (q) => q.questionType === QuestionType.TIME_SLOT
+    (q) => q.questionType === QuestionType.TIME_SLOT,
   );
   const otherQuestions = questionsWithIndex.filter(
-    (q) => q.questionType !== QuestionType.TIME_SLOT
+    (q) => q.questionType !== QuestionType.TIME_SLOT,
   );
 
   return (

--- a/src/pages/user/Apply/components/ApplicationForm/index.tsx
+++ b/src/pages/user/Apply/components/ApplicationForm/index.tsx
@@ -25,6 +25,7 @@ export const ApplicationForm = ({ questions }: Props) => {
       answers: [],
     },
   });
+  const { errors, isSubmitting, isSubmitSuccessful } = methods.formState;
 
   const { id } = useParams<{ id: string }>();
   const clubId = Number(id);
@@ -43,135 +44,139 @@ export const ApplicationForm = ({ questions }: Props) => {
   );
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <S.FormContainer>
-        <S.UserInfoWrapper>
-          <S.FormField>
-            <S.Label>이름</S.Label>
-            <OutlineInputField
-              placeholder='이름을 입력하세요.'
-              {...register('name', { required: '이름을 입력하세요.' })}
-              invalid={!!errors.name}
-              message={errors.name?.message}
-            />
-          </S.FormField>
-          <S.FormRow>
+    <FormProvider {...methods}>
+      <form onSubmit={methods.handleSubmit(onSubmit)}>
+        <S.FormContainer>
+          <S.UserInfoWrapper>
             <S.FormField>
-              <S.Label>학번</S.Label>
+              <S.Label>이름</S.Label>
               <OutlineInputField
-                placeholder='학번을 입력하세요.'
-                {...register('studentId', {
-                  required: '학번을 입력하세요.',
-                  maxLength: { value: 6, message: '학번은 최대 6자리까지 입력 가능합니다.' },
+                placeholder='이름을 입력하세요.'
+                {...methods.register('name', { required: '이름을 입력하세요.' })}
+                invalid={!!errors.name}
+                message={errors.name?.message}
+              />
+            </S.FormField>
+            <S.FormRow>
+              <S.FormField>
+                <S.Label>학번</S.Label>
+                <OutlineInputField
+                  placeholder='학번을 입력하세요.'
+                  {...methods.register('studentId', {
+                    required: '학번을 입력하세요.',
+                    maxLength: { value: 6, message: '학번은 최대 6자리까지 입력 가능합니다.' },
+                    pattern: {
+                      value: /^[0-9]{6}$/,
+                      message: '학번은 숫자 6자리여야 합니다.',
+                    },
+                  })}
+                  invalid={!!errors.studentId}
+                  message={errors.studentId?.message}
+                />
+              </S.FormField>
+              <S.FormField>
+                <S.Label>학과</S.Label>
+                <OutlineInputField
+                  placeholder='학과를 입력하세요.'
+                  {...methods.register('department', { required: '학과를 입력하세요.' })}
+                  invalid={!!errors.department}
+                  message={errors.department?.message}
+                />
+              </S.FormField>
+            </S.FormRow>
+            <S.FormField>
+              <S.Label>전화번호</S.Label>
+              <OutlineInputField
+                placeholder='010-0000-0000'
+                {...methods.register('phoneNumber', {
+                  required: '전화번호를 입력하세요.',
                   pattern: {
-                    value: /^[0-9]{6}$/,
-                    message: '학번은 숫자 6자리여야 합니다.',
+                    value: /^\d{2,3}-\d{3,4}-\d{4}$/,
+                    message: '올바른 전화번호 형식이 아닙니다.',
                   },
                 })}
-                invalid={!!errors.studentId}
-                message={errors.studentId?.message}
+                invalid={!!errors.phoneNumber}
+                message={errors.phoneNumber?.message}
               />
             </S.FormField>
             <S.FormField>
-              <S.Label>학과</S.Label>
+              <S.Label>이메일</S.Label>
               <OutlineInputField
-                placeholder='학과를 입력하세요.'
-                {...register('department', { required: '학과를 입력하세요.' })}
-                invalid={!!errors.department}
-                message={errors.department?.message}
+                placeholder='이메일을 입력하세요.'
+                {...methods.register('email', {
+                  required: '이메일을 입력하세요.',
+                  pattern: {
+                    value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                    message: '올바른 이메일 형식이 아닙니다. 예: example@email.com',
+                  },
+                })}
+                invalid={!!errors.email}
+                message={errors.email?.message}
               />
             </S.FormField>
-          </S.FormRow>
-          <S.FormField>
-            <S.Label>전화번호</S.Label>
-            <OutlineInputField
-              placeholder='010-0000-0000'
-              {...register('phoneNumber', {
-                required: '전화번호를 입력하세요.',
-                pattern: {
-                  value: /^\d{2,3}-\d{3,4}-\d{4}$/,
-                  message: '올바른 전화번호 형식이 아닙니다.',
-                },
-              })}
-              invalid={!!errors.phoneNumber}
-              message={errors.phoneNumber?.message}
-            />
-          </S.FormField>
-          <S.FormField>
-            <S.Label>이메일</S.Label>
-            <OutlineInputField
-              placeholder='이메일을 입력하세요.'
-              {...register('email', {
-                required: '이메일을 입력하세요.',
-                pattern: {
-                  value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-                  message: '올바른 이메일 형식이 아닙니다. 예: example@email.com',
-                },
-              })}
-              invalid={!!errors.email}
-              message={errors.email?.message}
-            />
-          </S.FormField>
-        </S.UserInfoWrapper>
+          </S.UserInfoWrapper>
 
-        <S.QuestionWrapper>
-          {otherQuestions.map((field) => (
-            <S.ChoiceFormFiled key={field.questionNum}>
-              <S.Label>{field.question}</S.Label>
-
-              {field.questionType === QuestionType.CHECKBOX &&
-                field.optionList?.map((option, optIndex) => (
-                  <S.Label key={optIndex}>
-                    <S.OptionInput
-                      type='checkbox'
-                      value={option}
-                      {...register(`answers.${field.originalIndex}`)}
-                    />
-                  ))}
-
-              {field.questionType === QuestionType.RADIO &&
-                field.optionList?.map((option, optIndex) => (
-                  <S.Label key={optIndex}>
-                    <S.OptionInput
-                      type='radio'
-                      value={option}
-                      {...register(`answers.${field.originalIndex}`)}
-                    />
-                    {option}
-                  </S.Label>
-                ))}
-
-              {field.questionType === QuestionType.TEXT && (
-                <OutlineTextareaField
-                  placeholder='1000자 미만으로 입력하세요.'
-                  {...register(`answers.${field.originalIndex}`)}
-                />
-              )}
-            </S.ChoiceFormFiled>
-          ))}
-        </S.QuestionWrapper>
-
-        {timeSlotQuestions.length > 0 && (
           <S.QuestionWrapper>
-            {timeSlotQuestions.map((field) => (
+            {otherQuestions.map((field) => (
               <S.ChoiceFormFiled key={field.questionNum}>
                 <S.Label>{field.question}</S.Label>
-                {field.timeSlotOption?.map((option, idx) => (
-                  <InterviewSchedule
-                    key={idx}
-                    availableTime={option.availableTime}
-                    date={option.date}
+
+                {field.questionType === QuestionType.CHECKBOX &&
+                  field.optionList?.map((option, optIndex) => (
+                    <S.Label key={optIndex}>
+                      <S.OptionInput
+                        type='checkbox'
+                        value={option}
+                        {...methods.register(`answers.${field.originalIndex}`)}
+                      />
+                      {option}
+                    </S.Label>
+                  ))}
+
+                {field.questionType === QuestionType.RADIO &&
+                  field.optionList?.map((option, optIndex) => (
+                    <S.Label key={optIndex}>
+                      <S.OptionInput
+                        type='radio'
+                        value={option}
+                        {...methods.register(`answers.${field.originalIndex}`)}
+                      />
+                      {option}
+                    </S.Label>
+                  ))}
+
+                {field.questionType === QuestionType.TEXT && (
+                  <OutlineTextareaField
+                    placeholder='1000자 미만으로 입력하세요.'
+                    {...methods.register(`answers.${field.originalIndex}`)}
                   />
-                ))}
+                )}
               </S.ChoiceFormFiled>
             ))}
           </S.QuestionWrapper>
-        )}
 
-        <Button type='submit'>{isSubmitting ? '제출중...' : '제출하기'}</Button>
-        {/* 제출 완료 후 toast 알림 적용 부분*/}
-        {isSubmitSuccessful && <span>제출 성공!</span>}
-      </S.FormContainer>
-    </form>
+          {timeSlotQuestions.length > 0 && (
+            <S.QuestionWrapper>
+              {timeSlotQuestions.map((field) => (
+                <S.ChoiceFormFiled key={field.questionNum}>
+                  <S.Label>{field.question}</S.Label>
+                  {field.timeSlotOption?.map((option, idx) => (
+                    <InterviewSchedule
+                      key={idx}
+                      availableTime={option.availableTime}
+                      date={option.date}
+                    />
+                  ))}
+                </S.ChoiceFormFiled>
+              ))}
+            </S.QuestionWrapper>
+          )}
+
+          <Button type='submit'>{isSubmitting ? '제출중...' : '제출하기'}</Button>
+          {/* 제출 완료 후 toast 알림 적용 부분*/}
+          {isSubmitSuccessful && <span>제출 성공!</span>}
+        </S.FormContainer>
+      </form>
+    </FormProvider>
   );
 };

--- a/src/pages/user/Apply/components/ClubDescriptionSection/index.tsx
+++ b/src/pages/user/Apply/components/ClubDescriptionSection/index.tsx
@@ -20,8 +20,8 @@ export const ClubDescription = ({ title }: props) => {
 const TextWrapper = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  gap: 35,
-  padding: 20,
+  gap: '2rem',
+  padding: '4rem 0',
 });
 
 const Title = styled.h1(({ theme }) => ({

--- a/src/pages/user/Apply/components/ClubDescriptionSection/index.tsx
+++ b/src/pages/user/Apply/components/ClubDescriptionSection/index.tsx
@@ -6,13 +6,13 @@ type props = {
   description: string | undefined;
 };
 
-export const ClubDescription = ({ title, description }: props) => {
+export const ClubDescription = ({ title }: props) => {
   return (
     <TextWrapper>
-      <Text size='xl' weight='bold'>
+      <Title>지원서 작성하기</Title>
+      <Text size='xl' weight='regular' color='#4E5968'>
         {title}
       </Text>
-      <Text>{description}</Text>
     </TextWrapper>
   );
 };
@@ -20,7 +20,11 @@ export const ClubDescription = ({ title, description }: props) => {
 const TextWrapper = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  alignItems: 'center',
   gap: 35,
   padding: 20,
 });
+
+const Title = styled.h1(({ theme }) => ({
+  fontSize: '2.5rem',
+  fontWeight: theme.font.weight.medium,
+}));

--- a/src/pages/user/ClubDetail/components/ClubDescriptionSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubDescriptionSection/index.tsx
@@ -27,7 +27,7 @@ const DescriptionContainer = styled.div(({ theme }) => ({
 }));
 
 const DescriptionText = styled.p(({ theme }) => ({
-  fontSize: theme.font.size.sm,
+  fontSize: theme.font.size.base,
   lineHeight: 1.6,
   margin: 0,
 }));

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -16,7 +16,7 @@ export const ClubInfoSidebarSection = () => {
     applicationNotice,
   } = mockClubDetail;
 
-  const clubId = useParams();
+  const { clubId } = useParams<{ clubId: string }>();
 
   return (
     <SidebarContainer>
@@ -28,7 +28,7 @@ export const ClubInfoSidebarSection = () => {
       </InfoItem>
       <InfoItem>정기 모임: {regularMeetingInfo}</InfoItem>
       <InfoItem>모집 상태: {recruitStatus}</InfoItem>
-      <Button to={`/club/${clubId.id}/apply`} width={'auto'}>
+      <Button to={`/clubs/${clubId}/apply`} width={'auto'}>
         지원하기
       </Button>
       <Notice>{applicationNotice}</Notice>

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -35,12 +35,14 @@ export const ClubInfoSidebarSection = () => {
 };
 
 const SidebarContainer = styled.div(({ theme }) => ({
+  marginTop: '1rem',
   backgroundColor: theme.colors.bg,
-  padding: '16px',
+  padding: '1.3rem',
   borderRadius: theme.radius.md,
   display: 'flex',
   flexDirection: 'column',
-  gap: '12px',
+  gap: '1rem',
+  border: '1px solid #E5E7ED',
 }));
 
 const InfoItem = styled.div(({ theme }) => ({

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -28,7 +28,9 @@ export const ClubInfoSidebarSection = () => {
       </InfoItem>
       <InfoItem>정기 모임: {regularMeetingInfo}</InfoItem>
       <InfoItem>모집 상태: {recruitStatus}</InfoItem>
-      <Button to={`/club/${clubId.id}/apply`}>지원하기</Button>
+      <Button to={`/club/${clubId.id}/apply`} width={'auto'}>
+        지원하기
+      </Button>
       <Notice>{applicationNotices}</Notice>
     </SidebarContainer>
   );

--- a/src/shared/components/ClubDetailLayout/ClubHeaderSection.tsx
+++ b/src/shared/components/ClubDetailLayout/ClubHeaderSection.tsx
@@ -29,7 +29,7 @@ const TextContainer = styled.div({
 });
 
 const Title = styled.h1(({ theme }) => ({
-  fontSize: '2rem',
+  fontSize: '2.5rem',
   fontWeight: theme.font.weight.medium,
   margin: '1rem 0 0 0.5rem',
 }));

--- a/src/shared/components/ClubDetailLayout/ClubHeaderSection.tsx
+++ b/src/shared/components/ClubDetailLayout/ClubHeaderSection.tsx
@@ -29,13 +29,13 @@ const TextContainer = styled.div({
 });
 
 const Title = styled.h1(({ theme }) => ({
-  fontSize: theme.font.size.xl,
-  fontWeight: theme.font.weight.bold,
+  fontSize: '2rem',
+  fontWeight: theme.font.weight.medium,
   margin: '1rem 0 0 0.5rem',
 }));
 
 const Category = styled.span(({ theme }) => ({
-  fontSize: theme.font.size.sm,
+  fontSize: theme.font.size.base,
   color: theme.colors.textSecondary,
   margin: '0.5rem 0 0 0.5rem',
 }));

--- a/src/shared/components/ClubDetailLayout/index.styled.ts
+++ b/src/shared/components/ClubDetailLayout/index.styled.ts
@@ -16,7 +16,7 @@ export const Layout = styled.main(({ theme }) => ({
     padding: '1.5rem',
   },
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    flexDirection: 'column',
+    display: 'block',
     padding: '1rem',
   },
 }));
@@ -56,6 +56,7 @@ export const ContentRight = styled.div(({ theme }) => ({
     margin: '1.5rem auto 0 auto',
   },
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    flex: 'initial',
     maxWidth: '100%',
     margin: '1rem 0 0 0',
     padding: '1rem',

--- a/src/shared/components/ClubDetailLayout/index.styled.ts
+++ b/src/shared/components/ClubDetailLayout/index.styled.ts
@@ -1,15 +1,16 @@
 import styled from '@emotion/styled';
 
 export const Layout = styled.main(({ theme }) => ({
-  backgroundColor: theme.colors.bgBlue,
   minHeight: '100vh',
-  padding: '2.6rem 3rem',
   display: 'flex',
   gap: '1.5rem',
   flexWrap: 'wrap',
   justifyContent: 'center',
   maxWidth: '1200px',
+  width: '100%',
   margin: '0 auto',
+  padding: '0 1.5rem',
+  boxSizing: 'border-box',
 
   [`@media (max-width: ${theme.breakpoints.web})`]: {
     padding: '1.5rem',
@@ -52,7 +53,6 @@ export const ContentRight = styled.div(({ theme }) => ({
 
   [`@media (max-width: ${theme.breakpoints.web})`]: {
     flex: '1 1 100%',
-    maxWidth: '31.25rem',
     margin: '1.5rem auto 0 auto',
   },
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #120 

## 📝작업 내용

동아리 상세페이지와 지원서 작성 페이지의 배경을 제거하고, 두 페이지가 자연스럽게 이어지도록 스타일을 개선했습니다.  
또한 동일한 스타일을 적용하며 반응형 레이아웃을 지원하도록 수정했습니다.

### 스크린샷 (선택)
#### 동아리 상세페이지
- 수정 전
<img width="770" height="365" alt="image" src="https://github.com/user-attachments/assets/894f3a5a-d98f-4ea3-ad67-8736234b37f4" />

- 수정 후
<img width="769" height="378" alt="image" src="https://github.com/user-attachments/assets/854c7de3-c485-4ee7-91bc-68ca920e6e45" />

- 모바일
<img width="308" height="637" alt="image" src="https://github.com/user-attachments/assets/a1a83f7f-4830-4011-9bdb-480a1b922705" />

#### 지원하기 페이지
- 수정 전
<img width="762" height="432" alt="image" src="https://github.com/user-attachments/assets/4bcc5d6c-8ff7-42b4-aba1-2129caa782ae" />

- 수정 후
<img width="769" height="419" alt="image" src="https://github.com/user-attachments/assets/944ddc0d-65ba-4f5c-8c9e-2b328c5ac9cc" />

## 💬리뷰 요구사항(선택)

지원하기 페이지에서 화면 크기를 줄이면, 오른쪽 input 창에 여백이 사라지는 문제가 발생합니다..