### PR TITLE
[FIX] 임시저장 토스트 메시지 위치 조정

### DIFF
--- a/src/pages/user/Apply/Page.tsx
+++ b/src/pages/user/Apply/Page.tsx
@@ -23,7 +23,6 @@ export const ClubApplicationPage = () => {
 };
 
 const ContentContainer = styled.div`
-  width: 48rem;
   display: flex;
   flex-direction: column;
   box-sizing: border-box;

--- a/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
+++ b/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
@@ -123,22 +123,29 @@ export const DateText = styled.span(({ theme }) => ({
 
 export const AutoSaveIndicator = styled.span(({ theme }) => ({
   position: 'fixed',
-  top: '1.25rem',
-  right: '1.875rem',
-  fontSize: '0.8125rem',
-  color: theme.colors.textSecondary,
+  top: '80px',
+  right: '2rem',
+  zIndex: 999,
+
+  backgroundColor: theme.colors.bg,
+  paddingTop: '0.5rem',
+  width: 'auto',
+
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'center',
-  gap: '0.375rem',
-  zIndex: 1000,
-  backgroundColor: 'white',
-  width: '10rem',
-  padding: '0.375rem 0.75rem',
-  borderRadius: '0.25rem',
+  justifyContent: 'flex-end',
+  gap: '0.5rem',
+  fontSize: theme.font.size.sm,
+  color: theme.colors.textPrimary,
 }));
 
 export const ActionButtonWrapper = styled.div`
   display: flex;
