### PR TITLE
[REFACTOR] Route 상수 계층 구조 적용 (#109)

### DIFF
--- a/src/constants/routerPath.ts
+++ b/src/constants/routerPath.ts
@@ -1,8 +1,16 @@
 export const ROUTE_PATH = {
-  MAIN: '/',
-  DASHBOARD: 'club/dashboard',
-  APPLICATIONDETAIL: 'clubs/:clubId/applicants/:applicantId',
-  CLUBDETAIL: 'clubs/:clubId',
-  CLUBEDIT: 'clubs/:clubId/edit',
-  CLUBAPPLICATION: 'clubs/:clubId/apply',
+  USER: {
+    APPLICATION: 'clubs/:clubId/apply',
+  },
+
+  ADMIN: {
+    DASHBOARD: 'clubs/dashboard',
+    APPLICATIONDETAIL: 'clubs/:clubId/applicants/:applicantId',
+    CLUBEDIT: 'clubs/:clubId/edit',
+  },
+
+  COMMON: {
+    MAIN: '/',
+    CLUBDETAIL: 'clubs/:clubId',
+  },
 };

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -9,34 +9,34 @@ import { MainPage } from '@/pages/user/Main/Page.tsx';
 import { ApplicationDetailPage } from './admin/ApplicationDetail/Page';
 import { ClubApplicationPage } from './user/Apply/Page';
 
-const { MAIN, CLUBDETAIL, CLUBEDIT, APPLICATIONDETAIL, DASHBOARD, CLUBAPPLICATION } = ROUTE_PATH;
+const { USER, ADMIN, COMMON } = ROUTE_PATH;
 
 export const router = createBrowserRouter([
   {
     element: <App />,
     children: [
-      { path: MAIN, element: <MainPage /> },
+      { path: COMMON.MAIN, element: <MainPage /> },
       {
-        path: CLUBDETAIL,
+        path: COMMON.CLUBDETAIL,
         element: <ClubDetailPage />,
       },
       {
-        path: CLUBAPPLICATION,
+        path: USER.APPLICATION,
         element: <ClubApplicationPage />,
       },
       {
         path: '/admin',
         children: [
           {
-            path: DASHBOARD,
+            path: ADMIN.DASHBOARD,
             element: <DashboardPage />,
           },
           {
-            path: APPLICATIONDETAIL,
+            path: ADMIN.APPLICATIONDETAIL,
             element: <ApplicationDetailPage />,
           },
           {
-            path: CLUBEDIT,
+            path: ADMIN.CLUBEDIT,
             element: <ClubDetailEditPage />,
           },
         ],


### PR DESCRIPTION
## #️⃣연관된 이슈

> (close) #109 

## 📝작업 내용

라우터에 계층 구조가 적용된 것처럼, 기존 RoutePath 상수에 계층 구조 적용

처음에는 URL이 아래와 같이 그대로 반영되도록 고려했는데, 
```ts
export const ROUTE_PATH = {
  MAIN: '/',
  CLUB: {
    DETAIL: 'clubs/:clubId',
    EDIT: 'clubs/:clubId/edit',
    APPLY: 'clubs/:clubId/apply',
    APPLICANT_DETAIL: 'clubs/:clubId/applicants/:applicantId',
  },
  DASHBOARD: 'clubs/dashboard',
};
```
대쉬보드는 동적 파라미터(:id)가 없다는 이유로 그룹화할 수 없는 상황이 좀 애매하다고 생각했습니다.

그래서 현재 프로젝트를 고려해서 큰 틀인 USER / ADMIN 기준으로 구분하면 URL과 1:1 매칭은 안되지만, 

```ts
        path: '/admin',
        children: [
          {
            path: ADMIN.DASHBOARD,
            element: <DashboardPage />,
          },
          {
            path: ADMIN.APPLICATIONDETAIL,
            element: <ApplicationDetailPage />,
          },
          {
            path: ADMIN.CLUBEDIT,
            element: <ClubDetailEditPage />,
```
현재 라우터에 정의된 방식에 적용하기 더 적합하다고 생각했습니다. 

만약 처음 방식을 적용했다면

```ts
        path: '/admin',
        children: [
          {
            path: DASHBOARD,
            element: <DashboardPage />,
          },
          {
            path: CLUB.APPLICATIONDETAIL,
            element: <ApplicationDetailPage />,
          },
          {
            path: CLUB.CLUBEDIT,
            element: <ClubDetailEditPage />,
```

구분은 3가지 ADMIN / USER / COMMON 기준으로 했습니다.

1. COMMON(메인 페이지, 동아리 상세 페이지),

2. ADMIN(대시보드, 지원자상세, 동아리 수정),

3. USER(동아리 지원)



### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

