### PR TITLE
[FIX] 지원서 텍스트 오버플로우 및 '미처리 지원자' 에러 토스트 수정

### DIFF
--- a/src/pages/admin/ApplicationDetail/components/ApplicationQuestionSection/index.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicationQuestionSection/index.tsx
@@ -36,6 +36,7 @@ const Wrapper = styled.div(({ theme }) => ({
 
 const QuestionWrapper = styled.div(() => ({
   marginBottom: '40px',
+
   '&:last-child': {
     marginBottom: 0,
   },
@@ -50,4 +51,5 @@ const AnswerText = styled.div(({ theme }) => ({
   paddingLeft: '24px',
   lineHeight: '1.8',
   color: theme.colors.gray700,
+  wordBreak: 'break-word',
 }));

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/ApplicantStarRating.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/ApplicantStarRating.tsx
@@ -3,28 +3,35 @@ import { useState } from 'react';
 
 type ApplicantStarRatingProps = {
   rating: number;
-  onRatingChange: (rating: number) => void;
+  onRatingChange?: (rating: number) => void;
+  readOnly?: boolean;
 };
 
 const STAR_INDICES = [1, 2, 3, 4, 5];
 
-export const ApplicantStarRating = ({ rating, onRatingChange }: ApplicantStarRatingProps) => {
+export const ApplicantStarRating = ({
+  rating,
+  onRatingChange,
+  readOnly = false,
+}: ApplicantStarRatingProps) => {
   const [previewRating, setPreviewRating] = useState(0);
 
   const handleStarClick = (index: number, e: React.MouseEvent<HTMLDivElement>) => {
+    if (readOnly || !onRatingChange) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const isLeftHalf = e.clientX - rect.left < rect.width / 2;
     onRatingChange(isLeftHalf ? index - 0.5 : index);
   };
 
   const handleStarHover = (index: number, e: React.MouseEvent<HTMLDivElement>) => {
+    if (readOnly) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const isLeftHalf = e.clientX - rect.left < rect.width / 2;
     setPreviewRating(isLeftHalf ? index - 0.5 : index);
   };
 
   return (
-    <StarContainer onMouseLeave={() => setPreviewRating(0)}>
+    <StarContainer onMouseLeave={() => setPreviewRating(0)} readOnly={readOnly}>
       {STAR_INDICES.map((index) => {
         const currentRating = previewRating || rating;
         const fillPercentage =
@@ -45,17 +52,17 @@ export const ApplicantStarRating = ({ rating, onRatingChange }: ApplicantStarRat
   );
 };
 
-const StarContainer = styled.div({
+const StarContainer = styled.div<{ readOnly: boolean }>(({ readOnly }) => ({
   display: 'flex',
   gap: '0.125rem',
   alignItems: 'center',
-  cursor: 'pointer',
-});
+  cursor: readOnly ? 'default' : 'pointer',
+}));
 
 const StarWrapper = styled.div({
   position: 'relative',
   display: 'inline-block',
-  fontSize: '1.25rem',
+  fontSize: '1rem',
 });
 
 const StarEmpty = styled.div(({ theme }) => ({

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentEditForm.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentEditForm.tsx
@@ -1,57 +1,34 @@
-import { useForm, Controller } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import { Button } from '@/shared/components/Button';
 import { UnderlineTextareaField } from '@/shared/components/Form/TextAreaField/UnderlineTextareaField';
-import { Text } from '@/shared/components/Text';
 import * as S from './CommentItem.styles';
-import { ApplicantStarRating } from '../ApplicantStarRating';
 import type { CommentFormData } from '@/pages/admin/ApplicationDetail/types/comments';
 
 type CommentEditFormProps = {
   content: string;
-  rating: number;
-  onSave: (data: CommentFormData) => void;
+  onSave: (data: Pick<CommentFormData, 'content'>) => void;
   onCancel: () => void;
 };
 
-export const CommentEditForm = ({ content, rating, onSave, onCancel }: CommentEditFormProps) => {
+export const CommentEditForm = ({ content, onSave, onCancel }: CommentEditFormProps) => {
   const {
     register,
     handleSubmit,
     formState: { errors },
-    control,
     reset,
-  } = useForm<CommentFormData>({
+  } = useForm<Pick<CommentFormData, 'content'>>({
     defaultValues: {
       content,
-      rating,
     },
   });
 
   const handleCancel = () => {
-    reset({ content, rating });
+    reset({ content });
     onCancel();
   };
 
   return (
     <S.EditMode onSubmit={handleSubmit(onSave)}>
-      <Controller
-        name='rating'
-        control={control}
-        rules={{
-          required: '별점을 선택해주세요.',
-          min: { value: 1, message: '별점을 선택해주세요.' },
-        }}
-        render={({ field: { value, onChange }, fieldState: { error } }) => (
-          <>
-            <ApplicantStarRating rating={value} onRatingChange={onChange} />
-            {error && (
-              <Text size='xs' color='#fa342c'>
-                {error.message}
-              </Text>
-            )}
-          </>
-        )}
-      />
       <UnderlineTextareaField
         {...register('content', {
           required: '댓글을 입력해주세요.',

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.styles.ts
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.styles.ts
@@ -15,8 +15,16 @@ export const Header = styled.div({
 
 export const AuthorInfo = styled.div({
   display: 'flex',
+  justifyContent: 'space-between',
   alignItems: 'center',
-  gap: '0.75rem',
+  flex: 1,
+  marginRight: '1rem',
+});
+
+export const NameRatingGroup = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
 });
 
 export const ButtonContainer = styled.div({

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.tsx
@@ -1,5 +1,7 @@
+import styled from '@emotion/styled';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { ApplicantStarRating } from '@/pages/admin/ApplicationDetail/components/CommentSection/ApplicantStarRating'; // Import ApplicantStarRating
 import { useComments } from '@/pages/admin/ApplicationDetail/hooks/useComments';
 import { useAuth } from '@/providers/auth';
 import { Text } from '@/shared/components/Text';
@@ -44,6 +46,11 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
           <Text size={'base'} weight={'medium'}>
             {author.name}
           </Text>
+          {rating !== undefined && (
+            <RatingWrapper>
+              <ApplicantStarRating rating={rating} readOnly={true} />
+            </RatingWrapper>
+          )}
           <Text size={'xs'} weight={'medium'} color={'#616677'}>
             {createdAt}
           </Text>
@@ -72,3 +79,8 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
     </S.Layout>
   );
 };
+
+const RatingWrapper = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+});

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { ApplicantStarRating } from '@/pages/admin/ApplicationDetail/components/CommentSection/ApplicantStarRating'; // Import ApplicantStarRating
+import { ApplicantStarRating } from '@/pages/admin/ApplicationDetail/components/CommentSection/ApplicantStarRating';
 import { useComments } from '@/pages/admin/ApplicationDetail/hooks/useComments';
 import { useAuth } from '@/providers/auth';
 import { Text } from '@/shared/components/Text';
@@ -43,14 +43,16 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
     <S.Layout>
       <S.Header>
         <S.AuthorInfo>
-          <Text size={'base'} weight={'medium'}>
-            {author.name}
-          </Text>
-          {rating !== undefined && (
-            <RatingWrapper>
-              <ApplicantStarRating rating={rating} readOnly={true} />
-            </RatingWrapper>
-          )}
+          <S.NameRatingGroup>
+            <Text size={'base'} weight={'medium'}>
+              {author.name}
+            </Text>
+            {rating !== undefined && (
+              <RatingWrapper>
+                <ApplicantStarRating rating={rating} readOnly={true} />
+              </RatingWrapper>
+            )}
+          </S.NameRatingGroup>
           <Text size={'xs'} weight={'medium'} color={'#616677'}>
             {createdAt}
           </Text>

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.tsx
@@ -16,16 +16,18 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
   const { user } = useAuth();
   const { deleteComment, updateComment } = useComments(Number(applicantId));
   const [isEditing, setIsEditing] = useState(false);
+  const [editableRating, setEditableRating] = useState(rating);
 
   const handleEdit = () => {
     setIsEditing(true);
+    setEditableRating(rating);
   };
 
-  const handleSave = (data: CommentFormData) => {
+  const handleSave = (data: Pick<CommentFormData, 'content'>) => {
     const newComment = {
       commentId,
       content: data.content.trim(),
-      rating: data.rating,
+      rating: editableRating,
     };
     updateComment(newComment);
     setIsEditing(false);
@@ -33,6 +35,7 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
 
   const handleCancel = () => {
     setIsEditing(false);
+    setEditableRating(rating);
   };
 
   const handleDelete = () => {
@@ -49,30 +52,30 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
             </Text>
             {rating !== undefined && (
               <RatingWrapper>
-                <ApplicantStarRating rating={rating} readOnly={true} />
+                <ApplicantStarRating
+                  rating={isEditing ? editableRating : rating}
+                  readOnly={!isEditing}
+                  onRatingChange={setEditableRating}
+                />
               </RatingWrapper>
             )}
           </S.NameRatingGroup>
-          <Text size={'xs'} weight={'medium'} color={'#616677'}>
-            {createdAt}
-          </Text>
+          {!isEditing && user?.userId === author.id && (
+            <S.ButtonContainer>
+              <S.ActionButton onClick={handleEdit}>수정</S.ActionButton>
+              <S.Divider>|</S.Divider>
+              <S.ActionButton onClick={handleDelete}>삭제</S.ActionButton>
+            </S.ButtonContainer>
+          )}
         </S.AuthorInfo>
-        {!isEditing && user?.userId === author.id && (
-          <S.ButtonContainer>
-            <S.ActionButton onClick={handleEdit}>수정</S.ActionButton>
-            <S.Divider>|</S.Divider>
-            <S.ActionButton onClick={handleDelete}>삭제</S.ActionButton>
-          </S.ButtonContainer>
-        )}
+
+        <Text size={'xs'} weight={'medium'} color={'#616677'}>
+          {createdAt}
+        </Text>
       </S.Header>
 
       {isEditing ? (
-        <CommentEditForm
-          content={content}
-          rating={rating}
-          onSave={handleSave}
-          onCancel={handleCancel}
-        />
+        <CommentEditForm content={content} onSave={handleSave} onCancel={handleCancel} />
       ) : (
         <S.CommentContent>
           <Text size={'sm'}>{content}</Text>
@@ -83,6 +86,7 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
 };
 
 const RatingWrapper = styled.div({
+  marginLeft: '0.5rem',
   display: 'flex',
   alignItems: 'center',
 });

--- a/src/pages/admin/Dashboard/hooks/useSentMessage.ts
+++ b/src/pages/admin/Dashboard/hooks/useSentMessage.ts
@@ -1,7 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
+import { AxiosError } from 'axios';
 import { sentMessage } from '@/pages/admin/Dashboard/api/sentMessage';
+import { toast } from '@/utils/toast';
 import type { ApplicationStage } from '@/pages/admin/Dashboard/types/dashboard';
+
+interface BackendErrorResponse {
+  error_code: string;
+  message: string;
+}
 
 export const useSentMessage = (clubId: number, stage: ApplicationStage) => {
   const queryClient = useQueryClient();
@@ -12,8 +18,18 @@ export const useSentMessage = (clubId: number, stage: ApplicationStage) => {
       queryClient.invalidateQueries({ queryKey: ['applicants', clubId] });
       toast.success('결과가 전송되었습니다.');
     },
-    onError: () => {
-      toast.error('결과 전송이 실패하였습니다.');
+    onError: (error: AxiosError) => {
+      const backendError = error.response?.data as BackendErrorResponse;
+      const errorMessage = backendError?.message;
+      const errorCode = backendError?.error_code;
+
+      if (errorCode === 'PENDING_APPLICATION_EXISTS') {
+        toast.error(errorMessage);
+      } else if (errorMessage) {
+        toast.error(errorMessage);
+      } else {
+        toast.error('결과 전송이 실패하였습니다.');
+      }
     },
   });
 

--- a/src/pages/user/Main/components/ClubListSection/Club.styled.ts
+++ b/src/pages/user/Main/components/ClubListSection/Club.styled.ts
@@ -58,7 +58,7 @@ export const CategoryStatusBox = styled.div(({ theme }) => ({
   textAlign: 'center',
   padding: '6px 10px',
   borderRadius: '10rem',
-  backgroundColor: theme.colors.gray200,
+  border: `1px solid ${theme.colors.gray200}`,
 }));
 
 export const CategoryStatusText = styled.div(({ theme }) => ({

--- a/src/shared/components/Text/index.tsx
+++ b/src/shared/components/Text/index.tsx
@@ -26,7 +26,7 @@ const StyledText = styled.div<{ size: FontSizeKey; weight: FontWeightKey; color:
   font-size: ${({ theme, size }) => theme.font.size[size]};
   font-weight: ${({ theme, weight }) => theme.font.weight[weight]};
   color: ${({ color }) => color};
-  white-space: nowrap;
+  white-space: normal;
 `;
 
 type FontSizeKey = keyof typeof theme.font.size;


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #371 

## 📝작업 내용
### 1. 텍스트 오버플로우 문제 해결 
지원서 상세 페이지의 텍스트 답변을 감싸는 컨테이너 컴포넌트에 `wordBreak: 'break-word'`속성을 추가했습니다.  이를 통해 경계선을 벗어나는 긴 텍스트가 

<img width="1061" height="184" alt="image" src="https://github.com/user-attachments/assets/56e5ec5a-e8f6-4f6d-9b90-a54a5afbee94" />
자동으로 줄바꿈되어 텍스트 상자 내에 올바르게 표시되게 하였습니다.
<img width="808" height="199" alt="image" src="https://github.com/user-attachments/assets/d86d84a8-e109-4c02-9356-844f0470d82f" />

### 2. '미처리 지원자' 에러 토스트 메시지 수정 
지원자 관리 페이지의 최종 제출 API의 try...catch 에러 핸들링 로직을 수정했습니다. 
`catch` 블록에서 `error.response.data.message` 값을 확인하여, 백엔드에서 전달된 특정 에러 메시지를 토스트 알림으로 띄우도록 분기 처리했습니다. 
> 그 외의 일반적인 에러는 기존처럼 "제출 실패"로 표시됩니다.
