### PR TITLE
[FEAT] 줄바꿈 문자 처리 및 화면 렌더링 개선

### DIFF
--- a/src/pages/admin/ApplicationDetail/components/ApplicationQuestionSection/index.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicationQuestionSection/index.tsx
@@ -9,7 +9,6 @@ type Props = {
 };
 
 export const ApplicantQuestionSection = ({ questionsAndAnswers }: Props) => {
-  console.log(questionsAndAnswers);
   return (
     <Wrapper>
       {questionsAndAnswers.map((item, index) => {

--- a/src/pages/user/ClubDetail/components/ClubDescriptionSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubDescriptionSection/index.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { SectionTitle } from '@/shared/components/SectionTitle';
+import { formatTextWithNewlines } from '@/utils/textFormatting';
 
 interface ClubDescriptionSectionProps {
   introductionOverview: string;
@@ -15,13 +16,13 @@ export const ClubDescriptionSection = ({
   return (
     <DescriptionContainer>
       <SectionTitle>동아리 소개</SectionTitle>
-      <DescriptionText>{introductionOverview}</DescriptionText>
+      <DescriptionText>{formatTextWithNewlines(introductionOverview)}</DescriptionText>
 
       <SectionTitle>활동 내용</SectionTitle>
-      <DescriptionText>{introductionActivity}</DescriptionText>
+      <DescriptionText>{formatTextWithNewlines(introductionActivity)}</DescriptionText>
 
       <SectionTitle>모집하는 사람</SectionTitle>
-      <DescriptionText>{introductionIdeal}</DescriptionText>
+      <DescriptionText>{formatTextWithNewlines(introductionIdeal)}</DescriptionText>
     </DescriptionContainer>
   );
 };

--- a/src/utils/textFormatting.tsx
+++ b/src/utils/textFormatting.tsx
@@ -1,3 +1,12 @@
+import { Fragment } from 'react';
+
 export const formatTextWithNewlines = (text: string) => {
-  return <span dangerouslySetInnerHTML={{ __html: text.replace(/\n/g, '<br/>') }} />;
+  return (text || '')
+    .split('\n')
+    .map((line, index, arr) => (
+      <Fragment key={index}>
+        {line}
+        {index < arr.length - 1 && <br />}
+      </Fragment>
+    ));
 };

--- a/src/utils/textFormatting.tsx
+++ b/src/utils/textFormatting.tsx
@@ -1,0 +1,3 @@
+export const formatTextWithNewlines = (text: string) => {
+  return <span dangerouslySetInnerHTML={{ __html: text.replace(/\n/g, '<br/>') }} />;
+};

--- a/src/utils/textFormatting.tsx
+++ b/src/utils/textFormatting.tsx
@@ -1,12 +1,10 @@
 import { Fragment } from 'react';
 
 export const formatTextWithNewlines = (text: string) => {
-  return (text || '')
-    .split('\n')
-    .map((line, index, arr) => (
-      <Fragment key={index}>
-        {line}
-        {index < arr.length - 1 && <br />}
-      </Fragment>
-    ));
+  return (text || '').split('\n').map((line, index, arr) => (
+    <Fragment key={index}>
+      {line}
+      {index < arr.length - 1 && <br />}
+    </Fragment>
+  ));
 };


### PR DESCRIPTION

## 📝작업 내용
- DB에 저장된 줄바꿈(\n)이 화면에 제대로 반영되지 않던 문제 수정
- 프론트에서` \n`을 `<br/>`로 변환하여 렌더링하도록 처리
- 백엔드 저장 방식은 그대로 유지하여 데이터 구조 변경 없음