### PR TITLE
[FIX] 회원가입 페이지 절대 경로로 수정

### DIFF
--- a/src/pages/admin/Login/hooks/useKakaoLogin.ts
+++ b/src/pages/admin/Login/hooks/useKakaoLogin.ts
@@ -27,7 +27,7 @@ export function useKakaoLogin() {
       try {
         const response: LoginResponse = await login(code, controller.signal);
         if (response.status === 'LOGIN_SUCCESS') navigate(ROUTE_PATH.COMMON.MAIN);
-        else navigate(ROUTE_PATH.COMMON.SIGNUP);
+        else navigate(`/${ROUTE_PATH.COMMON.SIGNUP}`);
       } catch (e: unknown) {
         if (isAxiosError(e) && e.code === 'ERR_CANCELED') {
           return;

--- a/src/pages/admin/Login/hooks/useKakaoLogin.ts
+++ b/src/pages/admin/Login/hooks/useKakaoLogin.ts
@@ -19,7 +19,7 @@ export function useKakaoLogin() {
 
     if (!code) {
       setIsLoading(false);
-      navigate(ROUTE_PATH.COMMON.LOGIN);
+      navigate(`/${ROUTE_PATH.COMMON.LOGIN}`);
       return;
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #311 

## 📝작업 내용
> 첫 로그인 -> 회원 가입 페이지 이동 중에 404Error 발생
- RoutePath 상수로 교체 이후, 상대 경로로 이동하기 때문에 라우터에 등록되지 않은 페이지로 이동.
- 절대 경로로 수정해서 (RoutePath 상수 prefix + '/') 해결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

