### PR TITLE
[FEAT] 지원서 댓글 CRUD 기능 구현 (#112)

### DIFF
--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -13,7 +13,7 @@ export const NAV_CONFIG: Record<Role, NavItemData[]> = {
   ],
   president: [
     { key: 'logo', label: '동아리움', to: '/', isLogo: true },
-    { key: 'applicants', label: '지원자관리', to: '/admin/club/dashboard' },
+    { key: 'applicants', label: '지원자관리', to: '/admin/clubs/dashboard' },
     { key: 'club', label: '동아리페이지관리', to: '/club' },
     { key: 'form', label: '지원폼관리', to: '/form' },
   ],

--- a/src/mocks/handler/applicant.ts
+++ b/src/mocks/handler/applicant.ts
@@ -63,14 +63,13 @@ interface UpdateCommentRequest {
 const updateCommentResolver = async ({
   params,
   request,
-}: { params: PathParams; request: Request }) => {
+}: {
+  params: PathParams;
+  request: Request;
+}) => {
   const { commentId } = params as { commentId: string };
   const { content, rating } = (await request.json()) as UpdateCommentRequest;
-  const updatedComment = applicantRepository.updateComment(
-    Number(commentId),
-    content,
-    rating,
-  );
+  const updatedComment = applicantRepository.updateComment(Number(commentId), content, rating);
   if (updatedComment) {
     return HttpResponse.json(updatedComment, { status: 200 });
   }

--- a/src/mocks/handler/applicant.ts
+++ b/src/mocks/handler/applicant.ts
@@ -33,6 +33,11 @@ const updateApplicationStatusResolver = async ({
   return HttpResponse.json({ status: 200 });
 };
 
+const getCommentsResolver = () => {
+  const comments = applicantRepository.getComments();
+  return HttpResponse.json(comments, { status: 200 });
+};
+
 export const applicantHandlers = [
   http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/applicants', getApplicantsResolver),
   http.get(
@@ -42,5 +47,9 @@ export const applicantHandlers = [
   http.patch(
     import.meta.env.VITE_API_BASE_URL + '/applications/:applicationId',
     updateApplicationStatusResolver,
+  ),
+  http.get(
+    import.meta.env.VITE_API_BASE_URL + '/applications/:applicationId/comments',
+    getCommentsResolver,
   ),
 ];

--- a/src/mocks/handler/applicant.ts
+++ b/src/mocks/handler/applicant.ts
@@ -49,6 +49,12 @@ const createCommentResolver = async ({ request }: { request: Request }) => {
   return HttpResponse.json(newComment, { status: 201 });
 };
 
+const deleteCommentResolver = ({ params }: { params: PathParams }) => {
+  const { commentId } = params as { commentId: string };
+  applicantRepository.deleteComment(Number(commentId));
+  return HttpResponse.json(null, { status: 200 });
+};
+
 export const applicantHandlers = [
   http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/applicants', getApplicantsResolver),
   http.get(
@@ -66,5 +72,9 @@ export const applicantHandlers = [
   http.post(
     import.meta.env.VITE_API_BASE_URL + '/applications/:applicationId/comments',
     createCommentResolver,
+  ),
+  http.delete(
+    import.meta.env.VITE_API_BASE_URL + '/applications/:applicationId/comments/:commentId',
+    deleteCommentResolver,
   ),
 ];

--- a/src/mocks/handler/applicant.ts
+++ b/src/mocks/handler/applicant.ts
@@ -55,6 +55,28 @@ const deleteCommentResolver = ({ params }: { params: PathParams }) => {
   return HttpResponse.json(null, { status: 200 });
 };
 
+interface UpdateCommentRequest {
+  content: string;
+  rating: number;
+}
+
+const updateCommentResolver = async ({
+  params,
+  request,
+}: { params: PathParams; request: Request }) => {
+  const { commentId } = params as { commentId: string };
+  const { content, rating } = (await request.json()) as UpdateCommentRequest;
+  const updatedComment = applicantRepository.updateComment(
+    Number(commentId),
+    content,
+    rating,
+  );
+  if (updatedComment) {
+    return HttpResponse.json(updatedComment, { status: 200 });
+  }
+  return HttpResponse.json({ message: 'Comment not found' }, { status: 404 });
+};
+
 export const applicantHandlers = [
   http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/applicants', getApplicantsResolver),
   http.get(
@@ -76,5 +98,9 @@ export const applicantHandlers = [
   http.delete(
     import.meta.env.VITE_API_BASE_URL + '/applications/:applicationId/comments/:commentId',
     deleteCommentResolver,
+  ),
+  http.put(
+    import.meta.env.VITE_API_BASE_URL + '/applications/:applicationId/comments/:commentId',
+    updateCommentResolver,
   ),
 ];

--- a/src/mocks/handler/applicant.ts
+++ b/src/mocks/handler/applicant.ts
@@ -38,7 +38,7 @@ const getCommentsResolver = () => {
   return HttpResponse.json(comments, { status: 200 });
 };
 
-interface CreateCommentRequest {
+export interface CreateCommentRequest {
   content: string;
   rating: number;
 }

--- a/src/mocks/handler/applicant.ts
+++ b/src/mocks/handler/applicant.ts
@@ -38,6 +38,17 @@ const getCommentsResolver = () => {
   return HttpResponse.json(comments, { status: 200 });
 };
 
+interface CreateCommentRequest {
+  content: string;
+  rating: number;
+}
+
+const createCommentResolver = async ({ request }: { request: Request }) => {
+  const { content, rating } = (await request.json()) as CreateCommentRequest;
+  const newComment = applicantRepository.createComment(content, rating);
+  return HttpResponse.json(newComment, { status: 201 });
+};
+
 export const applicantHandlers = [
   http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/applicants', getApplicantsResolver),
   http.get(
@@ -51,5 +62,9 @@ export const applicantHandlers = [
   http.get(
     import.meta.env.VITE_API_BASE_URL + '/applications/:applicationId/comments',
     getCommentsResolver,
+  ),
+  http.post(
+    import.meta.env.VITE_API_BASE_URL + '/applications/:applicationId/comments',
+    createCommentResolver,
   ),
 ];

--- a/src/mocks/repositories/applicant.ts
+++ b/src/mocks/repositories/applicant.ts
@@ -112,6 +112,22 @@ export const comments = [
   },
 ];
 
+export const createComment = (content: string, rating: number) => {
+  const newComment = {
+    commentId: comments.length + 1,
+    content,
+    rating,
+    author: {
+      id: 103,
+      name: '박영희',
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  comments.push(newComment);
+  return newComment;
+};
+
 export const applicantRepository = {
   getApplicants: (status: string | null) => {
     const statusLabelMap: Record<string, string> = {
@@ -146,5 +162,9 @@ export const applicantRepository = {
 
   getComments: () => {
     return comments;
+  },
+
+  createComment: (content: string, rating: number) => {
+    return createComment(content, rating);
   },
 };

--- a/src/mocks/repositories/applicant.ts
+++ b/src/mocks/repositories/applicant.ts
@@ -137,6 +137,17 @@ export const deleteComment = (commentId: number) => {
   return { success: false };
 };
 
+export const updateComment = (commentId: number, content: string, rating: number) => {
+  const commentToUpdate = comments.find((comment) => comment.commentId === commentId);
+  if (commentToUpdate) {
+    commentToUpdate.content = content;
+    commentToUpdate.rating = rating;
+    commentToUpdate.updatedAt = new Date().toISOString();
+    return commentToUpdate;
+  }
+  return null;
+};
+
 export const applicantRepository = {
   getApplicants: (status: string | null) => {
     const statusLabelMap: Record<string, string> = {
@@ -179,5 +190,9 @@ export const applicantRepository = {
 
   deleteComment: (commentId: number) => {
     return deleteComment(commentId);
+  },
+
+  updateComment: (commentId: number, content: string, rating: number) => {
+    return updateComment(commentId, content, rating);
   },
 };

--- a/src/mocks/repositories/applicant.ts
+++ b/src/mocks/repositories/applicant.ts
@@ -76,6 +76,42 @@ export const detailApplication: DetailApplication = {
   ],
 };
 
+export const comments = [
+  {
+    commentId: 20,
+    content: '지원자의 경험이 우리 동아리와 잘 맞는 것 같습니다.',
+    rating: 4.5,
+    author: {
+      id: 5,
+      name: '김운영',
+    },
+    createdAt: '2025-10-02T12:20:54.974Z',
+    updatedAt: '2025-10-02T12:20:54.974Z',
+  },
+  {
+    commentId: 21,
+    content: '지원자의 경험이 우리 동아리와 잘 맞는 것 같습니다.',
+    rating: 4.5,
+    author: {
+      id: 6,
+      name: '김호영',
+    },
+    createdAt: '2025-10-03T12:20:54.974Z',
+    updatedAt: '2025-10-03T12:20:54.974Z',
+  },
+  {
+    commentId: 22,
+    content: '지원자의 경험이 우리 동아리와 잘 맞는 것 같습니다.',
+    rating: 4.5,
+    author: {
+      id: 7,
+      name: '김자영',
+    },
+    createdAt: '2025-10-04T12:20:54.974Z',
+    updatedAt: '2025-10-04T12:20:54.974Z',
+  },
+];
+
 export const applicantRepository = {
   getApplicants: (status: string | null) => {
     const statusLabelMap: Record<string, string> = {
@@ -106,5 +142,9 @@ export const applicantRepository = {
       return { success: true };
     }
     return { success: false };
+  },
+
+  getComments: () => {
+    return comments;
   },
 };

--- a/src/mocks/repositories/applicant.ts
+++ b/src/mocks/repositories/applicant.ts
@@ -128,6 +128,15 @@ export const createComment = (content: string, rating: number) => {
   return newComment;
 };
 
+export const deleteComment = (commentId: number) => {
+  const index = comments.findIndex((comment) => comment.commentId === commentId);
+  if (index !== -1) {
+    comments.splice(index, 1);
+    return { success: true };
+  }
+  return { success: false };
+};
+
 export const applicantRepository = {
   getApplicants: (status: string | null) => {
     const statusLabelMap: Record<string, string> = {
@@ -166,5 +175,9 @@ export const applicantRepository = {
 
   createComment: (content: string, rating: number) => {
     return createComment(content, rating);
+  },
+
+  deleteComment: (commentId: number) => {
+    return deleteComment(commentId);
   },
 };

--- a/src/pages/admin/ApplicationDetail/api/comments.ts
+++ b/src/pages/admin/ApplicationDetail/api/comments.ts
@@ -24,3 +24,12 @@ export const createComment = async (
   );
   return await response.json();
 };
+
+export const deleteComment = async (applicationId: number, commentId: number): Promise<void> => {
+  await fetch(
+    import.meta.env.VITE_API_BASE_URL + `/applications/${applicationId}/comments/${commentId}`,
+    {
+      method: 'DELETE',
+    },
+  );
+};

--- a/src/pages/admin/ApplicationDetail/api/comments.ts
+++ b/src/pages/admin/ApplicationDetail/api/comments.ts
@@ -6,3 +6,21 @@ export const fetchComments = async (applicationId: number): Promise<Comment[]> =
   );
   return await response.json();
 };
+
+export const createComment = async (
+  applicationId: number,
+  content: string,
+  rating: number,
+): Promise<Comment> => {
+  const response = await fetch(
+    import.meta.env.VITE_API_BASE_URL + `/applications/${applicationId}/comments`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content, rating }),
+    },
+  );
+  return await response.json();
+};

--- a/src/pages/admin/ApplicationDetail/api/comments.ts
+++ b/src/pages/admin/ApplicationDetail/api/comments.ts
@@ -33,3 +33,22 @@ export const deleteComment = async (applicationId: number, commentId: number): P
     },
   );
 };
+
+export const updateComment = async (
+  applicationId: number,
+  commentId: number,
+  content: string,
+  rating: number,
+): Promise<Comment> => {
+  const response = await fetch(
+    import.meta.env.VITE_API_BASE_URL + `/applications/${applicationId}/comments/${commentId}`,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content, rating }),
+    },
+  );
+  return await response.json();
+};

--- a/src/pages/admin/ApplicationDetail/api/comments.ts
+++ b/src/pages/admin/ApplicationDetail/api/comments.ts
@@ -1,0 +1,8 @@
+import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
+
+export const fetchComments = async (applicationId: number): Promise<Comment[]> => {
+  const response = await fetch(
+    import.meta.env.VITE_API_BASE_URL + `/applications/${applicationId}/comments`,
+  );
+  return await response.json();
+};

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
-import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/OutlineTextareaField';
-import { Text } from '@/shared/components/Text';
+import { useState } from 'react';
 import { Form } from 'react-router-dom';
 import { Button } from '@/shared/components/Button';
-import { useState } from 'react';
+import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/OutlineTextareaField';
+import { Text } from '@/shared/components/Text';
 import type { CreateCommentRequest } from '@/mocks/handler/applicant';
 
 type Props = {

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
@@ -1,14 +1,53 @@
 import styled from '@emotion/styled';
 import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/OutlineTextareaField';
 import { Text } from '@/shared/components/Text';
+import { Form } from 'react-router-dom';
+import { Button } from '@/shared/components/Button';
+import { useState } from 'react';
+import type { CreateCommentRequest } from '@/mocks/handler/applicant';
 
-export const CommentForm = () => {
+type Props = {
+  createComment: (comment: CreateCommentRequest) => void;
+};
+
+export const CommentForm = ({ createComment }: Props) => {
+  const [content, setContent] = useState('');
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!content.trim()) {
+      alert('댓글을 입력해주세요');
+      return;
+    }
+
+    const newComment = {
+      content: content.trim(),
+      rating: 5,
+    };
+
+    createComment(newComment);
+    setContent('');
+  };
+
   return (
     <Layout>
       <Wrapper>
         <Text weight={'medium'}>댓글</Text>
       </Wrapper>
-      <OutlineTextareaField />
+      <Form onSubmit={handleSubmit}>
+        <OutlineTextareaField
+          value={content}
+          onChange={(e) => {
+            setContent(e.target.value);
+          }}
+        />
+        <ButtonWrapper>
+          <Button variant='outline' type='submit' width='3.5rem'>
+            등록
+          </Button>
+        </ButtonWrapper>
+      </Form>
     </Layout>
   );
 };
@@ -20,7 +59,13 @@ const Layout = styled.div({
   flexDirection: 'column',
 });
 
-const Wrapper = styled.div(() => ({
+const Wrapper = styled.div({
   display: 'flex',
   gap: '16px',
-}));
+});
+
+const ButtonWrapper = styled.div({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  marginRight: '-1.65rem',
+});

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem.tsx
@@ -1,13 +1,10 @@
 import styled from '@emotion/styled';
 import { Text } from '@/shared/components/Text';
+import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
 
-type CommentItemProps = {
-  author?: string;
-  createdAt?: string;
-  content?: string;
-};
+type Props = Pick<Comment, 'author' | 'content' | 'createdAt'>;
 
-export const CommentItem = ({ author, createdAt, content }: CommentItemProps) => {
+export const CommentItem = ({ author, content, createdAt }: Props) => {
   const handleEdit = () => {
     console.log('수정 클릭');
   };
@@ -20,8 +17,8 @@ export const CommentItem = ({ author, createdAt, content }: CommentItemProps) =>
     <Layout>
       <Header>
         <AuthorInfo>
-          <Text size={'sm'} weight={'medium'}>
-            {author}
+          <Text size={'base'} weight={'medium'}>
+            {author.name}
           </Text>
           <Text size={'xs'} weight={'medium'} color={'#616677'}>
             {createdAt}
@@ -45,7 +42,7 @@ export const CommentItem = ({ author, createdAt, content }: CommentItemProps) =>
 const Layout = styled.div(({ theme }) => ({
   borderLeft: `3px solid ${theme.colors.primary}`,
   paddingLeft: '1rem',
-  marginBottom: '2.8125rem',
+  marginBottom: '2.4rem',
 }));
 
 const Header = styled.div({

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem.tsx
@@ -1,16 +1,22 @@
+import { useParams } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { Text } from '@/shared/components/Text';
+import { useComments } from '@/pages/admin/ApplicationDetail/hooks/useComments';
 import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
 
-type Props = Pick<Comment, 'author' | 'content' | 'createdAt'>;
+type Props = Pick<Comment, 'author' | 'content' | 'createdAt' | 'commentId'>;
 
-export const CommentItem = ({ author, content, createdAt }: Props) => {
+export const CommentItem = ({ author, commentId, content, createdAt }: Props) => {
+  const { applicantId } = useParams();
+
+  const { deleteComment } = useComments(Number(applicantId));
+
   const handleEdit = () => {
     console.log('수정 클릭');
   };
 
   const handleDelete = () => {
-    console.log('삭제 클릭');
+    deleteComment(commentId);
   };
 
   return (

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem.tsx
@@ -1,11 +1,11 @@
-import { useParams } from 'react-router-dom';
-import { useState } from 'react';
 import styled from '@emotion/styled';
-import { Text } from '@/shared/components/Text';
-import { Button } from '@/shared/components/Button';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useComments } from '@/pages/admin/ApplicationDetail/hooks/useComments';
-import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
+import { Button } from '@/shared/components/Button';
 import { UnderlineTextareaField } from '@/shared/components/Form/TextAreaField/UnderlineTextareaField';
+import { Text } from '@/shared/components/Text';
+import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
 
 type Props = Pick<Comment, 'author' | 'content' | 'createdAt' | 'commentId' | 'rating'>;
 

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentList.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentList.tsx
@@ -3,6 +3,7 @@ import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
 
 type Props = {
   comments: Comment[];
+  deleteComment: (commentId: number) => void;
 };
 
 export const CommentList = ({ comments }: Props) => {
@@ -11,6 +12,7 @@ export const CommentList = ({ comments }: Props) => {
       {comments.map((comment) => (
         <CommentItem
           key={comment.commentId}
+          commentId={comment.commentId}
           content={comment.content}
           author={comment.author}
           createdAt={comment.createdAt.split('T')[0]}

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentList.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentList.tsx
@@ -1,9 +1,21 @@
 import { CommentItem } from './CommentItem';
+import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
 
-export const CommentList = () => {
+type Props = {
+  comments: Comment[];
+};
+
+export const CommentList = ({ comments }: Props) => {
   return (
     <div>
-      <CommentItem />
+      {comments.map((comment) => (
+        <CommentItem
+          key={comment.commentId}
+          content={comment.content}
+          author={comment.author}
+          createdAt={comment.createdAt.split('T')[0]}
+        />
+      ))}
     </div>
   );
 };

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentList.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentList.tsx
@@ -16,6 +16,7 @@ export const CommentList = ({ comments }: Props) => {
           content={comment.content}
           author={comment.author}
           createdAt={comment.createdAt.split('T')[0]}
+          rating={comment.rating}
         />
       ))}
     </div>

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentList.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentList.tsx
@@ -3,7 +3,6 @@ import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
 
 type Props = {
   comments: Comment[];
-  deleteComment: (commentId: number) => void;
 };
 
 export const CommentList = ({ comments }: Props) => {

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/index.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/index.tsx
@@ -1,8 +1,8 @@
 import { useParams } from 'react-router-dom';
-import { CommentForm } from './CommentForm';
-import { CommentList } from './CommentList';
 import { useComments } from '@/pages/admin/ApplicationDetail/hooks/useComments';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { CommentForm } from './CommentForm';
+import { CommentList } from './CommentList';
 
 export const CommentSection = () => {
   const { applicantId } = useParams();

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/index.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/index.tsx
@@ -7,14 +7,14 @@ import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 export const CommentSection = () => {
   const { applicantId } = useParams();
 
-  const { data, isLoading, error } = useComments(Number(applicantId));
+  const { data, isLoading, error, createComment } = useComments(Number(applicantId));
 
   if (isLoading) return <LoadingSpinner />;
   if (error) return <div>에러발생 : {error.message}</div>;
 
   return (
     <>
-      <CommentForm />
+      <CommentForm createComment={createComment} />
       <CommentList comments={data} />
     </>
   );

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/index.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/index.tsx
@@ -1,11 +1,21 @@
+import { useParams } from 'react-router-dom';
 import { CommentForm } from './CommentForm';
 import { CommentList } from './CommentList';
+import { useComments } from '@/pages/admin/ApplicationDetail/hooks/useComments';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 
 export const CommentSection = () => {
+  const { applicantId } = useParams();
+
+  const { data, isLoading, error } = useComments(Number(applicantId));
+
+  if (isLoading) return <LoadingSpinner />;
+  if (error) return <div>에러발생 : {error.message}</div>;
+
   return (
     <>
       <CommentForm />
-      <CommentList />
+      <CommentList comments={data} />
     </>
   );
 };

--- a/src/pages/admin/ApplicationDetail/hooks/useComments.ts
+++ b/src/pages/admin/ApplicationDetail/hooks/useComments.ts
@@ -1,17 +1,37 @@
-import { useQuery } from '@tanstack/react-query';
-import { fetchComments } from '@/pages/admin/ApplicationDetail/api/comments';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { fetchComments, createComment } from '@/pages/admin/ApplicationDetail/api/comments';
 import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
 import type { UseApiQueryResult } from '@/types/useApiQueryResult';
 
-export const useComments = (applicationId: number): UseApiQueryResult<Comment[]> => {
+type UseCommentsResult = UseApiQueryResult<Comment[]> & {
+  createComment: (comment: { content: string; rating: number }) => void;
+};
+
+export const useComments = (applicationId: number): UseCommentsResult => {
+  const queryClient = useQueryClient();
+
   const { data, isLoading, error } = useQuery({
     queryKey: ['comments', applicationId],
     queryFn: () => fetchComments(applicationId),
+  });
+
+  const { mutate: createCommentMutation } = useMutation({
+    mutationFn: ({ content, rating }: { content: string; rating: number }) =>
+      createComment(applicationId, content, rating),
+    onSuccess: (newComment) => {
+      queryClient.setQueryData(['comments', applicationId], (oldData: Comment[] | undefined) => {
+        if (oldData) {
+          return [...oldData, newComment];
+        }
+        return [newComment];
+      });
+    },
   });
 
   return {
     data: data || [],
     isLoading,
     error,
+    createComment: createCommentMutation,
   };
 };

--- a/src/pages/admin/ApplicationDetail/hooks/useComments.ts
+++ b/src/pages/admin/ApplicationDetail/hooks/useComments.ts
@@ -1,5 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchComments, createComment, deleteComment, updateComment } from '@/pages/admin/ApplicationDetail/api/comments';
+import {
+  fetchComments,
+  createComment,
+  deleteComment,
+  updateComment,
+} from '@/pages/admin/ApplicationDetail/api/comments';
 import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
 import type { UseApiQueryResult } from '@/types/useApiQueryResult';
 
@@ -43,8 +48,15 @@ export const useComments = (applicationId: number): UseCommentsResult => {
   });
 
   const { mutate: updateCommentMutation } = useMutation({
-    mutationFn: ({ commentId, content, rating }: { commentId: number; content: string; rating: number }) =>
-      updateComment(applicationId, commentId, content, rating),
+    mutationFn: ({
+      commentId,
+      content,
+      rating,
+    }: {
+      commentId: number;
+      content: string;
+      rating: number;
+    }) => updateComment(applicationId, commentId, content, rating),
     onSuccess: (updatedComment) => {
       queryClient.setQueryData(['comments', applicationId], (oldData: Comment[] | undefined) => {
         if (oldData) {

--- a/src/pages/admin/ApplicationDetail/hooks/useComments.ts
+++ b/src/pages/admin/ApplicationDetail/hooks/useComments.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchComments } from '@/pages/admin/ApplicationDetail/api/comments';
+import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
+import type { UseApiQueryResult } from '@/types/useApiQueryResult';
+
+export const useComments = (applicationId: number): UseApiQueryResult<Comment[]> => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['comments', applicationId],
+    queryFn: () => fetchComments(applicationId),
+  });
+
+  return {
+    data: data || [],
+    isLoading,
+    error,
+  };
+};

--- a/src/pages/admin/ApplicationDetail/types/comments.ts
+++ b/src/pages/admin/ApplicationDetail/types/comments.ts
@@ -1,0 +1,11 @@
+export type Comment = {
+  commentId: number;
+  content: string;
+  rating: number;
+  author: {
+    id: number;
+    name: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+};

--- a/src/shared/components/Form/TextAreaField/UnderlineTextareaField.tsx
+++ b/src/shared/components/Form/TextAreaField/UnderlineTextareaField.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
-import { Text } from '@/shared/components/Text';
 import { useEffect, useRef } from 'react';
+import { Text } from '@/shared/components/Text';
 
 type Props = {
   invalid?: boolean;

--- a/src/shared/components/Form/TextAreaField/UnderlineTextareaField.tsx
+++ b/src/shared/components/Form/TextAreaField/UnderlineTextareaField.tsx
@@ -1,0 +1,67 @@
+import styled from '@emotion/styled';
+import { Text } from '@/shared/components/Text';
+import { useEffect, useRef } from 'react';
+
+type Props = {
+  invalid?: boolean;
+  message?: string;
+} & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const UnderlineTextareaField = ({ invalid, message, ...props }: Props) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const adjustHeight = () => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = `${textarea.scrollHeight}px`;
+    }
+  };
+
+  useEffect(() => {
+    adjustHeight();
+  }, [props.value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    adjustHeight();
+    props.onChange?.(e);
+  };
+
+  return (
+    <>
+      <Input ref={textareaRef} invalid={invalid} {...props} onChange={handleChange} />
+      {message && (
+        <Text size={'xs'} color={invalid ? '#fa342c' : '#b0b3ba'}>
+          {message}
+        </Text>
+      )}
+    </>
+  );
+};
+
+const Input = styled.textarea<Pick<Props, 'invalid'>>(({ theme, invalid }) => ({
+  width: '100%',
+  border: 'none',
+  borderBottom: `1px solid ${theme.colors.gray300}`,
+  fontSize: theme.font.size.sm,
+  transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
+  marginBottom: '0.3rem',
+  textAlign: 'left',
+  padding: '0.25rem 0',
+  lineHeight: 1.5,
+  minHeight: '1.5em',
+  resize: 'none',
+  overflow: 'hidden',
+  boxSizing: 'border-box',
+
+  '&:focus': {
+    outline: 'none',
+    borderColor: theme.colors.primary,
+  },
+
+  '&::placeholder': {
+    color: theme.colors.textSecondary,
+  },
+
+  borderColor: invalid ? theme.colors.error : theme.colors.gray200,
+}));


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #112 

## 📝작업 내용

- 동아리 운영진이 지원서 상세 페이지에서 지원자에 대한 논의를 할 수 있도록 댓글 기능을 추가
- CRUD msw 연결



## 💬리뷰 요구사항(선택)

> 아직 로그인 기능이 구현이 안되어서 본인이 작성한 댓글에만 '수정, 삭제'버튼이 보이도록 처리하진 못한점 고려해주세요 
