### PR TITLE
[STYLE] LogoWrapper의 height 속성 제거 #268

### DIFF
--- a/src/pages/admin/Login/component/Logo/index.tsx
+++ b/src/pages/admin/Login/component/Logo/index.tsx
@@ -13,7 +13,6 @@ export const LogoWrapper = styled.div({
   justifyContent: 'center',
   alignItems: 'center',
   cursor: 'pointer',
-  height: '100%',
 });
 
 export const LogoImage = styled.img`


### PR DESCRIPTION
## #️⃣연관된 이슈

- #268 

## 📝작업 내용

> LogoWrapper의 height 속성 제거

### 스크린샷 (선택)
**변경전**
<img width="456" height="493" alt="image" src="https://github.com/user-attachments/assets/b2869bb0-37a8-4abf-ac7e-e77666800676" />

**변경후**
<img width="453" height="250" alt="image" src="https://github.com/user-attachments/assets/cdf0baa2-8d14-4173-bbf9-54e7a5b1a3a5" />

## 💬리뷰 요구사항(선택)
,
