### PR TITLE
[STYLE] 모바일 환경에서 Banner의 헤더텍스트 크기 축소

### DIFF
--- a/src/pages/user/Main/components/BannerSection/BannerText.tsx
+++ b/src/pages/user/Main/components/BannerSection/BannerText.tsx
@@ -26,6 +26,12 @@ export const HeaderText = styled.h2(({ theme }) => ({
   textShadow: '0 3px 6px rgba(0, 0, 0, 0.4)',
   margin: 0,
   lineHeight: 1.3,
+  [`@media(max-width: ${theme.breakpoints.web})`]: {
+    fontSize: '28px',
+  },
+  [`@media(max-width: ${theme.breakpoints.mobile})`]: {
+    fontSize: '22px',
+  },
 }));
 
 export const SubText = styled.p(({ theme }) => ({


### PR DESCRIPTION


## 📝작업 내용

> PC -> Mobile 배너 헤더 텍스트 크기 축소 

### 스크린샷 (선택)
**변경전**
<img width="179" height="161" alt="image" src="https://github.com/user-attachments/assets/be7d9768-2c76-4c37-b412-8c5ee5cbd1fd" />

**변경후**
<img width="195" height="173" alt="image" src="https://github.com/user-attachments/assets/46a988fc-e532-4750-a155-7a48a471ce78" />

## 💬리뷰 요구사항(선택)

