### PR TITLE
[FEAT] 동아리 탐색 페이지 필터 및 배너 섹션 리디자인 #404

### DIFF
--- a/src/pages/user/Main/Page.tsx
+++ b/src/pages/user/Main/Page.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useCallback, useState } from 'react';
 import { BannerSection } from '@/pages/user/Main/components/BannerSection';
 import { ClubListSection } from '@/pages/user/Main/components/ClubListSection';
+import { FiltersSection } from '@/pages/user/Main/components/FiltersSection';
 import type { RecruitStatus } from './types/club';
 import type { ClubCategoryEng } from '@/shared/types/club';
 
@@ -20,12 +21,12 @@ export const MainPage = () => {
 
   return (
     <Container>
-      <BannerSection
+      <BannerSection onChangeSearch={(s: string) => setSearchText(s)} />
+      <FiltersSection
         selectedCategory={categoryFilter}
         selectedRecruitStatus={recruitStatus}
         onSelectCategory={handleCategoryFilter}
         onSelectStatus={handleRecruitStatusFilter}
-        onChangeSearch={(s: string) => setSearchText(s)}
       />
       <ClubListSection
         categoryFilter={categoryFilter}

--- a/src/pages/user/Main/components/BannerSection/Banner.styled.ts
+++ b/src/pages/user/Main/components/BannerSection/Banner.styled.ts
@@ -9,13 +9,13 @@ export const BannerWrapper = styled.div(({ theme }) => ({
   alignItems: 'flex-start',
   width: '100%',
   maxWidth: '100vw',
-  height: 400,
+  height: '300px',
   gap: '16px',
   boxSizing: 'border-box',
   backgroundColor: theme.colors.bg,
 
   [`@media (max-width: ${theme.breakpoints.web})`]: {
-    minHeight: 300,
+    minHeight: 240,
     gap: 24,
     zIndex: 1000,
   },

--- a/src/pages/user/Main/components/BannerSection/BannerText.styled.ts
+++ b/src/pages/user/Main/components/BannerSection/BannerText.styled.ts
@@ -7,6 +7,7 @@ export const BannerTextWrapper = styled.div(({ theme }) => ({
   gap: '12px',
   position: 'relative',
   zIndex: 2,
+  marginTop: '88px',
 
   [`@media(max-width: ${theme.breakpoints.web})`]: {
     gap: '10px',
@@ -33,9 +34,9 @@ export const HeaderText = styled.h2(({ theme }) => ({
 
 export const SubText = styled.p(({ theme }) => ({
   fontSize: theme.font.size.lg,
-  fontWeight: theme.font.weight.regular,
+  fontWeight: theme.font.weight.medium,
   color: 'rgba(255, 255, 255, 0.9)',
-  textShadow: '0 2px 5px rgba(0, 0, 0, 0.3)',
+  textShadow: '0 2px 5px rgba(0, 0, 0, 0.5)',
   margin: 0,
   lineHeight: 1.5,
 }));

--- a/src/pages/user/Main/components/BannerSection/ClubSearchInput.tsx
+++ b/src/pages/user/Main/components/BannerSection/ClubSearchInput.tsx
@@ -40,14 +40,14 @@ const Input = styled.input(({ theme }) => ({
 }));
 
 const SearchIcon = styled(FiSearch)(({ theme }) => ({
-  marginLeft: '12px',
+  marginRight: '12px', // marginLeft → marginRight
   fontSize: '20px',
   color: theme.colors.textSecondary,
   flexShrink: 0,
 
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
     fontSize: '18px',
-    marginLeft: '8px',
+    marginRight: '8px', // marginLeft → marginRight
   },
 }));
 
@@ -63,8 +63,8 @@ export function ClubSearchInput({ onChangeSearch }: Props) {
 
   return (
     <InputWrapper>
-      <Input onChange={handleChange} placeholder='동아리를 검색하세요.' />
       <SearchIcon />
+      <Input onChange={handleChange} placeholder='동아리를 검색하세요.' />
     </InputWrapper>
   );
 }

--- a/src/pages/user/Main/components/BannerSection/ClubSearchInput.tsx
+++ b/src/pages/user/Main/components/BannerSection/ClubSearchInput.tsx
@@ -5,24 +5,21 @@ import { FiSearch } from 'react-icons/fi';
 const InputWrapper = styled.div(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  width: '400px',
-  maxWidth: '100%',
-  border: `1px solid ${theme.colors.border}`,
-  borderRadius: theme.radius.md,
-  padding: '10px 10px',
+  width: '100%',
+  border: 'none',
+  borderRadius: '50px',
+  padding: '16px 28px',
   backgroundColor: theme.colors.bg,
   boxSizing: 'border-box',
-  boxShadow: '0 2px 6px rgba(0,0,0,0.1)',
+  boxShadow: '0 8px 24px rgba(0, 0, 0, 0.15)',
 
   [`@media (max-width: ${theme.breakpoints.web})`]: {
-    width: 300,
-    maxWidth: '100%',
+    padding: '14px 24px',
   },
 
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    gap: 12,
-    width: '100%',
-    padding: '8px 12px',
+    padding: '12px 20px',
+    borderRadius: '40px',
   },
 }));
 
@@ -31,12 +28,28 @@ const Input = styled.input(({ theme }) => ({
   border: 'none',
   outline: 'none',
   fontSize: theme.font.size.base,
+  backgroundColor: 'transparent',
+
+  '::placeholder': {
+    color: theme.colors.textSecondary,
+  },
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    fontSize: theme.font.size.sm,
+  },
 }));
 
-const SearchIcon = styled(FiSearch)({
-  marginRight: '8px',
-  color: '#666',
-});
+const SearchIcon = styled(FiSearch)(({ theme }) => ({
+  marginLeft: '12px',
+  fontSize: '20px',
+  color: theme.colors.textSecondary,
+  flexShrink: 0,
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    fontSize: '18px',
+    marginLeft: '8px',
+  },
+}));
 
 type Props = {
   onChangeSearch: (s: string) => void;

--- a/src/pages/user/Main/components/BannerSection/index.tsx
+++ b/src/pages/user/Main/components/BannerSection/index.tsx
@@ -55,7 +55,6 @@ export const SearchContainer = styled.div(({ theme }) => ({
   zIndex: 10,
   width: '700px',
   maxWidth: '90%',
-  margin: '0 auto',
   marginLeft: 'calc((100% - 1200px) / 2 + 1.5rem)',
   boxSizing: 'border-box',
 

--- a/src/pages/user/Main/components/BannerSection/index.tsx
+++ b/src/pages/user/Main/components/BannerSection/index.tsx
@@ -55,7 +55,7 @@ export const SearchContainer = styled.div(({ theme }) => ({
   zIndex: 10,
   width: '700px',
   maxWidth: '90%',
-  marginLeft: 'calc((100% - 1200px) / 2 + 1.5rem)',
+  marginLeft: 'max(20px, calc((100vw - 1200px) / 2))',
   boxSizing: 'border-box',
 
   [`@media (max-width: ${theme.breakpoints.web})`]: {

--- a/src/pages/user/Main/components/BannerSection/index.tsx
+++ b/src/pages/user/Main/components/BannerSection/index.tsx
@@ -1,54 +1,14 @@
 import styled from '@emotion/styled';
-import { useSearchParams } from 'react-router-dom';
-import { CLUB_CATEGORY } from '@/app/constants/clubCategory';
 import { ClubSearchInput } from '@/pages/user/Main/components/BannerSection/ClubSearchInput.tsx';
-import { CLUB_RECRUIT_STATUS_KOR, type RecruitStatus } from '@/pages/user/Main/types/club.ts';
-import { Dropdown } from '@/shared/components/Dropdown/index.tsx';
-import {
-  engToKorCategory,
-  korToEngCategory,
-  korToEngRecruitStatus,
-} from '@/shared/utils/formatting.ts';
 import * as S from './Banner.styled.ts';
 import { BannerSlideshow } from './BannerSlideshow';
 import * as B from './BannerText.styled.ts';
-import type { ClubCategory, ClubCategoryEng } from '@/shared/types/club';
 
-type FilterRecruitStatus = RecruitStatus | '전체';
 type Props = {
   onChangeSearch: (searchText: string) => void;
-  onSelectCategory: (category: ClubCategoryEng) => void;
-  onSelectStatus: (recruitStatus: FilterRecruitStatus) => void;
-  selectedCategory: ClubCategoryEng;
-  selectedRecruitStatus: RecruitStatus | undefined;
 };
 
-export const BannerSection = ({
-  onChangeSearch,
-  onSelectCategory,
-  onSelectStatus,
-  selectedCategory,
-  selectedRecruitStatus,
-}: Props) => {
-  const [filterParams, setFilterParams] = useSearchParams();
-
-  const handleCategoryClick = (newCategory: ClubCategory) => {
-    const engCategory = korToEngCategory[newCategory];
-    onSelectCategory(engCategory);
-    filterParams.set('category', engCategory);
-    setFilterParams(filterParams);
-  };
-
-  const handleRecruitStatusClick = (status: RecruitStatus) => {
-    onSelectStatus(status);
-    if (status === '전체') {
-      filterParams.delete('status');
-    } else {
-      filterParams.set('status', korToEngRecruitStatus[status]);
-    }
-    setFilterParams(filterParams);
-  };
-
+export const BannerSection = ({ onChangeSearch }: Props) => {
   return (
     <S.BannerWrapper>
       <BannerSlideshow />
@@ -58,25 +18,11 @@ export const BannerSection = ({
           <B.HeaderText>함께할 사람이 있는 곳, 동아리움.</B.HeaderText>
           <B.SubText>관심 있는 동아리를 찾고, 참여해보세요.</B.SubText>
         </B.BannerTextWrapper>
-
-        <SearchContainer>
-          <ClubSearchInput onChangeSearch={onChangeSearch} />
-          <DropdownWrapper>
-            <Dropdown
-              placeholder='동아리 카테고리'
-              value={engToKorCategory[selectedCategory]}
-              options={CLUB_CATEGORY}
-              onSelect={handleCategoryClick}
-            />
-            <Dropdown
-              placeholder='모집 상태'
-              value={selectedRecruitStatus === '전체' ? undefined : selectedRecruitStatus}
-              options={['전체', ...CLUB_RECRUIT_STATUS_KOR] as RecruitStatus[]}
-              onSelect={handleRecruitStatusClick}
-            />
-          </DropdownWrapper>
-        </SearchContainer>
       </ContentContainer>
+
+      <SearchContainer>
+        <ClubSearchInput onChangeSearch={onChangeSearch} />
+      </SearchContainer>
     </S.BannerWrapper>
   );
 };
@@ -89,50 +35,40 @@ const ContentContainer = styled.div(({ theme }) => ({
   margin: '0 auto',
   display: 'flex',
   flexDirection: 'column',
-  gap: '16px',
+  gap: '24px',
   padding: '0 1.5rem',
   boxSizing: 'border-box',
+  paddingBottom: '60px',
 
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
     padding: '0 1rem',
-    gap: '12px',
+    paddingBottom: '50px',
+    gap: '16px',
   },
 }));
 
 export const SearchContainer = styled.div(({ theme }) => ({
-  position: 'relative',
+  position: 'absolute',
+  bottom: '-30px',
+  left: '0',
+  right: '0',
   zIndex: 10,
-  display: 'flex',
-  flexDirection: 'row',
-  justifyContent: 'flex-start',
-  alignItems: 'center',
-  width: '100%',
-  gap: 16,
+  width: '700px',
+  maxWidth: '90%',
+  margin: '0 auto',
+  marginLeft: 'calc((100% - 1200px) / 2 + 1.5rem)',
   boxSizing: 'border-box',
-  opacity: 1,
 
-  [`@media(max-width: ${theme.breakpoints.mobile})`]: {
-    flexDirection: 'column',
-    gap: 12,
-    width: '100%',
-    '& > *': {
-      width: '100%',
-      boxSizing: 'border-box',
-    },
+  [`@media (max-width: ${theme.breakpoints.web})`]: {
+    width: '600px',
+    bottom: '-25px',
+    marginLeft: '1.5rem',
   },
-}));
 
-export const DropdownWrapper = styled.div(({ theme }) => ({
-  display: 'flex',
-  flexDirection: 'row',
-  gap: 16,
-  zIndex: 3,
-
-  [`@media(max-width: ${theme.breakpoints.mobile})`]: {
-    width: '100%',
-    gap: 12,
-    '& > *': {
-      width: 'calc(50% - 6px)',
-    },
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    width: 'calc(100% - 2rem)',
+    bottom: '-25px',
+    marginLeft: '1rem',
+    marginRight: '1rem',
   },
 }));

--- a/src/pages/user/Main/components/FiltersSection/index.styled.ts
+++ b/src/pages/user/Main/components/FiltersSection/index.styled.ts
@@ -39,7 +39,7 @@ export const TabsWrapper = styled.div(({ theme }) => ({
     gap: '8px',
     width: '100%',
   },
-  '@media (max-width: 409px)': {
+  ['@media (max-width: 409px)']: {
     gap: '6px',
   },
 }));
@@ -83,11 +83,11 @@ export const TabButton = styled.button<TabButtonProps>(({ theme, isSelected }) =
     transform: 'scale(0.98)',
   },
 
-  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+  [`@media (max-width: 504px)`]: {
     padding: '8px 16px',
     fontSize: theme.font.size.sm,
   },
-  '@media (max-width: 400px)': {
+  ['@media (max-width: 400px)']: {
     padding: '8px 11px',
     fontSize: theme.font.size.sm,
   },

--- a/src/pages/user/Main/components/FiltersSection/index.styled.ts
+++ b/src/pages/user/Main/components/FiltersSection/index.styled.ts
@@ -39,6 +39,9 @@ export const TabsWrapper = styled.div(({ theme }) => ({
     gap: '8px',
     width: '100%',
   },
+  '@media (max-width: 409px)': {
+    gap: '6px',
+  },
 }));
 
 type TabButtonProps = {
@@ -82,6 +85,10 @@ export const TabButton = styled.button<TabButtonProps>(({ theme, isSelected }) =
 
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
     padding: '8px 16px',
+    fontSize: theme.font.size.sm,
+  },
+  '@media (max-width: 400px)': {
+    padding: '8px 11px',
     fontSize: theme.font.size.sm,
   },
 }));

--- a/src/pages/user/Main/components/FiltersSection/index.styled.ts
+++ b/src/pages/user/Main/components/FiltersSection/index.styled.ts
@@ -16,18 +16,18 @@ export const FilterTabsContainer = styled.div(({ theme }) => ({
   },
 }));
 
-export const FilterRow = styled.div(({ theme }) => ({
+export const FilterRow = styled.div({
   display: 'flex',
   alignItems: 'center',
   width: '100%',
   gap: '48px',
 
-  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+  '@media (max-width: 672px)': {
     flexDirection: 'column',
     alignItems: 'flex-start',
     gap: '16px',
   },
-}));
+});
 
 export const TabsWrapper = styled.div(({ theme }) => ({
   display: 'flex',

--- a/src/pages/user/Main/components/FiltersSection/index.styled.ts
+++ b/src/pages/user/Main/components/FiltersSection/index.styled.ts
@@ -1,0 +1,167 @@
+import styled from '@emotion/styled';
+
+export const FilterTabsContainer = styled.div(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+  width: '100%',
+  maxWidth: '1200px',
+  margin: '0 auto',
+  padding: '32px 1.5rem 24px 1.5rem',
+  boxSizing: 'border-box',
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    gap: '12px',
+    padding: '32px 1rem 20px 1rem',
+  },
+}));
+
+export const FilterRow = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  width: '100%',
+  gap: '48px',
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    gap: '16px',
+  },
+}));
+
+export const TabsWrapper = styled.div(({ theme }) => ({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '10px',
+  alignItems: 'center',
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    gap: '8px',
+    width: '100%',
+  },
+}));
+
+type TabButtonProps = {
+  isSelected: boolean;
+};
+
+export const TabButton = styled.button<TabButtonProps>(({ theme, isSelected }) => ({
+  position: 'relative',
+  padding: '10px 20px',
+  backgroundColor: 'transparent',
+  border: 'none',
+  color: isSelected ? theme.colors.textPrimary : theme.colors.textSecondary,
+  fontSize: theme.font.size.base,
+  fontWeight: isSelected ? theme.font.weight.medium : theme.font.weight.regular,
+  cursor: 'pointer',
+  transition: 'all 0.2s ease',
+  whiteSpace: 'nowrap',
+  boxSizing: 'border-box',
+
+  '&::after': isSelected
+    ? {
+        content: '""',
+        position: 'absolute',
+        bottom: '0',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        width: '80%',
+        height: '3px',
+        backgroundColor: theme.colors.primary,
+        borderRadius: '2px',
+      }
+    : {},
+
+  '&:hover': {
+    color: theme.colors.primary,
+  },
+
+  '&:active': {
+    transform: 'scale(0.98)',
+  },
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    padding: '8px 16px',
+    fontSize: theme.font.size.sm,
+  },
+}));
+
+export const DropdownWrapper = styled.div({
+  position: 'relative',
+  minWidth: '120px',
+  flexShrink: 0,
+});
+
+export const DropdownButton = styled.button(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+  padding: '7px 9px',
+  backgroundColor: theme.colors.bg,
+  border: `1.5px solid ${theme.colors.border}`,
+  borderRadius: theme.radius.md,
+  fontSize: theme.font.size.xs,
+  fontWeight: theme.font.weight.medium,
+  color: theme.colors.gray400,
+  cursor: 'pointer',
+  transition: 'all 0.2s ease',
+  gap: '8px',
+
+  '&:hover': {
+    borderColor: theme.colors.gray300,
+  },
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    fontSize: theme.font.size.xs,
+    padding: '8px 12px',
+  },
+}));
+
+type DropdownIconProps = {
+  isOpen: boolean;
+};
+
+export const DropdownIcon = styled.span<DropdownIconProps>(({ theme, isOpen }) => ({
+  fontSize: '10px',
+  transition: 'transform 0.2s ease',
+  transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+  color: theme.colors.gray400,
+}));
+
+export const DropdownMenu = styled.div(({ theme }) => ({
+  position: 'absolute',
+  top: 'calc(100% + 4px)',
+  left: 0,
+  right: 0,
+  backgroundColor: theme.colors.bg,
+  border: `1.5px solid ${theme.colors.gray200}`,
+  borderRadius: theme.radius.md,
+  boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+  zIndex: 100,
+  overflow: 'hidden',
+}));
+
+type DropdownItemProps = {
+  isSelected: boolean;
+};
+
+export const DropdownItem = styled.div<DropdownItemProps>(({ theme, isSelected }) => ({
+  padding: '10px 16px',
+  fontSize: theme.font.size.sm,
+  fontWeight: isSelected ? theme.font.weight.medium : theme.font.weight.regular,
+  color: isSelected ? theme.colors.primary : theme.colors.textPrimary,
+  backgroundColor: isSelected ? theme.colors.primary100 : 'transparent',
+  cursor: 'pointer',
+  transition: 'all 0.2s ease',
+
+  '&:hover': {
+    backgroundColor: theme.colors.bgGreen,
+    color: theme.colors.primary,
+  },
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    fontSize: theme.font.size.xs,
+    padding: '8px 12px',
+  },
+}));

--- a/src/pages/user/Main/components/FiltersSection/index.tsx
+++ b/src/pages/user/Main/components/FiltersSection/index.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { CLUB_CATEGORY } from '@/app/constants/clubCategory';
+import { CLUB_RECRUIT_STATUS_KOR, type RecruitStatus } from '@/pages/user/Main/types/club.ts';
+import {
+  engToKorCategory,
+  korToEngCategory,
+  korToEngRecruitStatus,
+} from '@/shared/utils/formatting.ts';
+import * as S from './index.styled';
+import type { ClubCategory, ClubCategoryEng } from '@/shared/types/club';
+
+type FilterRecruitStatus = RecruitStatus | '전체';
+
+type FiltersSectionProps = {
+  selectedCategory: ClubCategoryEng;
+  selectedRecruitStatus: RecruitStatus | undefined;
+  onSelectCategory: (category: ClubCategoryEng) => void;
+  onSelectStatus: (recruitStatus: FilterRecruitStatus) => void;
+};
+
+export const FiltersSection = ({
+  selectedCategory,
+  selectedRecruitStatus,
+  onSelectCategory,
+  onSelectStatus,
+}: FiltersSectionProps) => {
+  const [filterParams, setFilterParams] = useSearchParams();
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const handleCategoryClick = (newCategory: ClubCategory) => {
+    const engCategory = korToEngCategory[newCategory];
+    onSelectCategory(engCategory);
+    filterParams.set('category', engCategory);
+    setFilterParams(filterParams);
+  };
+
+  const handleRecruitStatusClick = (status: FilterRecruitStatus) => {
+    onSelectStatus(status);
+    if (status === '전체') {
+      filterParams.delete('status');
+    } else {
+      filterParams.set('status', korToEngRecruitStatus[status as RecruitStatus]);
+    }
+    setFilterParams(filterParams);
+    setIsDropdownOpen(false);
+  };
+
+  return (
+    <S.FilterTabsContainer>
+      <S.FilterRow>
+        <S.TabsWrapper>
+          {CLUB_CATEGORY.map((category) => (
+            <S.TabButton
+              key={category}
+              isSelected={engToKorCategory[selectedCategory] === category}
+              onClick={() => handleCategoryClick(category)}
+            >
+              {category}
+            </S.TabButton>
+          ))}
+        </S.TabsWrapper>
+
+        <S.DropdownWrapper>
+          <S.DropdownButton onClick={() => setIsDropdownOpen(!isDropdownOpen)}>
+            {selectedRecruitStatus || '전체'}
+            <S.DropdownIcon isOpen={isDropdownOpen}>▼</S.DropdownIcon>
+          </S.DropdownButton>
+
+          {isDropdownOpen && (
+            <S.DropdownMenu>
+              {['전체', ...CLUB_RECRUIT_STATUS_KOR].map((status) => (
+                <S.DropdownItem
+                  key={status}
+                  isSelected={(selectedRecruitStatus || '전체') === status}
+                  onClick={() => handleRecruitStatusClick(status as FilterRecruitStatus)}
+                >
+                  {status}
+                </S.DropdownItem>
+              ))}
+            </S.DropdownMenu>
+          )}
+        </S.DropdownWrapper>
+      </S.FilterRow>
+    </S.FilterTabsContainer>
+  );
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #404 

## 📝작업 내용

> 이번 PR에서 작업한 내용

1. 필터 섹션 UI 개선

- 카테고리 필터: 배너 위 큰 드롭다운 → 탭 형태로 변경 (선택 시 하단 밑줄 표시)
- 모집 상태 필터: 배너 위 큰 드롭다운 → 작은 드롭다운으로 변경
- 두 필터를 수평 배치 (모바일에서는 세로 스택)

2. 배너 검색창 위치 조정

- 배너 하단 50% 오버랩 배치로 변경
- pill 스타일 적용 (border-radius: 50px)
- 우측 드롭다운 삭제로 인한 검색창 너비 확대 (700px)

3. 배너 크기 최적화

- 배너 높이 크게 축소
- 텍스트 크기 및 여백 조정으로 리디자인에 맞는 균형 개선

4. 반응형 리디자인 적용 체크
- 태블릿, 모바일 화면에서의 비율 및 디자인

### 스크린샷 (선택)

- 리디자인 전 기존 메인페이지
<img width="1470" height="799" alt="스크린샷 2026-01-11 오후 6 13 25" src="https://github.com/user-attachments/assets/4a24ddba-eb91-48e2-8412-db234252a6a6" />


- 리디자인 후 메인페이지
<img width="1470" height="799" alt="스크린샷 2026-01-11 오후 6 13 29" src="https://github.com/user-attachments/assets/b6ee3cf0-68ab-497c-883f-b678b9094c7f" />

- 반응형
<img width="300" height="744" alt="스크린샷 2026-01-11 오후 6 21 52" src="https://github.com/user-attachments/assets/a6d31d52-4ec7-44cb-9164-72ea76ef8499" />
<img width="250" height="759" alt="스크린샷 2026-01-11 오후 6 22 06" src="https://github.com/user-attachments/assets/e84a2408-3051-42ed-9668-6aa1b3010f53" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
