### PR TITLE
[STYLE] 날짜 텍스트 줄바뀜 방지

### DIFF
--- a/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
+++ b/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
@@ -113,11 +113,12 @@ export const Wrapper = styled.div({
 });
 
 export const DateText = styled.span(({ theme }) => ({
-  textAlign: 'center',
-  width: '100px',
+  textAlign: 'left',
+  minWidth: '150px',
   padding: '10px 0 20px 0',
   fontWeight: theme.font.weight.bold,
   fontSize: theme.font.size.sm,
+  whiteSpace: 'nowrap',
 }));
 
 export const AutoSaveIndicator = styled.span(({ theme }) => ({


### PR DESCRIPTION

## 📝작업 내용
지원서 제출 시 날짜 텍스트 부분 줄바뀜 방지


### 스크린샷 (선택)

**변경 전**
<img width="418" height="478" alt="image" src="https://github.com/user-attachments/assets/024074a0-f443-4911-8084-14afdb669479" />


**변경 후**
<img width="272" height="198" alt="image" src="https://github.com/user-attachments/assets/1893fd09-c073-47f4-b3b6-2770e1c14982" />

## 💬리뷰 요구사항(선택)
서버에서 응답을 날짜별로 각각 내려줘야 날짜-시간 1:1 매칭이 가능할 것 같네요
