### PR TITLE
[BUG] TimeslotFieldBuilder에서 시간 미선택 시 null 전송 오류 수정

### DIFF
--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
@@ -84,7 +84,7 @@ export const FormFieldItem = ({ formHandler, index, onRemove, isEditMode }: Prop
     } else if (newType === 'TIME_SLOT') {
       setValue(`formQuestions.${index}.timeSlotOptions`, {
         date: '',
-        availableTime: { start: '', end: '' },
+        availableTime: { start: '07:00:00', end: '07:00:00' },
       });
     }
   };

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/index.tsx
@@ -26,7 +26,7 @@ export const ApplicationFieldsFormTableSection = ({ formHandler, isEditMode }: P
       question: '',
       isRequired: true,
       optionList: [],
-      timeSlotOptions: { date: '', availableTime: { start: '', end: '' } },
+      timeSlotOptions: { date: '', availableTime: { start: '07:00:00', end: '07:00:00' } },
     });
   };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #327 

## 📝작업 내용

**[문제발생]**
지원서 양식 빌더에서 타임슬롯 항목을 추가할 때, 시간을 별도로 선택하지 않으면 availableTime의 start와 end 값이 null로 전송되는 문제가 있었습니다.

**[해결 사항]**
타임슬롯 항목이 생성되거나, 다른 항목에서 타임슬롯 유형으로 변경될 때 availableTime의 start와 end의 기본값을 07:00:00으로 설정하여 문제를 해결했습니다.

- 신규 항목 추가: 새로운 질문 항목을 추가할 때 availableTime의 start와 end에 기본값 설정
- 항목 유형 변경: 질문 유형을 TIME_SLOT으로 변경할 때 availableTime의 start와 end에 기본값 설정