### PR TITLE
[REFACTOR] 검색 결과 상태 표시 수정

### DIFF
--- a/src/pages/user/Main/components/ClubListSection/NoSearchResult.tsx
+++ b/src/pages/user/Main/components/ClubListSection/NoSearchResult.tsx
@@ -1,0 +1,40 @@
+import { type Club, type RecruitStatus } from '@/pages/user/Main/types/club.ts';
+import { getNoSearchMessage } from '@/pages/user/Main/utils/searchClubs.ts';
+import { Text } from '@/shared/components/Text';
+import * as S from './Club.styled.ts';
+import type { ClubCategoryEng } from '@/types/club.ts';
+
+const NoSearchResult = (
+  filteredClubs: Club[],
+  searchText: string,
+  categoryFilter: ClubCategoryEng,
+  recruitStatus: RecruitStatus | undefined,
+) => {
+  if (filteredClubs.length > 0) return null;
+
+  const mainText = getNoSearchMessage(searchText, categoryFilter, recruitStatus);
+  const subText = '동아리명, 카테고리, 동아리 소개로 검색해 보세요.';
+
+  return (
+    <S.ClubListContainer>
+      <S.NoSearchResultContainer>
+        <S.SearchImage
+          src='/assets/noSearchResults.svg'
+          alt='이미지 없음'
+          width={100}
+          height={100}
+        />
+        <S.TextWrapper>
+          <Text color='#757575' size='xl' weight='regular'>
+            {mainText}
+          </Text>
+          <Text color='#7E8691' size='sm'>
+            {subText}
+          </Text>
+        </S.TextWrapper>
+      </S.NoSearchResultContainer>
+    </S.ClubListContainer>
+  );
+};
+
+export default NoSearchResult;

--- a/src/pages/user/Main/components/ClubListSection/index.tsx
+++ b/src/pages/user/Main/components/ClubListSection/index.tsx
@@ -1,19 +1,23 @@
 import { useNavigate } from 'react-router-dom';
 import { useClubFiltering } from '@/pages/user/Main/hooks/useClubFiltering.ts';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner.tsx';
-import { Text } from '@/shared/components/Text';
 import { engToKorCategory } from '@/utils/formatting.ts';
 import * as S from './Club.styled.ts';
+import NoSearchResult from './NoSearchResult.tsx';
 import type { Club, RecruitStatus } from '@/pages/user/Main/types/club.ts';
 import type { ClubCategoryEng } from '@/types/club';
 
