### PR TITLE
style : 배너 내부의 요소 가운데 정렬되도록 수정

### DIFF
--- a/src/pages/user/Main/components/BannerSection/index.tsx
+++ b/src/pages/user/Main/components/BannerSection/index.tsx
@@ -43,31 +43,55 @@ export const BannerSection = ({
   return (
     <S.BannerWrapper>
       <BannerSlideshow />
-      <B.BannerTextWrapper>
-        <B.HeaderText>함께할 사람이 있는 곳, 동아리움.</B.HeaderText>
-        <B.SubText>관심 있는 전남대학교 동아리를 찾고, 참여해보세요.</B.SubText>
-      </B.BannerTextWrapper>
+      <ContentContainer>
+        <B.BannerTextWrapper>
+          <B.HeaderText>함께할 사람이 있는 곳, 동아리움.</B.HeaderText>
+          <B.SubText>관심 있는 전남대학교 동아리를 찾고, 참여해보세요.</B.SubText>
+        </B.BannerTextWrapper>
 
-      <SearchContainer>
-        <ClubSearchInput onChangeSearch={onChangeSearch} />
-        <DropdownWrapper>
-          <Dropdown
-            placeholder='동아리 카테고리'
-            value={engToKorCategory[selectedCategory]}
-            options={CLUB_CATEGORY}
-            onSelect={handleCategoryClick}
-          />
-          <Dropdown
-            placeholder='모집 상태'
-            value={selectedRecruitStatus ? selectedRecruitStatus : undefined}
-            options={[...CLUB_RECRUIT_STATUS_KOR]}
-            onSelect={handleRecruitStatusClick}
-          />
-        </DropdownWrapper>
-      </SearchContainer>
+        <SearchContainer>
+          <ClubSearchInput onChangeSearch={onChangeSearch} />
+          <DropdownWrapper>
+            <Dropdown
+              placeholder='동아리 카테고리'
+              value={engToKorCategory[selectedCategory]}
+              options={CLUB_CATEGORY}
+              onSelect={handleCategoryClick}
+            />
+            <Dropdown
+              placeholder='모집 상태'
+              value={selectedRecruitStatus ? selectedRecruitStatus : undefined}
+              options={[...CLUB_RECRUIT_STATUS_KOR]}
+              onSelect={handleRecruitStatusClick}
+            />
+          </DropdownWrapper>
+        </SearchContainer>
+      </ContentContainer>
     </S.BannerWrapper>
   );
 };
+
+const ContentContainer = styled.div(({ theme }) => ({
+  position: 'relative',
+  zIndex: 2,
+  width: '100%',
+  maxWidth: '1200px',
+  margin: '0 auto',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+  padding: '0 80px',
+  boxSizing: 'border-box',
+
+  [`@media (max-width: ${theme.breakpoints.web})`]: {
+    padding: '0 40px',
+  },
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    padding: '0 16px',
+    gap: '12px',
+  },
+}));
 
 const BannerSlideshow = () => {
   const images = ['/assets/banner01.jpg', '/assets/banner02.jpg', '/assets/banner03.jpg'];


### PR DESCRIPTION
## 📝작업 내용

- Banner 내부의 요소들이 width가 늘어남에 따라 화면 왼쪽으로 동아리 Item 요소들의 기준선을 초과하는 부분을 개선하기 위해서 가운데 정렬되도록 수정

### 스크린샷 (선택)

Desktop 기준

변경 전  
<img width="1923" height="983" alt="image" src="https://github.com/user-attachments/assets/49280c8f-4458-4293-b699-604ebf718b64" />

변경 후
<img width="1590" height="868" alt="image" src="https://github.com/user-attachments/assets/850730a1-b07c-4fbe-92e4-3d9d15c15f80" />

## 💬리뷰 요구사항(선택)

