### PR TITLE
[REFACTOR] 지원자 상태 업데이트 시 대시보드 요약 데이터 자동 갱신 (#316)

### DIFF
--- a/src/pages/admin/ApplicationDetail/hooks/useDetailApplication.ts
+++ b/src/pages/admin/ApplicationDetail/hooks/useDetailApplication.ts
@@ -40,6 +40,7 @@ export const useDetailApplications = (
         },
       );
       queryClient.invalidateQueries({ queryKey: ['applicants', clubId] });
+      queryClient.invalidateQueries({ queryKey: ['dashboardSummary', clubId] });
     },
   });
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #316 

## 📝작업 내용

현재 지원자 목록에서 '대기 중'인 지원자의 상태를 '합격' 또는 '불합격'으로 변경해도, 페이지 상단의 대시보드 요약 데이터(총 지원자 수)가 즉시 새로고침되지 않은 문제가 발생하여 결과를 즉시 확인하려면 페이지를 수동으로 새로고침해야 하는 불편함이 있습니다.

이를 해결하기 위해 합/불 상태 변경 API 요청이 성공하는 즉시 대시보드 요약 조회 API를 자동으로 갱신하였습니다.

**onSuccess 콜백 추가**
useMutation의 onSuccess 콜백 핸들러 내부에서 queryClient.invalidateQueries({querykey : ['dashboardSummary'...]})를 호출

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
