### PR TITLE
[FIX] user와 selectedClub 변경시 네비게이션이 참조하도록 훅 추가 #372

### DIFF
--- a/src/shared/components/Navigation/hooks/useClubList.ts
+++ b/src/shared/components/Navigation/hooks/useClubList.ts
@@ -39,5 +39,19 @@ export const useClubList = () => {
 
   const selectedClub = clubs.find((club) => club.clubId === user?.clubId) ?? clubs[0] ?? null;
 
+  useEffect(() => {
+    if (user && selectedClub && user.role !== selectedClub.role) {
+      const updatedUser = {
+        ...user,
+        clubId: selectedClub.clubId ?? undefined,
+        clubName: selectedClub.clubName ?? '',
+        role: selectedClub.role ?? null,
+      };
+
+      setUser(updatedUser);
+      localStorage.setItem('user_data', JSON.stringify(updatedUser));
+    }
+  }, [user, selectedClub, setUser, clubs]);
+
   return { clubs, selectedClub, handleSelectClub };
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

close #372 

## 📝작업 내용

`src/shared/components/Navigation/hooks/useClubList.ts` 파일에 `useEffect` 로직을 추가하여, `selectedClub`이 결정되는 시점에 해당 동아리의 `clubId`와 **`role`** 정보를 `useAuth`의 `user` 상태에 즉시 반영하도록 수정했습니다.

1.  `useClubList` 내에 `useEffect` 훅 추가.
2.  `user`와 `selectedClub` 상태가 변경될 때, `selectedClub`의 `role`을 가져와 `user` 상태(`setUser`)와 로컬 스토리지에 업데이트.
3.  이로써 네비게이션 컴포넌트가 최신/정확한 Role을 참조하게 되어 올바른 메뉴 셋이 표시됨.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
