### PR TITLE
[STYLE] 지원자 목록 아이템 호버 효과 추가 및 UX 개선 (#397)

### DIFF
--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
@@ -10,6 +10,7 @@ export const ItemWrapper = styled.div`
 
   &:hover {
     cursor: pointer;
+    background-color: #f5f5f5;
   }
 
   & > p {

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
@@ -7,6 +7,7 @@ export const ItemWrapper = styled.div`
   gap: 2rem;
   align-items: center;
   padding: 1.5rem 0;
+  transition: background-color 0.2s ease;
 
   &:hover {
     cursor: pointer;

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
@@ -11,7 +11,7 @@ export const ItemWrapper = styled.div`
 
   &:hover {
     cursor: pointer;
-    background-color: #f5f5f5;
+    background-color: ${({ theme }) => theme.colors.gray00};
   }
 
   & > p {


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #397 

## 📝작업 내용

지원자 목록의 각 항목이 클릭 가능한지 알기 어렵다는 사용자 피드백을 수용하여, 리스트 아이템에 마우스 호버를 추가했습니다.
> 기존에는 마우스를 올려도 변화가 없어 클릭 가능 여부가 불분명했으나, 커서 모양 변경과 배경색 하이라이팅을 통해 사용자가 직관적으로 상세 페이지로 이동할 수 있음을 인지하도록 개선