### PR TITLE
[STYLE] 메인페이지 모집 상태 표시의 불필요한 여백 제거

### DIFF
--- a/src/pages/user/Main/components/ClubListSection/Club.styled.ts
+++ b/src/pages/user/Main/components/ClubListSection/Club.styled.ts
@@ -31,15 +31,14 @@ export const StatusContainer = styled.div({
   gap: '8px',
   alignItems: 'center',
 });
-
 export const RecruitStatusBox = styled.div<Props>(({ theme, status }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   textAlign: 'center',
-  padding: '6px 10px',
+  padding: '6px 12px',
   borderRadius: '10rem',
-  width: 60,
+  whiteSpace: 'nowrap',
   backgroundColor: status === '모집중' ? theme.colors.primary : theme.colors.gray200,
 }));
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #313 

## 📝작업 내용
- 메인페이지 동아링 모집 상태 UI의 불필요한 여백 제거

### 스크린샷 
**변경전**
<img width="589" height="184" alt="스크린샷 2025-11-22 오전 9 22 58" src="https://github.com/user-attachments/assets/ae6287f0-0183-40c8-b252-b0a53db3cc14" />
**변경후**
<img width="604" height="193" alt="스크린샷 2025-11-22 오전 9 22 50" src="https://github.com/user-attachments/assets/2610aea3-ecde-4787-aec1-618cb9d07cde" />

## 💬리뷰 요구사항(선택)

