### PR TITLE
[STYLE] 메인페이지 모집 상태 스타일 변경#324

### DIFF
--- a/src/pages/user/Main/components/ClubListSection/Club.styled.ts
+++ b/src/pages/user/Main/components/ClubListSection/Club.styled.ts
@@ -34,9 +34,14 @@ type Props = {
 };
 
 export const RecruitStatusBox = styled.div<Props>(({ theme, status }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  textAlign: 'center',
   padding: '6px 10px',
   borderRadius: theme.radius.md,
-  width: 50,
+  width: 60,
+  minHeight: 20,
   backgroundColor: status === '모집중' ? theme.colors.primary : theme.colors.gray200,
 }));
 
@@ -45,6 +50,7 @@ export const RecruitStatusText = styled.div<Props>(({ theme }) => ({
   fontSize: theme.font.size.xs,
   fontWeight: theme.font.weight.medium,
   color: 'white',
+  lineHeight: 1.2,
 }));
 
 export const Grid = styled.div(({ theme }) => ({


### PR DESCRIPTION
- '모집 준비중' 변경 시 2줄로 넘어가는 문제 해결

## #️⃣연관된 이슈

- closea #324 

## 📝작업 내용

- '모집 상태중' 동아리 상태 변경시 2줄로 넘어가는 문제 해결
- RecruitStatusBox 스타일 수정
```ts
export const RecruitStatusBox = styled.div<Props>(({ theme, status }) => ({
  display: 'flex',
  alignItems: 'center',
  justifyContent: 'center',
  textAlign: 'center',
...
  width: 60,
  minHeight: 20,
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 폰트 크기랑 외부 상태 표시 박스랑 크기가 이질성이 좀 있는 것 같은데 우선 문제해결을 위해 수정했습니다.
