### PR TITLE
[REFACTOR] User Role 타입 객체 상수 기반으로 변경 & 역할에 따른 네비게이션 렌더링 수정  #306

### DIFF
--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -1,4 +1,4 @@
-import type { Role, NavItemData } from '@/types/navigation';
+import { type Role, type NavItemData, ROLE } from '@/types/navigation';
 
 export const getNavItems = (role: Role): NavItemData[] => {
   const commonItems: NavItemData[] = [
@@ -6,7 +6,7 @@ export const getNavItems = (role: Role): NavItemData[] => {
     { key: 'notices', label: '공지 사항', to: '/notices' },
   ];
 
-  if (role === 'admin') {
+  if (role === ROLE.CLUB_ADMIN || ROLE.CLUB_EXECUTIVE) {
     return [
       ...commonItems,
       { key: 'applicants', label: '지원자관리', to: '/admin/clubs/:clubId/dashboard' },

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -10,7 +10,7 @@ export const getNavItems = (role: Role): NavItemData[] => {
     return [...commonItems, { key: 'logout', label: '로그아웃', to: '#' }];
   }
 
-  if (role === ROLE.CLUB_ADMIN || ROLE.CLUB_EXECUTIVE) {
+  if (role === ROLE.CLUB_ADMIN || role === ROLE.CLUB_EXECUTIVE) {
     return [
       ...commonItems,
       { key: 'applicants', label: '지원자관리', to: '/admin/clubs/:clubId/dashboard' },
@@ -19,5 +19,6 @@ export const getNavItems = (role: Role): NavItemData[] => {
       { key: 'logout', label: '로그아웃', to: '#' },
     ];
   }
+
   return [...commonItems, { key: 'login', label: '관리자 로그인', to: '/login' }];
 };

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -6,6 +6,10 @@ export const getNavItems = (role: Role): NavItemData[] => {
     { key: 'notices', label: '공지 사항', to: '/notices' },
   ];
 
+  if (role === ROLE.CLUB_MEMBER || role === ROLE.APPLICANT) {
+    return [...commonItems, { key: 'logout', label: '로그아웃', to: '#' }];
+  }
+
   if (role === ROLE.CLUB_ADMIN || ROLE.CLUB_EXECUTIVE) {
     return [
       ...commonItems,

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -9,6 +9,7 @@ import {
   setTemporaryToken,
   storeUserData,
 } from '@/shared/auth/token';
+import { ROLE } from '@/types/navigation';
 import type { ErrorResponse } from '@/pages/admin/Signup/type/error';
 import type { AuthContextType, User } from '@/types/auth';
 
@@ -55,7 +56,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
           const defaultClub = response.clubListInfo?.[0];
 
           if (!defaultClub || !defaultClub.role) {
-            const userData: User = { role: 'admin' };
+            const userData: User = { role: ROLE.APPLICANT };
             setUser(userData);
             storeUserData(userData);
             break;
@@ -100,7 +101,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
 
   const completeSignup = useCallback((accessToken: string) => {
     setAccessToken(accessToken);
-    const userData: User = { role: 'admin' };
+    const userData: User = { role: ROLE.CLUB_MEMBER };
     setUser(userData);
     storeUserData(userData);
   }, []);

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -30,7 +30,7 @@ export const AuthContext = createContext<AuthContextType>({
 });
 
 export function UserProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<User>({ role: null });
+  const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
     const initAuth = async () => {
@@ -87,7 +87,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   const logout = useCallback(async () => {
     try {
       await logoutUser();
-      setUser({ role: null });
+
       clearAuthData();
       const kakaoLogoutUrl = `https://kauth.kakao.com/oauth/logout?client_id=${REST_API_KEY}&logout_redirect_uri=${LOGOUT_REDIRECT_URI}`;
       window.location.href = kakaoLogoutUrl;

--- a/src/shared/components/Navigation/hooks/useNavigation.ts
+++ b/src/shared/components/Navigation/hooks/useNavigation.ts
@@ -1,8 +1,8 @@
 import { useLocation } from 'react-router-dom';
 import { getNavItems } from '@/constants/navigation';
 import { useAuth } from '@/providers/auth';
+import { type NavItemData } from '@/types/navigation';
 import { replaceRouteParams } from '@/utils/replaceRouteParams';
-import type { NavItemData } from '@/types/navigation';
 
 export const useNavigation = () => {
   const { user, logout } = useAuth();

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,4 +1,10 @@
-export type Role = 'admin' | null;
+export const ROLE = {
+  CLUB_EXECUTIVE: 'CLUB_EXECUTIVE',
+  CLUB_ADMIN: 'CLUB_ADMIN',
+  NONE: null,
+} as const;
+
+export type Role = (typeof ROLE)[keyof typeof ROLE];
 
 export type NavItemData = {
   key: string;

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -3,10 +3,9 @@ export const ROLE = {
   CLUB_ADMIN: 'CLUB_ADMIN',
   CLUB_MEMBER: 'CLUB_MEMBER',
   APPLICANT: 'APPLICANT',
-  NONE: null,
 } as const;
 
-export type Role = (typeof ROLE)[keyof typeof ROLE];
+export type Role = (typeof ROLE)[keyof typeof ROLE] | null;
 
 export type NavItemData = {
   key: string;

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,6 +1,8 @@
 export const ROLE = {
   CLUB_EXECUTIVE: 'CLUB_EXECUTIVE',
   CLUB_ADMIN: 'CLUB_ADMIN',
+  CLUB_MEMBER: 'CLUB_MEMBER',
+  APPLICANT: 'APPLICANT',
   NONE: null,
 } as const;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close #306 

## 📝작업 내용
Context API에서 관리하는 User의 Role type을 상수기반 객체 방식으로 변경했습니다.
```ts
export const ROLE = {
  CLUB_EXECUTIVE: 'CLUB_EXECUTIVE',
  CLUB_ADMIN: 'CLUB_ADMIN',
  NONE: null,
} as const;
```

동아리 운영진, 동아리 회장에게는 동아리 관리와 관련된 네비게이션이 렌더링 되게 구성하고,
이외의 구성원에게는 비회원과 동일한 UI가 보이도록 했습니다.

서버측에서 관리하는 Role 예시

```ts 
     APPLICANT("지원자"),
     SYSTEM_ADMIN("시스템 관리자"),
    CLUB_MEMBER("동아리 원"),
     CLUB_EXECUTIVE("동아리 운영진"),
   CLUB_ADMIN("동아리 회장");
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

추가 기능에 따라 역할 추가 & 역할에 따른 네비게이션 메뉴 렌더링을 고려했고, 현재 백엔드에서 전송해줄 것으로 기대되는 
