### PR TITLE
[FEAT] 지원서 별점 평가 기능 추가 (#113)

### DIFF
--- a/src/pages/admin/ApplicationDetail/components/CommentSection/ApplicantStarRating.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/ApplicantStarRating.tsx
@@ -1,27 +1,40 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
 
-interface ApplicantStarRatingProps {
+type ApplicantStarRatingProps = {
   rating: number;
   onRatingChange: (rating: number) => void;
-}
+};
 
 const STAR_INDICES = [1, 2, 3, 4, 5];
 
 export const ApplicantStarRating = ({ rating, onRatingChange }: ApplicantStarRatingProps) => {
   const [hover, setHover] = useState(0);
 
+  const handleStarClick = (index: number, e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const isLeftHalf = e.clientX - rect.left < rect.width / 2;
+    onRatingChange(isLeftHalf ? index - 0.5 : index);
+  };
+
+  const handleStarHover = (index: number, e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const isLeftHalf = e.clientX - rect.left < rect.width / 2;
+    setHover(isLeftHalf ? index - 0.5 : index);
+  };
+
   return (
-    <StarContainer
-      onMouseLeave={() => setHover(0)}
-    >
+    <StarContainer onMouseLeave={() => setHover(0)}>
       {STAR_INDICES.map((index) => {
-        const fillPercentage = index <= (hover || rating) ? 100 : 0;
+        const currentRating = hover || rating;
+        const fillPercentage =
+          index <= currentRating ? 100 : index - 0.5 === currentRating ? 50 : 0;
+
         return (
           <StarWrapper
             key={index}
-            onClick={() => onRatingChange(index)}
-            onMouseEnter={() => setHover(index)}
+            onClick={(e) => handleStarClick(index, e)}
+            onMouseMove={(e) => handleStarHover(index, e)}
           >
             <StarEmpty>★</StarEmpty>
             <StarFilled fillPercentage={fillPercentage}>★</StarFilled>

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/ApplicantStarRating.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/ApplicantStarRating.tsx
@@ -1,0 +1,59 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+
+interface ApplicantStarRatingProps {
+  rating: number;
+  onRatingChange: (rating: number) => void;
+}
+
+const STAR_INDICES = [1, 2, 3, 4, 5];
+
+export const ApplicantStarRating = ({ rating, onRatingChange }: ApplicantStarRatingProps) => {
+  const [hover, setHover] = useState(0);
+
+  return (
+    <StarContainer
+      onMouseLeave={() => setHover(0)}
+    >
+      {STAR_INDICES.map((index) => {
+        const fillPercentage = index <= (hover || rating) ? 100 : 0;
+        return (
+          <StarWrapper
+            key={index}
+            onClick={() => onRatingChange(index)}
+            onMouseEnter={() => setHover(index)}
+          >
+            <StarEmpty>★</StarEmpty>
+            <StarFilled fillPercentage={fillPercentage}>★</StarFilled>
+          </StarWrapper>
+        );
+      })}
+    </StarContainer>
+  );
+};
+
+const StarContainer = styled.div({
+  display: 'flex',
+  gap: '0.125rem',
+  alignItems: 'center',
+  cursor: 'pointer',
+});
+
+const StarWrapper = styled.div({
+  position: 'relative',
+  display: 'inline-block',
+  fontSize: '1.25rem',
+});
+
+const StarEmpty = styled.div(({ theme }) => ({
+  color: theme.colors.gray200,
+}));
+
+const StarFilled = styled.div<{ fillPercentage: number }>(({ fillPercentage, theme }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  color: theme.colors.primary,
+  overflow: 'hidden',
+  width: `${fillPercentage}%`,
+}));

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
@@ -4,6 +4,7 @@ import { Form } from 'react-router-dom';
 import { Button } from '@/shared/components/Button';
 import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/OutlineTextareaField';
 import { Text } from '@/shared/components/Text';
+import { ApplicantStarRating } from './ApplicantStarRating';
 import type { CreateCommentRequest } from '@/mocks/handler/applicant';
 
 type Props = {
@@ -11,6 +12,7 @@ type Props = {
 };
 
 export const CommentForm = ({ createComment }: Props) => {
+  const [rating, setRating] = useState(0);
   const [content, setContent] = useState('');
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -34,6 +36,7 @@ export const CommentForm = ({ createComment }: Props) => {
     <Layout>
       <Wrapper>
         <Text weight={'medium'}>댓글</Text>
+        <ApplicantStarRating rating={rating} onRatingChange={setRating} />
       </Wrapper>
       <Form onSubmit={handleSubmit}>
         <OutlineTextareaField

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
@@ -19,12 +19,17 @@ export const CommentForm = ({ createComment }: Props) => {
   const isContentInvalid = !content.trim();
   const isRatingInvalid = rating === 0;
   const isSubmitDisabled = isRatingInvalid || isContentInvalid;
+  const isContentTooLong = content.length > 500;
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setContent(e.target.value);
+  };
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsSubmitted(true);
 
-    if (isSubmitDisabled) {
+    if (isSubmitDisabled || isContentTooLong) {
       return;
     }
 
@@ -40,7 +45,9 @@ export const CommentForm = ({ createComment }: Props) => {
   };
 
   let errorMessage = '';
-  if (isSubmitted && isSubmitDisabled) {
+  if (isContentTooLong) {
+    errorMessage = '댓글은 500자 이하로 입력해주세요.';
+  } else if (isSubmitted && isSubmitDisabled) {
     if (isRatingInvalid && isContentInvalid) {
       errorMessage = '별점과 댓글을 모두 입력해주세요.';
     } else if (isRatingInvalid) {
@@ -59,13 +66,14 @@ export const CommentForm = ({ createComment }: Props) => {
       <Form onSubmit={handleSubmit}>
         <OutlineTextareaField
           value={content}
-          onChange={(e) => {
-            setContent(e.target.value);
-          }}
-          invalid={isSubmitted && isSubmitDisabled}
+          onChange={handleChange}
+          invalid={(isSubmitted && isSubmitDisabled) || isContentTooLong}
           message={errorMessage}
         />
         <ButtonWrapper>
+          <Text size={'sm'} color={isContentTooLong ? '#fa342c' : '#b0b3ba'}>
+            {content.length} / 500
+          </Text>
           <Button variant='outline' type='submit' width='3.5rem'>
             등록
           </Button>
@@ -89,6 +97,8 @@ const Wrapper = styled.div({
 
 const ButtonWrapper = styled.div({
   display: 'flex',
-  justifyContent: 'flex-end',
-  marginRight: '-1.65rem',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginRight: '-2rem',
+  padding: '0 0.3rem',
 });

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
@@ -25,7 +25,7 @@ export const CommentForm = ({ createComment }: Props) => {
 
     const newComment = {
       content: content.trim(),
-      rating: 5,
+      rating: rating,
     };
 
     createComment(newComment);

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
@@ -14,12 +14,17 @@ type Props = {
 export const CommentForm = ({ createComment }: Props) => {
   const [rating, setRating] = useState(0);
   const [content, setContent] = useState('');
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const isContentInvalid = !content.trim();
+  const isRatingInvalid = rating === 0;
+  const isSubmitDisabled = isRatingInvalid || isContentInvalid;
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setIsSubmitted(true);
 
-    if (!content.trim()) {
-      alert('댓글을 입력해주세요');
+    if (isSubmitDisabled) {
       return;
     }
 
@@ -30,7 +35,20 @@ export const CommentForm = ({ createComment }: Props) => {
 
     createComment(newComment);
     setContent('');
+    setRating(0);
+    setIsSubmitted(false);
   };
+
+  let errorMessage = '';
+  if (isSubmitted && isSubmitDisabled) {
+    if (isRatingInvalid && isContentInvalid) {
+      errorMessage = '별점과 댓글을 모두 입력해주세요.';
+    } else if (isRatingInvalid) {
+      errorMessage = '별점을 선택해주세요.';
+    } else {
+      errorMessage = '댓글을 입력해주세요.';
+    }
+  }
 
   return (
     <Layout>
@@ -44,6 +62,8 @@ export const CommentForm = ({ createComment }: Props) => {
           onChange={(e) => {
             setContent(e.target.value);
           }}
+          invalid={isSubmitted && isSubmitDisabled}
+          message={errorMessage}
         />
         <ButtonWrapper>
           <Button variant='outline' type='submit' width='3.5rem'>

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem.tsx
@@ -5,6 +5,7 @@ import { useComments } from '@/pages/admin/ApplicationDetail/hooks/useComments';
 import { Button } from '@/shared/components/Button';
 import { UnderlineTextareaField } from '@/shared/components/Form/TextAreaField/UnderlineTextareaField';
 import { Text } from '@/shared/components/Text';
+import { ApplicantStarRating } from './ApplicantStarRating';
 import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
 
 type Props = Pick<Comment, 'author' | 'content' | 'createdAt' | 'commentId' | 'rating'>;
@@ -15,6 +16,7 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
 
   const [isEditing, setIsEditing] = useState(false);
   const [editedContent, setEditedContent] = useState(content);
+  const [editedRating, setEditedRating] = useState(rating);
 
   const handleEdit = () => {
     setIsEditing(true);
@@ -26,17 +28,22 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
       alert('댓글 내용을 입력해주세요');
       return;
     }
+    if (editedRating === 0) {
+      alert('별점을 선택해주세요.');
+      return;
+    }
 
     updateComment({
       commentId,
       content: editedContent,
-      rating,
+      rating: editedRating,
     });
     setIsEditing(false);
   };
 
   const handleCancel = () => {
     setEditedContent(content);
+    setEditedRating(rating);
     setIsEditing(false);
   };
 
@@ -69,6 +76,7 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
 
       {isEditing ? (
         <EditMode>
+          <ApplicantStarRating rating={editedRating} onRatingChange={setEditedRating} />
           <UnderlineTextareaField
             value={editedContent}
             onChange={(e) => setEditedContent(e.target.value)}


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #113

## 📝작업 내용

운영진이 각 지원서에 대해 개별적으로 별점을 부여하는 기능을 추가하였습니다.

**1. 개인 별점 평가 컴포넌트 추가**
- 댓글 입력창 상단에 현재 로그인한 운영진이 개인적으로 부여할 별점을 선택하는 UI를 추가
- 0.5점 단위로 선택 가능

**2. 수정 버튼을 누르면 이전에 부여한 별점이 표시되며 언제든지 수정 가능**


**3. 댓글창 비활성화 로직 구현**
- 운영진이 댓글과 개인 별점을 모두 부여해야만 댓글 등록 가능

**4. 댓글 글자 제한 500자 이내**

## 스크린샷
<img width="548" height="398" alt="image" src="https://github.com/user-attachments/assets/6580cdd3-5a60-4e58-9169-9310c2af157b" />



## 💬리뷰 요구사항(선택)

> 현재는 댓글이나 개인별점 중 하나라도 입력하지 않은 상태에서 버튼을 클릭하면 에러 메시지가 표시됩니다.
그런데 아예 입력이 완료되지 않으면 버튼 자체를 비활성화하는 것이 사용자 경험 측면에서 더 나을까요?
