### PR TITLE
[FIX] 지원폼 생성 페이지 스타일 수정

### DIFF
--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
@@ -80,7 +80,7 @@ export const FormFieldItem = ({ formHandler, index, onRemove, isEditMode }: Prop
     setValue(`formQuestions.${index}.fieldType`, newType);
 
     if (newType === 'RADIO' || newType === 'CHECKBOX') {
-      setValue(`formQuestions.${index}.optionList`, []);
+      setValue(`formQuestions.${index}.optionList`, [{ value: '' }]);
     } else if (newType === 'TIME_SLOT') {
       setValue(`formQuestions.${index}.timeSlotOptions`, {
         date: '',

--- a/src/pages/admin/ApplicationFormBuilder/styles/timeslot.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/styles/timeslot.styled.ts
@@ -21,6 +21,7 @@ export const CustomInputWrapper = styled.div(({ theme }) => ({
   justifyContent: 'center',
   width: '15rem',
   cursor: 'pointer',
+  position: 'relative',
   borderBottom: `1px solid ${theme.colors.gray200}`,
   paddingBottom: '0.5rem',
   boxSizing: 'border-box',

--- a/src/pages/admin/ApplicationFormBuilder/styles/timeslot.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/styles/timeslot.styled.ts
@@ -14,22 +14,21 @@ export const Layout = styled.div({
 export const DatePickerWrapper = styled.div({
   position: 'relative',
 });
-
 export const CustomInputWrapper = styled.div(({ theme }) => ({
+  height: '29px',
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'space-between',
+  justifyContent: 'center',
   width: '15rem',
-  padding: '0.75rem 1rem',
-  borderBottom: `1px solid ${theme.colors.gray200}`,
-  backgroundColor: theme.colors.bg,
   cursor: 'pointer',
-  position: 'relative',
+  borderBottom: `1px solid ${theme.colors.gray200}`,
+  paddingBottom: '0.5rem',
+  boxSizing: 'border-box',
 
   '&::after': {
     content: '"⌵"',
     position: 'absolute',
-    top: '6px',
+    top: '-5px',
     right: '13px',
     color: theme.colors.textSecondary,
     fontSize: '22px',

--- a/src/shared/components/Form/InputField/UnderlineInputField.tsx
+++ b/src/shared/components/Form/InputField/UnderlineInputField.tsx
@@ -26,6 +26,9 @@ const Input = styled.input<Pick<Props, 'invalid'>>(({ theme, invalid }) => ({
   fontSize: theme.font.size.sm,
   flex: 1,
   textAlign: 'center',
+  height: '29px',
+  padding: '0 0 0.5rem 0',
+  boxSizing: 'border-box',
   transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
 
   '&:focus': {


### PR DESCRIPTION

## 📝작업 내용

**옵션추가 안한 경우 수정하기 누르면 반영이 안되는데, 수정사항이 없다라는 오류가 뜨지 않는 문제** 
=> 라디오, 체크박스 옵션 선택 시 기본 옵션 필드 제공
<img width="800" height="246" alt="image" src="https://github.com/user-attachments/assets/4477c8e9-1a88-417a-b5e6-e7724473a527" />

**글자와 라인 사이 간격이 안맞는 문제**
- 수정 전
<img width="1161" height="243" alt="image" src="https://github.com/user-attachments/assets/01f51bae-1821-4947-a9e9-1445c0989d4d" />

- 수정 후
<img width="797" height="174" alt="image" src="https://github.com/user-attachments/assets/8faa0f0d-8aa9-48a0-9993-5d2e4dbec7b0" />

