### PR TITLE
[FEAT] 지원폼 검증 추가  

### DIFF
--- a/src/pages/user/Apply/components/ApplicationForm/index.tsx
+++ b/src/pages/user/Apply/components/ApplicationForm/index.tsx
@@ -175,7 +175,14 @@ export const ApplicationForm = ({ questions }: Props) => {
                       <S.OptionInput
                         type='checkbox'
                         value={option}
-                        {...methods.register(`answers.${field.originalIndex}`)}
+                        {...methods.register(`answers.${field.originalIndex}`, {
+                          validate: (value) => {
+                            if (Array.isArray(value) && value.length > 0) {
+                              return true;
+                            }
+                            return '하나 이상 선택해야 합니다.';
+                          },
+                        })}
                       />
                       {option}
                     </S.Label>
@@ -187,7 +194,9 @@ export const ApplicationForm = ({ questions }: Props) => {
                       <S.OptionInput
                         type='radio'
                         value={option}
-                        {...methods.register(`answers.${field.originalIndex}`)}
+                        {...methods.register(`answers.${field.originalIndex}`, {
+                          required: '하나를 선택해야 합니다.',
+                        })}
                       />
                       {option}
                     </S.Label>
@@ -196,7 +205,10 @@ export const ApplicationForm = ({ questions }: Props) => {
                 {field.questionType === QuestionTypes.TEXT && (
                   <OutlineTextareaField
                     placeholder='1000자 미만으로 입력하세요.'
-                    {...methods.register(`answers.${field.originalIndex}`)}
+                    {...methods.register(`answers.${field.originalIndex}`, {
+                      required: '내용을 입력하세요.',
+                      maxLength: { value: 1000, message: '최대 1000자까지 입력 가능합니다.' },
+                    })}
                   />
                 )}
               </S.ChoiceFormFiled>
@@ -211,6 +223,7 @@ export const ApplicationForm = ({ questions }: Props) => {
                   <Controller
                     name={`answers.${field.originalIndex}`}
                     control={methods.control}
+                    rules={{ required: '면접 시간을 선택하세요.' }}
                     render={({ field: controllerField }) => (
                       <>
                         {field.timeSlotOptions?.map(

--- a/src/pages/user/Apply/components/ApplicationForm/index.tsx
+++ b/src/pages/user/Apply/components/ApplicationForm/index.tsx
@@ -7,6 +7,7 @@ import { useApplicationSubmit } from '@/pages/user/Apply/hooks/useApplicationSub
 import { Button } from '@/shared/components/Button';
 import { OutlineInputField } from '@/shared/components/Form/InputField/OutlineInputField';
 import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/OutlineTextareaField';
+import { Text } from '@/shared/components/Text';
 import * as S from './index.styled';
 import { InterviewScheduleSelector } from './InterviewScheduleSelector';
 import type {
@@ -210,6 +211,11 @@ export const ApplicationForm = ({ questions }: Props) => {
                       maxLength: { value: 1000, message: '최대 1000자까지 입력 가능합니다.' },
                     })}
                   />
+                )}
+                {errors.answers?.[field.originalIndex] && (
+                  <Text size='xs' color='#fa342c'>
+                    {errors.answers[field.originalIndex]?.message}
+                  </Text>
                 )}
               </S.ChoiceFormFiled>
             ))}


### PR DESCRIPTION

## 📝작업 내용

- 지원폼 필수 문항에 validation 추가(인적 사항과 동일한 validation message 반영)
- 지원폼 제출 시 확인 메일 내용 toast 알림에 추가 
### 스크린샷 (선택)

**필수 문항**
<img width="278" height="394" alt="image" src="https://github.com/user-attachments/assets/b0cf1bc8-33b7-4d46-97ae-15cf8514241c" />

**확인 메일 메시지**
<img width="408" height="100" alt="스크린샷 2025-11-09 오전 3 01 28" src="https://github.com/user-attachments/assets/a07e8be5-2c38-4680-9c3f-4b6713c5f7d9" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