-  gap: 2rem;
+  gap: 1.5rem;
+  width: 100%;
+
+  & > * {
+    width: auto;
+    flex: 1 1 0;
+  }
 `;

--- a/src/pages/user/Main/Page.tsx
+++ b/src/pages/user/Main/Page.tsx
@@ -39,7 +39,7 @@ export const MainPage = () => {
 export const Container = styled.div({
   display: 'flex',
   flexDirection: 'column',
-  gap: '60px',
+  gap: '10px',
   width: '100%',
   maxWidth: '100vw',
   boxSizing: 'border-box',

--- a/src/pages/user/Main/components/ClubListSection/Club.styled.ts
+++ b/src/pages/user/Main/components/ClubListSection/Club.styled.ts
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { theme } from '@/styles/theme';
 import type { RecruitStatus } from '@/pages/user/Main/types/club';
 
 export const ClubCategoryText = styled.div(({ theme }) => ({
@@ -57,35 +56,28 @@ export const Grid = styled.div(({ theme }) => ({
   display: 'grid',
   gap: 30,
   padding: '30px 0',
-  gridTemplateColumns: 'repeat(4, 1fr)',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
   justifyItems: 'center',
 
-  [`@media (max-width: ${theme.breakpoints.web})`]: {
-    gridTemplateColumns: 'repeat(2, 1fr)',
-  },
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    gridTemplateColumns: '1fr',
+    gap: 15,
     padding: '20px 12px',
   },
 }));
 
 export const ClubListContainer = styled.div({
+  width: '100%',
   maxWidth: '1200px',
   margin: '0 auto',
-
-  [`@media (max-width: ${theme.breakpoints.web})`]: {
-    maxWidth: '90%',
-  },
-
-  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    maxWidth: '100%',
-  },
+  padding: '0 1.5rem',
+  boxSizing: 'border-box',
 });
 
 export const ClubItem = styled.div(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
-  width: 240,
+  width: '100%',
+  boxSizing: 'border-box',
   minHeight: '130px',
   height: 'auto',
   marginBottom: 10,
@@ -94,11 +86,6 @@ export const ClubItem = styled.div(({ theme }) => ({
   boxShadow: theme.shadow.md,
   padding: 16,
   gap: 16,
-  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    width: 'calc(100vw - 32px)',
-    maxWidth: '100%',
-    boxSizing: 'border-box',
-  },
 }));
 
 export const NoSearchResultContainer = styled.div({

--- a/src/shared/components/Navigation/NavigationContainer.tsx
+++ b/src/shared/components/Navigation/NavigationContainer.tsx
@@ -44,21 +44,23 @@ export const NavigationContainer = ({
 
   return (
     <>
-      <NavContainer ref={navRef}>
-        {logo && <MobileLogoLink to='/'>{logo}</MobileLogoLink>}
-        <HamburgerButton onClick={onToggleMobileMenu}>
-          <HamburgerLine />
-          <HamburgerLine />
-          <HamburgerLine />
-        </HamburgerButton>
+      <NavWrapper>
+        <NavContainer ref={navRef}>
+          {logo && <MobileLogoLink to='/'>{logo}</MobileLogoLink>}
+          <HamburgerButton onClick={onToggleMobileMenu}>
+            <HamburgerLine />
+            <HamburgerLine />
+            <HamburgerLine />
+          </HamburgerButton>
 
-        <DesktopNav>{children}</DesktopNav>
+          <DesktopNav>{children}</DesktopNav>
 
-        <UnderlineIndicator
-          style={underlineStyle}
-          visible={!!selectedItem && selectedItem !== ''}
-        />
-      </NavContainer>
+          <UnderlineIndicator
+            style={underlineStyle}
+            visible={!!selectedItem && selectedItem !== ''}
+          />
+        </NavContainer>
+      </NavWrapper>
 
       <MobileMenuOverlay isOpen={isMobileMenuOpen} onClick={onToggleMobileMenu} />
 
@@ -70,24 +72,43 @@ export const NavigationContainer = ({
   );
 };
 
-const NavContainer = styled.nav(({ theme }) => ({
+const NavWrapper = styled.div(({ theme }) => ({
   width: '100%',
-  padding: '20px 5vw',
-  display: 'flex',
-  flexWrap: 'wrap',
-  alignItems: 'center',
-  gap: '4rem',
-  boxSizing: 'border-box',
   backgroundColor: theme.colors.bg,
   boxShadow: theme.shadow.sm,
-  zIndex: theme.zIndex.header,
   position: 'sticky',
   top: 0,
+  zIndex: theme.zIndex.header,
 
   [`@media (max-width: ${theme.breakpoints.web})`]: {
     zIndex: 1001,
-    padding: '15px 5vw',
     boxShadow: '0 2px 8px rgba(0, 0, 0, 0.08)',
+  },
+}));
+
+const NavContainer = styled.nav(({ theme }) => ({
+  width: '100%',
+  maxWidth: '1400px',
+  margin: '0 auto',
+  padding: '20px 7vw',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4rem',
+  boxSizing: 'border-box',
+  position: 'relative',
+
+  '@media (max-width: 1300px)': {
+    gap: '2rem',
+    padding: '20px 4vw',
+  },
+
+  '@media (max-width: 1100px)': {
+    gap: '1rem',
+    padding: '20px 3vw',
+  },
+
+  [`@media (max-width: ${theme.breakpoints.web})`]: {
+    padding: '15px 5vw',
   },
 }));
 
@@ -131,6 +152,15 @@ const DesktopNav = styled.div({
   alignItems: 'center',
   gap: '4rem',
   flex: 1,
+  minWidth: 0,
+
+  '@media (max-width: 1300px)': {
+    gap: '2rem',
+  },
+
+  '@media (max-width: 1100px)': {
+    gap: '1rem',
+  },
 
   [`@media (max-width: ${theme.breakpoints.web})`]: {
     display: 'none',

--- a/src/shared/components/Navigation/index.tsx
+++ b/src/shared/components/Navigation/index.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 import { Logo } from '@/pages/admin/Login/component/Logo';
 import { useAuth } from '@/providers/auth';
-import { theme } from '@/styles/theme';
 import { ClubSelector } from './components/ClubSelector';
 import { useNavigation } from './hooks/useNavigation';
 import { NavigationContainer } from './NavigationContainer';
@@ -70,22 +69,44 @@ export const Navigation = () => {
   );
 };
 
-const LeftMenu = styled.div({
+const LeftMenu = styled.div(({ theme }) => ({
   display: 'flex',
-  gap: '4rem',
+  gap: '2rem',
+  alignItems: 'center',
+  minWidth: 0,
+  flex: '0 1 auto',
+
+  '@media (max-width: 1300px)': {
+    gap: '1.5rem',
+  },
+
+  '@media (max-width: 1100px)': {
+    gap: '1rem',
+  },
 
   [`@media (max-width: ${theme.breakpoints.web})`]: {
     flexDirection: 'column',
     gap: '1.5rem',
     width: '100%',
+    alignItems: 'flex-start',
   },
-});
+}));
 
-const RightMenu = styled.div({
+const RightMenu = styled.div(({ theme }) => ({
   marginLeft: 'auto',
   display: 'flex',
   alignItems: 'center',
-  gap: '2.5rem',
+  gap: '1.5rem',
+  flex: '0 0 auto',
+  minWidth: 0,
+
+  '@media (max-width: 1300px)': {
+    gap: '1rem',
+  },
+
+  '@media (max-width: 1100px)': {
+    gap: '0.8rem',
+  },
 
   [`@media (max-width: ${theme.breakpoints.web})`]: {
     marginLeft: 0,
@@ -93,5 +114,7 @@ const RightMenu = styled.div({
     marginTop: '1rem',
     paddingTop: '1rem',
     borderTop: '1px solid rgba(0, 0, 0, 0.1)',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
   },
-});
+}));


### PR DESCRIPTION

## 📝작업 내용

지원하기 페이지에서 '임시저장 완료' 토스트 메시지가 화면 상단의 '관리자 로그인 버튼' 등 다른 UI 요소를 가리는 레이어 문제가 있었습니다.

토스트 메시지가 네비게이션 바보다는 아래쪽에 표시되도록 수정하여, 상단 UI를 가리지 않도록 했습니다.

### 스크린샷 (선택)
<img width="1684" height="118" alt="image" src="https://github.com/user-attachments/assets/65704c1b-39f5-4236-bae1-4e92753cb6a7" />
