### PR TITLE
[STYLE] 메인페이지 카드리스트 섹션 수정

### DIFF
--- a/src/pages/user/Main/components/ClubListSection/Club.styled.ts
+++ b/src/pages/user/Main/components/ClubListSection/Club.styled.ts
@@ -38,9 +38,8 @@ export const RecruitStatusBox = styled.div<Props>(({ theme, status }) => ({
   justifyContent: 'center',
   textAlign: 'center',
   padding: '6px 10px',
-  borderRadius: theme.radius.md,
+  borderRadius: '10rem',
   width: 60,
-  minHeight: 20,
   backgroundColor: status === '모집중' ? theme.colors.primary : theme.colors.gray200,
 }));
 
@@ -81,9 +80,8 @@ export const ClubItem = styled.div(({ theme }) => ({
   minHeight: '130px',
   height: 'auto',
   marginBottom: 10,
-  border: `1px solid ${theme.colors.border}`,
-  borderRadius: theme.radius.lg,
-  boxShadow: theme.shadow.md,
+  border: `1px solid #E6E8EB`,
+  borderRadius: theme.radius.md,
   padding: 16,
   gap: 16,
 }));

--- a/src/pages/user/Main/components/ClubListSection/Club.styled.ts
+++ b/src/pages/user/Main/components/ClubListSection/Club.styled.ts
@@ -1,12 +1,6 @@
 import styled from '@emotion/styled';
 import type { RecruitStatus } from '@/pages/user/Main/types/club';
 
-export const ClubCategoryText = styled.div(({ theme }) => ({
-  fontSize: theme?.font?.size?.xs,
-  fontWeight: theme.font.weight.regular,
-  color: theme?.colors.textSecondary,
-}));
-
 export const ClubNameText = styled.div(({ theme }) => ({
   fontSize: theme?.font?.size?.lg,
   fontWeight: theme.font.weight.bold,
@@ -32,6 +26,12 @@ type Props = {
   status: RecruitStatus;
 };
 
+export const StatusContainer = styled.div({
+  display: 'flex',
+  gap: '8px',
+  alignItems: 'center',
+});
+
 export const RecruitStatusBox = styled.div<Props>(({ theme, status }) => ({
   display: 'flex',
   alignItems: 'center',
@@ -43,11 +43,29 @@ export const RecruitStatusBox = styled.div<Props>(({ theme, status }) => ({
   backgroundColor: status === '모집중' ? theme.colors.primary : theme.colors.gray200,
 }));
 
-export const RecruitStatusText = styled.div<Props>(({ theme }) => ({
+export const RecruitStatusText = styled.div<Props>(({ theme, status }) => ({
   textAlign: `center`,
   fontSize: theme.font.size.xs,
   fontWeight: theme.font.weight.medium,
-  color: 'white',
+  color: status === '모집중' ? theme.colors.primary00 : theme.colors.textPrimary,
+  lineHeight: 1.2,
+}));
+
+export const CategoryStatusBox = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  textAlign: 'center',
+  padding: '6px 10px',
+  borderRadius: '10rem',
+  backgroundColor: theme.colors.gray200,
+}));
+
+export const CategoryStatusText = styled.div(({ theme }) => ({
+  textAlign: `center`,
+  fontSize: theme.font.size.xs,
+  fontWeight: theme.font.weight.medium,
+  color: theme.colors.textPrimary,
   lineHeight: 1.2,
 }));
 
@@ -82,8 +100,13 @@ export const ClubItem = styled.div(({ theme }) => ({
   marginBottom: 10,
   border: `1px solid #E6E8EB`,
   borderRadius: theme.radius.md,
-  padding: 16,
+  padding: '1.7rem 1.5rem',
   gap: 16,
+  transition: 'transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out',
+  '&:hover': {
+    transform: 'scale(1.02)',
+    boxShadow: `0 0 10px ${theme.colors.blue200}50`,
+  },
 }));
 
 export const NoSearchResultContainer = styled.div({

--- a/src/pages/user/Main/components/ClubListSection/index.tsx
+++ b/src/pages/user/Main/components/ClubListSection/index.tsx
@@ -39,18 +39,22 @@ export const ClubListSection = ({
       <S.Grid>
         {filteredClubs.map((club: Club) => (
           <S.ClubItem onClick={() => navigate(`/clubs/${club.id}`)} key={club.id}>
-            <S.ClubCategoryText>
-              {club.category in engToKorCategory
-                ? engToKorCategory[club.category as ClubCategoryEng]
-                : '전체'}
-            </S.ClubCategoryText>
             <S.ClubNameText>{club.name}</S.ClubNameText>
             <S.ClubIntroduction>{club.shortIntroduction}</S.ClubIntroduction>
-            <S.RecruitStatusBox status={club.recruitStatus}>
-              <S.RecruitStatusText status={club.recruitStatus}>
-                {club.recruitStatus}
-              </S.RecruitStatusText>
-            </S.RecruitStatusBox>
+            <S.StatusContainer>
+              <S.CategoryStatusBox>
+                <S.CategoryStatusText>
+                  {club.category in engToKorCategory
+                    ? engToKorCategory[club.category as ClubCategoryEng]
+                    : '전체'}
+                </S.CategoryStatusText>
+              </S.CategoryStatusBox>
+              <S.RecruitStatusBox status={club.recruitStatus}>
+                <S.RecruitStatusText status={club.recruitStatus}>
+                  {club.recruitStatus}
+                </S.RecruitStatusText>
+              </S.RecruitStatusBox>
+            </S.StatusContainer>
           </S.ClubItem>
         ))}
       </S.Grid>


### PR DESCRIPTION
## 📝작업 내용

**메인페이지 카드 스타일 수정**
- 카테고리 영역 statusBox로 분리
<img width="294" height="173" alt="image" src="https://github.com/user-attachments/assets/59104189-c9c6-4e57-a5cb-004cae0bf264" />

**호버시 카드 크기 확대 스타일 추가**
<img width="320" height="184" alt="image" src="https://github.com/user-attachments/assets/dd2b0947-e75c-47ac-b694-a46ef2ac0fad" />

