### PR TITLE
[REFACTOR] Comment 타입 인라인 정의를 Pick으로 재구성하여 재사용성 개선 (#151)

### DIFF
--- a/src/pages/admin/ApplicationDetail/hooks/useComments.ts
+++ b/src/pages/admin/ApplicationDetail/hooks/useComments.ts
@@ -8,10 +8,13 @@ import {
 import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
 import type { UseApiQueryResult } from '@/types/useApiQueryResult';
 
+type CreateCommentPayload = Pick<Comment, 'content' | 'rating'>;
+type UpdateCommentPayload = Pick<Comment, 'commentId' | 'content' | 'rating'>;
+
 type UseCommentsResult = UseApiQueryResult<Comment[]> & {
-  createComment: (comment: { content: string; rating: number }) => void;
+  createComment: (comment: CreateCommentPayload) => void;
   deleteComment: (commentId: number) => void;
-  updateComment: (comment: { commentId: number; content: string; rating: number }) => void;
+  updateComment: (comment: UpdateCommentPayload) => void;
 };
 
 export const useComments = (applicationId: number): UseCommentsResult => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #151 

## 📝작업 내용
코드 리뷰 피드백을 반영하여 UseCommentsResult 내부에 인라인으로 선언되었던 타입을 Comment 타입을 재사용하는 방식으로 리팩토링했습니다.

**문제 코드**
```js
type UseCommentsResult = UseApiQueryResult<Comment[]> & {
  createComment: (comment: { content: string; rating: number }) => void;
  deleteComment: (commentId: number) => void;
  updateComment: (comment: { commentId: number; content: string; rating: number }) => void;
};
```

**개선된 코드**
- 기존 UseCommentsResult 타입 내에 하드코딩되어 있던 익명 타입을 제거
- Pick을 사용하여 Comment 타입으로부터 CreateCommentPayload, UpdateCommentPayload 타입을 새로 정의

```js
type CreateCommentPayload = Pick<Comment, 'content' | 'rating'>;
type UpdateCommentPayload = Pick<Comment, 'commentId' | 'content' | 'rating'>;

type UseCommentsResult = UseApiQueryResult<Comment[]> & {
  createComment: (comment: CreateCommentPayload) => void;
  deleteComment: (commentId: number) => void;
  updateComment: (comment: UpdateCommentPayload) => void;
};
```
