### PR TITLE
[FIX] clubId 변경 시 지원자 필터 Count가 갱신되도록 수정

### DIFF
--- a/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStatusButton.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStatusButton.tsx
@@ -27,8 +27,8 @@ const Wrapper = styled.button<Pick<Props, 'selected' | 'label'>>(({ theme, selec
       color: theme.colors.red600,
     },
     미정: {
-      backgroundColor: theme.colors.gray100,
-      color: theme.colors.gray600,
+      backgroundColor: theme.colors.gray200,
+      color: theme.colors.gray700,
     },
   };
 

--- a/src/pages/admin/Dashboard/Page.tsx
+++ b/src/pages/admin/Dashboard/Page.tsx
@@ -1,18 +1,20 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { ApplicantListSection } from './components/ApplicantListSection';
 import { DashboardSummarySection } from './components/DashboardSummarySection';
 import { SentAcceptanceMessagesSection } from './components/SentAcceptanceMessagesSection';
 import type { ApplicationStage } from '@/pages/admin/Dashboard/types/dashboard';
 
 export const DashboardPage = () => {
+  const { clubId } = useParams();
   const [stage, setStage] = useState<ApplicationStage>('서류');
 
   return (
     <Layout>
       <Container>
         <DashboardSummarySection />
-        <ApplicantListSection stage={stage} setStage={setStage} />
+        <ApplicantListSection stage={stage} setStage={setStage} clubId={Number(clubId)} />
         <SentAcceptanceMessagesSection stage={stage} />
       </Container>
     </Layout>

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/Filter/ApplicationFilter.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/Filter/ApplicationFilter.tsx
@@ -12,11 +12,12 @@ export type Props = {
   option: ApplicationFilterOption;
   onOptionChange: (option: ApplicationFilterOption) => void;
   stage: ApplicationStage;
+  clubId: number;
 };
 
-export const ApplicationStatusFilter = ({ option, onOptionChange, stage }: Props) => {
+export const ApplicationStatusFilter = ({ option, onOptionChange, stage, clubId }: Props) => {
   const apiStage = stageMap[stage];
-  const { counts } = useApplicants(1, apiStage);
+  const { counts } = useApplicants(clubId, apiStage);
 
   return (
     <Wrapper>

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/index.tsx
@@ -13,9 +13,10 @@ import type {
 interface ApplicantListSectionProps {
   stage: ApplicationStage;
   setStage: React.Dispatch<React.SetStateAction<ApplicationStage>>;
+  clubId: number;
 }
 
-export const ApplicantListSection = ({ stage, setStage }: ApplicantListSectionProps) => {
+export const ApplicantListSection = ({ stage, setStage, clubId }: ApplicantListSectionProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const optionType = 'ALL' as ApplicationFilterOption;
 
@@ -43,6 +44,7 @@ export const ApplicantListSection = ({ stage, setStage }: ApplicantListSectionPr
           option={filterOption}
           onOptionChange={handleFilterOptionChange}
           stage={stage}
+          clubId={clubId}
         />
       </ApplicantFilterTopBarWrapper>
       <ListWrapper>


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #317 

## 📝작업 내용

실제 clubId와 관계없이 필터링 카운트가 항상 clubId: 1을 기준으로 하드코딩 되어있던 문제 해결

`DashboardPage.tsx`에서 `useParams()`를 통해 `clubId`를 동적으로 가져와 `ApplicantListSection`을 거쳐 `ApplicationStatusFilter`로 전달되도록 함.


