### PR TITLE
[CHORE]: github actions Secret Key 디버깅 추가

### DIFF
--- a/.github/workflows/fe-ci-cd.yml
+++ b/.github/workflows/fe-ci-cd.yml
@@ -100,6 +100,16 @@ jobs:
         if: steps.restore-node-modules.outputs.cache-hit != 'true'
         run: npm install
 
+      - name: Debug environment
+        run: |
+          echo "VITE_API_BASE_URL=$VITE_API_BASE_URL"
+          echo "VITE_KAKAO_REDIRECT_URI=$VITE_KAKAO_REDIRECT_URI"
+          echo "VITE_KAKAO_REST_API_KEY=$VITE_KAKAO_REST_API_KEY"
+        env:
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+          VITE_KAKAO_REDIRECT_URI: ${{ secrets.VITE_KAKAO_REDIRECT_URI }}
+          VITE_KAKAO_REST_API_KEY: ${{ secrets.VITE_KAKAO_REST_API_KEY }}
+
       - name: Run Build
         env:
           VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용
``
VITE_API_BASE_URL 
VITE_KAKAO_REDIRECT_URI 
VITE_KAKAO_REST_API_KEY
``
자동 배포 과정 이후 값이 안 읽히는 부분이 생겨서(3개중 1개는 읽히고, 2개는 읽히지 않음)
원인 파악을 위해 위 3개의 값을 디버깅하는 코드를 추가했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- 혹시 로그인 페이지에서 로그인 이후 undifned 관련 이슈가 생기면 local dev 브랜치 기준으로 dist 폴더를 배포하는 방식으로 해결해야할 것 같습니다.(현재 로컬에서 수동으로 배포하는 경우 정상적으로 진행됨, github actions에서 읽는 과정에서만 문제)
