### PR TITLE
[FEAT] 로그인 성공 시 전역상태 관리에 userID 추가

### DIFF
--- a/src/mocks/repositories/auth.ts
+++ b/src/mocks/repositories/auth.ts
@@ -23,6 +23,7 @@ export const authRepository = {
   getLoginSuccessResponse: (): LoginResponse => ({
     status: 'LOGIN_SUCCESS',
     accessToken: 'mock-access-token',
+    userId: 100,
     clubAndRoleList: mockClubListInfo,
   }),
 

--- a/src/pages/admin/Login/api/auth.test.ts
+++ b/src/pages/admin/Login/api/auth.test.ts
@@ -15,6 +15,7 @@ describe('auth API 테스트', () => {
   it('postAuthCode - 로그인 성공 응답 반환', async () => {
     const mockResponse: LoginResponse = {
       status: 'LOGIN_SUCCESS',
+      userId: 100,
       accessToken: 'mockAccessToken',
       clubAndRoleList: [],
     };

--- a/src/pages/admin/Login/api/auth.ts
+++ b/src/pages/admin/Login/api/auth.ts
@@ -5,7 +5,7 @@ import type { AxiosResponse } from 'axios';
 interface LoginSuccessResponse {
   status: 'LOGIN_SUCCESS';
   accessToken: string;
-  userId: string;
+  userId: number;
   clubAndRoleList: ClubMemberInfo[];
 }
 

--- a/src/pages/admin/Login/api/auth.ts
+++ b/src/pages/admin/Login/api/auth.ts
@@ -5,7 +5,7 @@ import type { AxiosResponse } from 'axios';
 interface LoginSuccessResponse {
   status: 'LOGIN_SUCCESS';
   accessToken: string;
-
+  userId: string;
   clubAndRoleList: ClubMemberInfo[];
 }
 

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -20,6 +20,7 @@ export type User = {
   role: (typeof ROLE)[keyof typeof ROLE] | null;
   clubId?: number;
   clubName?: string;
+  userId?: string;
   clubAndRoleList?: ClubMemberInfo[];
 };
 
@@ -79,8 +80,8 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
           case 'LOGIN_SUCCESS': {
             setAccessToken(response.accessToken);
 
-            const defaultClub = response.clubAndRoleList?.[0];
-            if (!defaultClub || !defaultClub.role) {
+            const defaultUserInfo = response.clubAndRoleList?.[0];
+            if (!defaultUserInfo || !defaultUserInfo.role) {
               const userData: User = {
                 role: ROLE.APPLICANT,
                 clubAndRoleList: response.clubAndRoleList,
@@ -89,11 +90,13 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
               break;
             }
 
-            const { role, clubId, clubName } = defaultClub;
+            const userId = response.userId;
+            const { role, clubId, clubName } = defaultUserInfo;
             const userData: User = {
               role,
               clubId,
               clubName,
+              userId,
               clubAndRoleList: response.clubAndRoleList,
             };
             setUser(userData);

--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -20,7 +20,7 @@ export type User = {
   role: (typeof ROLE)[keyof typeof ROLE] | null;
   clubId?: number;
   clubName?: string;
-  userId?: string;
+  userId?: number;
   clubAndRoleList?: ClubMemberInfo[];
 };
 


### PR DESCRIPTION

## 📝작업 내용

- 로그인 성공시 기존에 관리하던 데이터에 userId 추가(여러 동아리 운영 시에도 공통으로 쓰임)
-  전역 상태 관리를 위한 변수명 변경 **defaultClub** -> **defaultClubInfo** 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
userId type : stirng -> number 수정 

