### PR TITLE
[FIX] 면접 시간 한 자리 수 시간 zero-padding 적용 (#308)

### DIFF
--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/Builders/TimeslotFieldBuilder.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/Builders/TimeslotFieldBuilder.tsx
@@ -38,10 +38,10 @@ export const TimeslotFieldBuilder = ({ formHandler, questionIndex, isEditMode }:
   });
 
   const currentStartTime =
-    watch(`formQuestions.${questionIndex}.timeSlotOptions.availableTime.start`) || '7:00';
+    watch(`formQuestions.${questionIndex}.timeSlotOptions.availableTime.start`) || '07:00:00';
 
   const currentEndTime =
-    watch(`formQuestions.${questionIndex}.timeSlotOptions.availableTime.end`) || '7:00';
+    watch(`formQuestions.${questionIndex}.timeSlotOptions.availableTime.end`) || '07:00:00';
 
   const handleStartTimeSelect = (newTime: string) => {
     setValue(`formQuestions.${questionIndex}.timeSlotOptions.availableTime.start`, newTime);

--- a/src/pages/admin/ApplicationFormBuilder/utils/generateTimes.ts
+++ b/src/pages/admin/ApplicationFormBuilder/utils/generateTimes.ts
@@ -1,3 +1,3 @@
 export const generateTimes = () => {
-  return Array.from({ length: 24 }, (_, i) => `${i}:00:00`).slice(7);
+  return Array.from({ length: 24 }, (_, i) => `${String(i).padStart(2, '0')}:00:00`).slice(7);
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #308

## 📝작업 내용

지원폼 제출 시 면접 시간이 8:00:00처럼 한 자리로 표시되던 문제를, 08:00:00과 같이 항상 두 자리로 표기되도록 포맷팅 로직을 수정했습니다.

