### PR TITLE
[FEAT] 댓글 수정 권한 적용 및 별점 상시 표시

### DIFF
--- a/src/pages/admin/ApplicationDetail/Page.tsx
+++ b/src/pages/admin/ApplicationDetail/Page.tsx
@@ -1,4 +1,6 @@
 import { useParams } from 'react-router-dom';
+import { useAuth } from '@/providers/auth';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { ApplicantInfoSection } from './components/ApplicantInfoSection';
 import { ApplicantProfileSection } from './components/ApplicantProfileSection/index';
 import { ApplicantQuestionSection } from './components/ApplicationQuestionSection';
@@ -8,6 +10,7 @@ import * as S from './index.styled';
 
 export const ApplicationDetailPage = () => {
   const { clubId, applicantId } = useParams();
+  const { user } = useAuth();
 
   const {
     data: detailApplicants,
@@ -16,8 +19,12 @@ export const ApplicationDetailPage = () => {
     updateStatus,
   } = useDetailApplications(Number(clubId), Number(applicantId));
 
-  if (isLoading) return <div> 로딩중</div>;
+  if (isLoading || !user) return <LoadingSpinner />;
   if (error) return <div>에러발생 : {error.message}</div>;
+
+  if (user.clubId !== Number(clubId)) {
+    return <div>권한이 없습니다.</div>;
+  }
 
   return (
     <S.PageLayout>

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useComments } from '@/pages/admin/ApplicationDetail/hooks/useComments';
+import { useAuth } from '@/providers/auth';
 import { Text } from '@/shared/components/Text';
 import { CommentEditForm } from './CommentEditForm';
 import * as S from './CommentItem.styles';
@@ -10,6 +11,7 @@ type Props = Pick<Comment, 'author' | 'content' | 'createdAt' | 'commentId' | 'r
 
 export const CommentItem = ({ author, commentId, content, createdAt, rating }: Props) => {
   const { applicantId } = useParams();
+  const { user } = useAuth();
   const { deleteComment, updateComment } = useComments(Number(applicantId));
   const [isEditing, setIsEditing] = useState(false);
 
@@ -46,7 +48,7 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
             {createdAt}
           </Text>
         </S.AuthorInfo>
-        {!isEditing && (
+        {!isEditing && user?.userId === author.id && (
           <S.ButtonContainer>
             <S.ActionButton onClick={handleEdit}>수정</S.ActionButton>
             <S.Divider>|</S.Divider>


### PR DESCRIPTION

## 📝작업 내용

**권한 처리** 
자신이 작성하지 않은 댓글의 '수정'/'삭제' 버튼이 보이지 않도록 수정했습니다.

**UI 개선**
'수정' 버튼을 누르기 전, 댓글 조회 상태에서도 이전에 부여한 별점이 보이도록 개선했습니다.