### PR TITLE
[STYLE] 지원자 상태 UI 개선 및 페이지 레이아웃 조정(#398)

### DIFF
--- a/src/app/mocks/client.ts
+++ b/src/app/mocks/client.ts
@@ -4,6 +4,7 @@ import { clubHandlers } from '@/app/mocks/handler/club';
 import { noticeHandlers } from '@/app/mocks/handler/notice';
 import { applyFormHandlers } from './handler/applyForm';
 import { authHandlers } from './handler/auth';
+import { dashboardHandlers } from './handler/dashboard';
 
 export const client = setupWorker(
   ...clubHandlers,
@@ -11,4 +12,5 @@ export const client = setupWorker(
   ...noticeHandlers,
   ...applyFormHandlers,
   ...authHandlers,
+  ...dashboardHandlers,
 );

--- a/src/app/mocks/handler/dashboard.ts
+++ b/src/app/mocks/handler/dashboard.ts
@@ -1,57 +1,23 @@
 import { http, HttpResponse } from 'msw';
-import type {
-  DashboardSummary,
-  ApplicantsApiResponse,
-} from '@/pages/admin/Dashboard/types/dashboard';
+import { dashboardRepository } from '@/app/mocks/repositories/dashboard';
+
+const getDashboardSummaryResolver = () => {
+  const summary = dashboardRepository.getDashboardSummary();
+  return HttpResponse.json(summary, { status: 200 });
+};
+
+const getApplicantsResolver = () => {
+  const applicants = dashboardRepository.getApplicants();
+  return HttpResponse.json(applicants, { status: 200 });
+};
 
 export const dashboardHandlers = [
-  // 대시보드 요약 정보
-  http.get('/api/clubs/:clubId/dashboard', () => {
-    const response: DashboardSummary = {
-      totalApplicantCount: 45,
-      pendingApplicationCount: 12,
-      startDay: '2024-03-01',
-      endDay: '2024-03-31',
-    };
-
-    return HttpResponse.json(response, { status: 200 });
-  }),
-
-  // 지원자 목록 (서류/면접)
-  http.get('/api/clubs/:clubId/dashboard/applicants', () => {
-    const response: ApplicantsApiResponse = {
-      applicants: [
-        {
-          applicantId: 1,
-          name: '김철수',
-          studentId: '202401',
-          department: '컴퓨터공학과',
-          phoneNumber: '010-1234-5678',
-          email: 'test1@example.com',
-          status: 'PENDING',
-        },
-        {
-          applicantId: 2,
-          name: '이영희',
-          studentId: '202402',
-          department: '경영학과',
-          phoneNumber: '010-2345-6789',
-          email: 'test2@example.com',
-          status: 'APPROVED',
-        },
-        {
-          applicantId: 3,
-          name: '박민수',
-          studentId: '202403',
-          department: '전자공학과',
-          phoneNumber: '010-3456-7890',
-          email: 'test3@example.com',
-          status: 'REJECTED',
-        },
-      ],
-      message: null,
-    };
-
-    return HttpResponse.json(response, { status: 200 });
-  }),
+  http.get(
+    import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/dashboard',
+    getDashboardSummaryResolver,
+  ),
+  http.get(
+    import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/dashboard/applicants',
+    getApplicantsResolver,
+  ),
 ];

--- a/src/app/mocks/handler/dashboard.ts
+++ b/src/app/mocks/handler/dashboard.ts
@@ -1,0 +1,57 @@
+import { http, HttpResponse } from 'msw';
+import type {
+  DashboardSummary,
+  ApplicantsApiResponse,
+} from '@/pages/admin/Dashboard/types/dashboard';
+
+export const dashboardHandlers = [
+  // 대시보드 요약 정보
+  http.get('/api/clubs/:clubId/dashboard', () => {
+    const response: DashboardSummary = {
+      totalApplicantCount: 45,
+      pendingApplicationCount: 12,
+      startDay: '2024-03-01',
+      endDay: '2024-03-31',
+    };
+
+    return HttpResponse.json(response, { status: 200 });
+  }),
+
+  // 지원자 목록 (서류/면접)
+  http.get('/api/clubs/:clubId/dashboard/applicants', () => {
+    const response: ApplicantsApiResponse = {
+      applicants: [
+        {
+          applicantId: 1,
+          name: '김철수',
+          studentId: '202401',
+          department: '컴퓨터공학과',
+          phoneNumber: '010-1234-5678',
+          email: 'test1@example.com',
+          status: 'PENDING',
+        },
+        {
+          applicantId: 2,
+          name: '이영희',
+          studentId: '202402',
+          department: '경영학과',
+          phoneNumber: '010-2345-6789',
+          email: 'test2@example.com',
+          status: 'APPROVED',
+        },
+        {
+          applicantId: 3,
+          name: '박민수',
+          studentId: '202403',
+          department: '전자공학과',
+          phoneNumber: '010-3456-7890',
+          email: 'test3@example.com',
+          status: 'REJECTED',
+        },
+      ],
+      message: null,
+    };
+
+    return HttpResponse.json(response, { status: 200 });
+  }),
+];

--- a/src/app/mocks/repositories/dashboard.ts
+++ b/src/app/mocks/repositories/dashboard.ts
@@ -1,0 +1,55 @@
+import type {
+  DashboardSummary,
+  ApplicantsApiResponse,
+  ApplicantData,
+} from '@/pages/admin/Dashboard/types/dashboard';
+
+const MOCK_DASHBOARD_SUMMARY: DashboardSummary = {
+  totalApplicantCount: 45,
+  pendingApplicationCount: 12,
+  startDay: '2024-03-01',
+  endDay: '2024-03-31',
+};
+
+const MOCK_APPLICANTS: ApplicantData[] = [
+  {
+    applicantId: 1,
+    name: '김철수',
+    studentId: '202401',
+    department: '컴퓨터공학과',
+    phoneNumber: '010-1234-5678',
+    email: 'test1@example.com',
+    status: 'PENDING',
+  },
+  {
+    applicantId: 2,
+    name: '이영희',
+    studentId: '202402',
+    department: '경영학과',
+    phoneNumber: '010-2345-6789',
+    email: 'test2@example.com',
+    status: 'APPROVED',
+  },
+  {
+    applicantId: 3,
+    name: '박민수',
+    studentId: '202403',
+    department: '전자공학과',
+    phoneNumber: '010-3456-7890',
+    email: 'test3@example.com',
+    status: 'REJECTED',
+  },
+];
+
+export const dashboardRepository = {
+  getDashboardSummary: (): DashboardSummary => {
+    return MOCK_DASHBOARD_SUMMARY;
+  },
+
+  getApplicants: (): ApplicantsApiResponse => {
+    return {
+      applicants: MOCK_APPLICANTS,
+      message: null,
+    };
+  },
+};

--- a/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStatusButton.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStatusButton.tsx
@@ -21,32 +21,44 @@ const Wrapper = styled.button<Pick<Props, 'selected' | 'label'>>(({ theme, selec
     합격: {
       backgroundColor: theme.colors.primary100,
       color: theme.colors.primary800,
+      border: `2px solid ${theme.colors.primary800}`,
     },
     불합격: {
       backgroundColor: theme.colors.red100,
       color: theme.colors.red600,
+      border: `2px solid ${theme.colors.red600}`,
     },
     미정: {
       backgroundColor: theme.colors.gray200,
       color: theme.colors.gray700,
+      border: `2px solid ${theme.colors.gray700}`,
     },
   };
 
   const defaultStyle = {
     backgroundColor: theme.colors.gray100,
     color: theme.colors.gray600,
+    border: `2px solid ${theme.colors.gray300}`,
   };
 
   const appliedStyle = selected ? statusStyles[label] : defaultStyle;
 
   return {
-    border: 'none',
-    padding: '0.4rem 1.7rem',
+    padding: '0.3rem 1.5rem',
     cursor: 'pointer',
-    fontSize: theme.font.size.sm,
+    fontSize: theme.font.size.base,
     fontWeight: selected ? theme.font.weight.bold : theme.font.weight.regular,
     transition: 'all 200ms ease-in-out',
     borderRadius: '4rem',
+    boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+    '&:hover': {
+      transform: 'translateY(-2px)',
+      boxShadow: '0 4px 8px rgba(0, 0, 0, 0.15)',
+    },
+    '&:active': {
+      transform: 'translateY(0)',
+      boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+    },
     ...appliedStyle,
   };
 });

--- a/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStatusToggle.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStatusToggle.tsx
@@ -42,5 +42,5 @@ export const ApplicantStatusToggle = ({ status, updateStatus }: Props) => {
 
 const Container = styled.div(() => ({
   display: 'flex',
-  gap: '2rem',
+  gap: '1.5rem',
 }));

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentForm.tsx
@@ -102,6 +102,6 @@ const ButtonWrapper = styled.div({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  marginRight: '-2rem',
+  marginRight: '-0.35rem',
   padding: '0 0.3rem',
 });

--- a/src/pages/admin/ApplicationDetail/index.styled.ts
+++ b/src/pages/admin/ApplicationDetail/index.styled.ts
@@ -4,6 +4,10 @@ export const PageLayout = styled.div({
   display: 'flex',
   gap: '1.5rem',
   padding: '2rem 2.2rem 2rem 2rem',
+  maxWidth: '1400px',
+  margin: '0 auto',
+  width: '100%',
+  boxSizing: 'border-box',
 
   '@media (max-width: 72.5rem)': {
     flexDirection: 'column',

--- a/src/pages/admin/ApplicationDetail/index.styled.ts
+++ b/src/pages/admin/ApplicationDetail/index.styled.ts
@@ -5,7 +5,7 @@ export const PageLayout = styled.div({
   gap: '1.5rem',
   padding: '2rem 2.2rem 2rem 2rem',
   maxWidth: '1400px',
-  margin: '0 auto',
+  margin: '1rem auto',
   width: '100%',
   boxSizing: 'border-box',
 

--- a/src/pages/admin/Dashboard/Page.tsx
+++ b/src/pages/admin/Dashboard/Page.tsx
@@ -32,6 +32,6 @@ const Layout = styled.div({
 const Container = styled.main({
   maxWidth: '1200px',
   width: '100%',
-  padding: '1.5rem',
+  padding: '3rem 1.5rem',
   boxSizing: 'border-box',
 });


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #398 


## 📝작업 내용
지원자 관리 페이지의 상태 표시 UI를 개선하고, 페이지 레이아웃을 일관성 있게 조정했습니다.


### 1. 지원자 상태 버튼 UI 개선
- **테두리 추가**: 각 상태(합격/불합격/미정)에 2px 테두리를 추가하여 버튼임을 명확히 표현
- **호버 효과 추가**: 마우스 오버 시 위로 살짝 올라가는 애니메이션과 그림자 효과 추가
- **그림자 효과**: box-shadow를 추가하여 버튼의 입체감 강화


### 2. MSW 핸들러 추가
- 대시보드 API 모킹 핸들러 추가
- `/api/clubs/:clubId/dashboard` 
- `/api/clubs/:clubId/dashboard/applicants` 

### 스크린샷 (선택)

**기본**
<img width="761" height="133" alt="image" src="https://github.com/user-attachments/assets/78e0cfd8-81d2-43f4-a0a5-7e11d9c24e3e" />
<img width="779" height="113" alt="image" src="https://github.com/user-attachments/assets/d91a1424-b55b-4d1e-8dae-7c5640f3b9d6" />

**호버시**
<img width="636" height="94" alt="image" src="https://github.com/user-attachments/assets/ff1c799d-ed56-4432-90d5-8705b0649963" />


## 💬리뷰 요구사항(선택)
> 회의에서 논의된 내용에서 일부 수정했는데, 괜찮은지 확인 부탁드려요~