-type Props = {
+type ClubFilteringProps = {
   categoryFilter: ClubCategoryEng;
   searchText: string;
-  recruitStatus: RecruitStatus | undefined;
+  recruitStatus?: RecruitStatus;
 };
 
-export const ClubListSection = ({ categoryFilter, searchText, recruitStatus }: Props) => {
+export const ClubListSection = ({
+  categoryFilter,
+  searchText,
+  recruitStatus,
+}: ClubFilteringProps) => {
   const navigate = useNavigate();
 
   const filterStatus = recruitStatus === '전체' ? undefined : recruitStatus;
@@ -28,29 +32,7 @@ export const ClubListSection = ({ categoryFilter, searchText, recruitStatus }: P
   if (error) return <div>에러발생 : {error.message}</div>;
 
   if (filteredClubs.length === 0)
-    return (
-      <S.ClubListContainer>
-        <S.NoSearchResultContainer>
-          <S.SearchImage
-            src='/assets/noSearchResults.svg'
-            alt='이미지 없음'
-            width={100}
-            height={100}
-          />
-          <S.TextWrapper>
-            <Text
-              color={'#757575'}
-              size={'xl'}
-              weight={'regular'}
-            >{`\`${searchText}\`검색 결과가 없습니다`}</Text>
-            <Text
-              color={'#7E8691'}
-              size={'sm'}
-            >{`동아리명, 카테고리, 동아리 소개로 검색해 보세요.`}</Text>
-          </S.TextWrapper>
-        </S.NoSearchResultContainer>
-      </S.ClubListContainer>
-    );
+    return NoSearchResult(filteredClubs, searchText, categoryFilter, filterStatus);
 
   return (
     <S.ClubListContainer>

--- a/src/pages/user/Main/components/ClubListSection/index.tsx
+++ b/src/pages/user/Main/components/ClubListSection/index.tsx
@@ -29,7 +29,7 @@ export const ClubListSection = ({
   } = useClubFiltering(categoryFilter, searchText, filterStatus);
 
   if (isLoading) return <LoadingSpinner />;
-  if (error) return <div>에러발생 : {error.message}</div>;
+  if (error) return <div>{error.message}</div>;
 
   if (filteredClubs.length === 0)
     return NoSearchResult(filteredClubs, searchText, categoryFilter, filterStatus);

--- a/src/pages/user/Main/types/club.ts
+++ b/src/pages/user/Main/types/club.ts
@@ -8,7 +8,7 @@ export type Club = {
   recruitStatus: RecruitStatus;
 };
 
-const RECRUIT_STATUS_MAP = {
+export const RECRUIT_STATUS_MAP = {
   RECRUITING: '모집중',
   CLOSED: '모집 종료',
   PREPARING: '모집 준비중',

--- a/src/pages/user/Main/utils/searchClubs.ts
+++ b/src/pages/user/Main/utils/searchClubs.ts
@@ -1,4 +1,7 @@
-import type { Club } from '../types/club.ts';
+import { CLUB_CATEGORY_MAP } from '@/constants/clubCategory.ts';
+import { engToKorCategory } from '@/utils/formatting.ts';
+import { RECRUIT_STATUS_MAP, type Club, type RecruitStatus } from '../types/club.ts';
+import type { ClubCategoryEng } from '@/types/club.ts';
 
 export const searchClubs = (clubs: Club[], searchKeyword: string): Club[] => {
   return searchKeyword
@@ -9,4 +12,16 @@ export const searchClubs = (clubs: Club[], searchKeyword: string): Club[] => {
           club.shortIntroduction.replace(/\s+/g, '').includes(searchKeyword),
       )
     : clubs;
+};
+
+export const getNoSearchMessage = (
+  searchText: string,
+  categoryFilter: ClubCategoryEng,
+  recruitStatus: RecruitStatus | undefined,
+) => {
+  if (searchText) return `\`${searchText}\` 검색 결과가 없습니다.`;
+  if (categoryFilter !== CLUB_CATEGORY_MAP.전체)
+    return `\`${engToKorCategory[categoryFilter]}\` 카테고리에 해당하는 동아리가 존재하지 않습니다.`;
+  if (recruitStatus && recruitStatus !== RECRUIT_STATUS_MAP.ALL)
+    return `현재 \`${recruitStatus}\` 상태인 동아리가 없습니다.`;
 };

--- a/src/shared/components/Footer/index.styled.ts
+++ b/src/shared/components/Footer/index.styled.ts
@@ -1,6 +1,9 @@
 import styled from '@emotion/styled';
 
 export const FooterContainer = styled.div(({ theme }) => ({
+  position: 'fixed',
+  bottom: 0,
+  left: 0,
   width: '100%',
   backgroundColor: theme.colors.gray100,
   padding: 32,


### PR DESCRIPTION

## 📝작업 내용

> 검색 결과 뿐만 아니라 카테고리 필터링, 모집 상태 필터링 결과에 따라 해당되는 동아리가 없는 경우 표시되는 텍스트가 유동적으로 변하도록 수정

### 스크린샷 (선택)
**동아리 모집 상태**
<img width="915" height="454" alt="스크린샷 2025-11-09 오전 1 46 44" src="https://github.com/user-attachments/assets/f1eff56c-7347-45a0-a6f1-827d8d2d8570" />
**동아리 검색 결과**
<img width="973" height="441" alt="스크린샷 2025-11-09 오전 1 46 15" src="https://github.com/user-attachments/assets/5c6fc005-1d85-47b8-bca3-4c82ad65b6ce" />
**동아리 카테고리 필터링**
<img width="1018" height="455" alt="스크린샷 2025-11-09 오전 1 46 38" src="https://github.com/user-attachments/assets/19abf227-7168-4a48-a345-11bb2025c478" />


검색 결과 표시 되는 경우 <Footer> 섹션 하단에 고정되도록 수정
<img width="1429" height="872" alt="스크린샷 2025-11-09 오전 2 01 21" src="https://github.com/user-attachments/assets/945a1469-071e-4596-94a1-da8d47000a6b" />


## 💬리뷰 요구사항(선택)


