### PR TITLE
[REFACTOR] 인증 관련 타입(User, AuthContextType) 중복 제거 및 통합

### DIFF
--- a/src/providers/auth.tsx
+++ b/src/providers/auth.tsx
@@ -1,10 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
-import {
-  logoutUser,
-  postAuthCode,
-  type LoginResponse,
-  type ClubMemberInfo,
-} from '@/pages/admin/Login/api/auth';
+import { logoutUser, postAuthCode, type LoginResponse } from '@/pages/admin/Login/api/auth';
 import { postSignupForm, type RegisterSuccessResponse } from '@/pages/admin/Signup/api/signup';
 import {
   clearAuthData,
@@ -17,22 +12,7 @@ import {
 import { ROLE } from '@/types/navigation';
 import { handleAxiosError } from '@/utils/handleAxiosError';
 import type { SignupFormInputs } from '@/pages/admin/Signup/type/signup';
-
-export type User = {
-  role: (typeof ROLE)[keyof typeof ROLE] | null;
-  clubId?: number;
-  clubName?: string;
-  userId?: number;
-  clubAndRoleList?: ClubMemberInfo[];
-};
-
-export type AuthContextType = {
-  user: User | null;
-  setUser: (user: User) => void;
-  login: (code: string, signal: AbortSignal) => Promise<LoginResponse>;
-  logout: () => Promise<void>;
-  completeSignup: (signupFormValue: SignupFormInputs, temporaryToken: string) => void;
-};
+import type { User, AuthContextType } from '@/types/auth';
 
 const REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
 const LOGOUT_REDIRECT_URI = import.meta.env.VITE_LOGOUT_REDIRECT_URI;
@@ -141,7 +121,6 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       };
       setAccessToken(response.accessToken);
       setUser(userData);
-      // const userData: User = { role: ROLE.CLUB_MEMBER };
     },
     [setUser],
   );

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,10 +1,13 @@
 import type { Role } from './navigation';
-import type { LoginResponse } from '@/pages/admin/Login/api/auth';
+import type { LoginResponse, ClubMemberInfo } from '@/pages/admin/Login/api/auth';
+import type { SignupFormInputs } from '@/pages/admin/Signup/type/signup';
 
 export type User = {
   role: Role;
   clubId?: number;
   clubName?: string;
+  userId?: number;
+  clubAndRoleList?: ClubMemberInfo[];
 };
 
 export type AuthContextType = {
@@ -12,5 +15,5 @@ export type AuthContextType = {
   setUser: (user: User) => void;
   login: (code: string, signal: AbortSignal) => Promise<LoginResponse>;
   logout: () => Promise<void>;
-  completeSignup: (accessToken: string) => void;
+  completeSignup: (signupFormValue: SignupFormInputs, temporaryToken: string) => void;
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

close #377 

## 📝작업 내용

현재 프로젝트 내에 `User` 타입 정의가 여러 파일에 중복되어 존재합니다.

중복 정의된 `User` 타입은 잠재적인 타입 불일치 오류를 야기할 수 있어서 한 개로 통합사용하도록 구조를 수정하고 로그인을 통해 작동 확인을 하였습니다.

- 인증 관련 핵심 타입인 `User`와 `AuthContextType`을 한개의 파일에서만 정의하게 수정

- 두 가지 `User` 타입 중 더 많은 정보를 포함하고 있던 **타입 2 정의를 기준으로 통합**하여 타입의 명확성을 확보

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
