### PR TITLE
[FEAT] 지원폼 생성 페이지에 면접 전형 옵션 기능 추가(#408)

### DIFF
--- a/src/app/mocks/repositories/applyForm.ts
+++ b/src/app/mocks/repositories/applyForm.ts
@@ -5,6 +5,7 @@ const applyForms: Record<string, ApplicationFormData> = {
     title: '카태켐 12기 지원서',
     description: '카카오테크 캠퍼스 12기 모집을 위한 지원서입니다.',
     recruitDate: '2025-03-01 ~ 2025-03-31',
+    interviewRequired: false,
     formQuestions: [
       {
         questionNum: 1,
@@ -28,20 +29,6 @@ const applyForms: Record<string, ApplicationFormData> = {
         isRequired: true,
         optionList: [{ value: 'JAVA' }, { value: 'C' }, { value: 'C++' }],
         displayOrder: 3,
-      },
-      {
-        questionNum: 4,
-        question: '면접 시간을 설정해주세요.',
-        fieldType: 'TIME_SLOT',
-        isRequired: true,
-        displayOrder: 4,
-        timeSlotOptions: {
-          date: '2025-09-24 ~ 2025-09-25',
-          availableTime: {
-            start: '10:00',
-            end: '21:00',
-          },
-        },
       },
     ],
   },

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -10,7 +10,7 @@ import { MainPage } from '@/pages/user/Main/Page.tsx';
 import { NoticeDetailPage } from '@/pages/user/Notice/DetailPage';
 import { NoticeListPage } from '@/pages/user/Notice/Page';
 import { ApplicationDetailPage } from './admin/ApplicationDetail/Page';
-import { ApplicationFormBuilder } from './admin/ApplicationFormBuilder/Page';
+import { ApplicationFormBuilderPage } from './admin/ApplicationFormBuilder/Page';
 import { KakaoCallback } from './admin/Login/KakaoCallback';
 import { LoginPage } from './admin/Login/Page';
 import { AdminSignupPage } from './admin/Signup/Page';
@@ -69,7 +69,7 @@ export const router = createBrowserRouter([
           },
           {
             path: ADMIN.APPLICATION_FORM_BUILDER,
-            element: <ApplicationFormBuilder />,
+            element: <ApplicationFormBuilderPage />,
           },
         ],
       },

--- a/src/pages/admin/ApplicationFormBuilder/Page.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/Page.tsx
@@ -12,7 +12,7 @@ import { ApplicationFieldsFormTableSection } from './components/FieldsFormTableS
 import { ApplicationFormBuilderHeaderSection } from './components/HeaderSection';
 import type { ApplicationFormData } from './types/fieldType';
 
-export const ApplicationFormBuilder = () => {
+export const ApplicationFormBuilderPage = () => {
   const { clubId } = useParams();
   const [isEditMode, setIsEditMode] = useState(false);
   const [isInterviewMode, setIsInterviewMode] = useState(false);
@@ -24,6 +24,7 @@ export const ApplicationFormBuilder = () => {
       title: '',
       description: '',
       recruitDate: '',
+      interviewRequired: false,
       formQuestions: [],
     },
   });

--- a/src/pages/admin/ApplicationFormBuilder/Page.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/Page.tsx
@@ -53,6 +53,29 @@ export const ApplicationFormBuilderPage = () => {
   const isInterviewMode = formHandler.watch('interviewRequired');
   const handleInterviewChange = (checked: boolean) => {
     formHandler.setValue('interviewRequired', checked);
+
+    const currentQuestions = formHandler.getValues('formQuestions');
+
+    if (checked) {
+      formHandler.setValue('formQuestions', [
+        {
+          questionNum: 1,
+          fieldType: 'TIME_SLOT',
+          displayOrder: 1,
+          question: '면접 시간 선택',
+          isRequired: true,
+          optionList: [],
+          timeSlotOptions: { date: '', availableTime: { start: '09:00:00', end: '18:00:00' } },
+        },
+        ...currentQuestions.map((q, i) => ({ ...q, questionNum: i + 2, displayOrder: i + 2 })),
+      ]);
+    } else {
+      const filtered = currentQuestions.filter((q) => q.fieldType !== 'TIME_SLOT');
+      formHandler.setValue(
+        'formQuestions',
+        filtered.map((q, i) => ({ ...q, questionNum: i + 1, displayOrder: i + 1 })),
+      );
+    }
   };
 
   if (isLoading) return <LoadingSpinner />;
@@ -70,6 +93,7 @@ export const ApplicationFormBuilderPage = () => {
           onInterviewChange={handleInterviewChange}
         />
         <ApplicationInfoSection formHandler={formHandler} isEditMode={isEditMode} />
+
         <ApplicationFieldsFormTableSection formHandler={formHandler} isEditMode={isEditMode} />
       </ContentContainer>
     </Layout>

--- a/src/pages/admin/ApplicationFormBuilder/Page.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/Page.tsx
@@ -57,6 +57,7 @@ export const ApplicationFormBuilderPage = () => {
     const currentQuestions = formHandler.getValues('formQuestions');
 
     if (checked) {
+      const filteredQuestions = currentQuestions.filter((q) => q.fieldType !== 'TIME_SLOT');
       formHandler.setValue('formQuestions', [
         {
           questionNum: 1,
@@ -70,7 +71,7 @@ export const ApplicationFormBuilderPage = () => {
             availableTime: { start: '09:00:00', end: '18:00:00' },
           },
         },
-        ...currentQuestions.map((q, i) => ({ ...q, questionNum: i + 2, displayOrder: i + 2 })),
+        ...filteredQuestions.map((q, i) => ({ ...q, questionNum: i + 2, displayOrder: i + 2 })),
       ]);
     } else {
       const filtered = currentQuestions.filter((q) => q.fieldType !== 'TIME_SLOT');

--- a/src/pages/admin/ApplicationFormBuilder/Page.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/Page.tsx
@@ -15,7 +15,6 @@ import type { ApplicationFormData } from './types/fieldType';
 export const ApplicationFormBuilderPage = () => {
   const { clubId } = useParams();
   const [isEditMode, setIsEditMode] = useState(false);
-  const [isInterviewMode, setIsInterviewMode] = useState(false);
   const { data, isLoading, error } = useAdaptedApplicationForm(Number(clubId));
   const { adaptedPatchForm } = useAdaptedPatchApplicationForm(Number(clubId));
 
@@ -51,8 +50,9 @@ export const ApplicationFormBuilderPage = () => {
     });
   });
 
+  const isInterviewMode = formHandler.watch('interviewRequired');
   const handleInterviewChange = (checked: boolean) => {
-    setIsInterviewMode(checked);
+    formHandler.setValue('interviewRequired', checked);
   };
 
   if (isLoading) return <LoadingSpinner />;

--- a/src/pages/admin/ApplicationFormBuilder/Page.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/Page.tsx
@@ -15,7 +15,7 @@ import type { ApplicationFormData } from './types/fieldType';
 export const ApplicationFormBuilder = () => {
   const { clubId } = useParams();
   const [isEditMode, setIsEditMode] = useState(false);
-
+  const [isInterviewMode, setIsInterviewMode] = useState(false);
   const { data, isLoading, error } = useAdaptedApplicationForm(Number(clubId));
   const { adaptedPatchForm } = useAdaptedPatchApplicationForm(Number(clubId));
 
@@ -50,6 +50,10 @@ export const ApplicationFormBuilder = () => {
     });
   });
 
+  const handleInterviewChange = (checked: boolean) => {
+    setIsInterviewMode(checked);
+  };
+
   if (isLoading) return <LoadingSpinner />;
   if (error) return <div>에러발생 : {error.message}</div>;
 
@@ -61,6 +65,8 @@ export const ApplicationFormBuilder = () => {
           onEdit={handleEdit}
           onSave={handleSave}
           onCancel={handleCancel}
+          isInterviewMode={isInterviewMode}
+          onInterviewChange={handleInterviewChange}
         />
         <ApplicationInfoSection formHandler={formHandler} isEditMode={isEditMode} />
         <ApplicationFieldsFormTableSection formHandler={formHandler} isEditMode={isEditMode} />

--- a/src/pages/admin/ApplicationFormBuilder/Page.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/Page.tsx
@@ -62,10 +62,13 @@ export const ApplicationFormBuilderPage = () => {
           questionNum: 1,
           fieldType: 'TIME_SLOT',
           displayOrder: 1,
-          question: '면접 시간 선택',
+          question: '면접 가능한 시간을 선택해주세요',
           isRequired: true,
           optionList: [],
-          timeSlotOptions: { date: '', availableTime: { start: '09:00:00', end: '18:00:00' } },
+          timeSlotOptions: {
+            date: '',
+            availableTime: { start: '09:00:00', end: '18:00:00' },
+          },
         },
         ...currentQuestions.map((q, i) => ({ ...q, questionNum: i + 2, displayOrder: i + 2 })),
       ]);

--- a/src/pages/admin/ApplicationFormBuilder/components/ApplicationInfoSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/ApplicationInfoSection/index.tsx
@@ -42,7 +42,7 @@ export const ApplicationInfoSection = ({ formHandler, isEditMode }: Props) => {
   return (
     <>
       <Global styles={datePickerStyles} />
-      <Layout>
+      <Layout isEditMode={isEditMode}>
         <Wrapper>
           <UnderlineInputField
             placeholder='ex. 동아리명 10기 신입부원 모집'
@@ -93,16 +93,17 @@ export const ApplicationInfoSection = ({ formHandler, isEditMode }: Props) => {
   );
 };
 
-const Layout = styled.div(({ theme }) => ({
+const Layout = styled.div<{ isEditMode: boolean }>(({ theme, isEditMode }) => ({
   width: '100%',
   border: `1px solid ${theme.colors.gray200}`,
   borderRadius: theme.radius.sm,
   padding: '1.5rem',
-  backgroundColor: 'white',
+  backgroundColor: isEditMode ? theme.colors.bg : theme.colors.gray00,
   display: 'flex',
   flexDirection: 'column',
   gap: '2.5rem',
   boxSizing: 'border-box',
+  cursor: 'auto',
 
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
     padding: '1rem',

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/Builders/TimeslotFieldBuilder.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/Builders/TimeslotFieldBuilder.tsx
@@ -8,6 +8,7 @@ import { datePickerStyles } from '@/pages/admin/ApplicationFormBuilder/styles/da
 import * as S from '@/pages/admin/ApplicationFormBuilder/styles/timeslot.styled';
 import { generateTimes } from '@/pages/admin/ApplicationFormBuilder/utils/generateTimes';
 import { Dropdown } from '@/shared/components/Dropdown';
+import { OutlineInputField } from '@/shared/components/Form/InputField/OutlineInputField';
 import { Text } from '@/shared/components/Text';
 import type { CustomInputProps } from '@/pages/admin/ApplicationFormBuilder/types/clubInfo';
 import type { ApplicationFormData } from '@/pages/admin/ApplicationFormBuilder/types/fieldType';
@@ -27,7 +28,12 @@ const CustomInput = ({ value, onClick }: CustomInputProps) => (
 );
 
 export const TimeslotFieldBuilder = ({ formHandler, questionIndex, isEditMode }: Props) => {
-  const { register, setValue, watch } = formHandler;
+  const {
+    register,
+    setValue,
+    watch,
+    formState: { errors },
+  } = formHandler;
 
   const timeSlotDate = watch(`formQuestions.${questionIndex}.timeSlotOptions.date`);
 
@@ -54,7 +60,19 @@ export const TimeslotFieldBuilder = ({ formHandler, questionIndex, isEditMode }:
   return (
     <>
       <Global styles={datePickerStyles} />
-      <S.Layout>
+      <S.HeaderWrapper>
+        <OutlineInputField
+          placeholder='질문 내용을 입력하세요.'
+          {...register(`formQuestions.${questionIndex}.question`, {
+            required: '질문 내용을 입력해주세요.',
+            minLength: { value: 1, message: '질문 내용은 최소 한 글자 이상 입력해야 합니다.' },
+          })}
+          invalid={!!errors.formQuestions?.[questionIndex]?.question}
+          message={errors.formQuestions?.[questionIndex]?.question?.message}
+          disabled={!isEditMode}
+        />
+      </S.HeaderWrapper>
+      <S.Container>
         <S.DatePickerWrapper>
           <DatePicker
             locale={ko}
@@ -71,9 +89,14 @@ export const TimeslotFieldBuilder = ({ formHandler, questionIndex, isEditMode }:
           <input
             type='hidden'
             {...register(`formQuestions.${questionIndex}.timeSlotOptions.date`, {
-              required: '모집 기간을 선택해주세요',
+              required: '면접 기간을 선택해주세요',
             })}
           />
+          {errors.formQuestions?.[questionIndex]?.timeSlotOptions?.date && (
+            <S.ErrorMessage>
+              {errors.formQuestions[questionIndex].timeSlotOptions.date.message}
+            </S.ErrorMessage>
+          )}
         </S.DatePickerWrapper>
 
         <S.TimeSelectContainer>
@@ -96,7 +119,7 @@ export const TimeslotFieldBuilder = ({ formHandler, questionIndex, isEditMode }:
             />
           </S.TimeSelectWrapper>
         </S.TimeSelectContainer>
-      </S.Layout>
+      </S.Container>
     </>
   );
 };

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
@@ -11,7 +11,6 @@ import { OutlineInputField } from '@/shared/components/Form/InputField/OutlineIn
 import { CheckboxOptionsBuilder } from './Builders/CheckboxOptionsBuilder';
 import { RadioOptionsBuilder } from './Builders/RadioOptionsBuilder';
 import { TextOptionsBuilder } from './Builders/TextOptionsBuilder';
-import { TimeslotFieldBuilder } from './Builders/TimeslotFieldBuilder';
 import type {
   QuestionType,
   ApplicationFormData,
@@ -23,7 +22,7 @@ type Props = {
   onRemove?: () => void;
   isEditMode: boolean;
 };
-const fieldTypes: QuestionType[] = ['텍스트', '라디오', '체크박스', '타임슬롯'];
+const fieldTypes: QuestionType[] = ['텍스트', '라디오', '체크박스'];
 
 export const FormFieldItem = ({ formHandler, index, onRemove, isEditMode }: Props) => {
   const {
@@ -62,14 +61,7 @@ export const FormFieldItem = ({ formHandler, index, onRemove, isEditMode }: Prop
             isEditMode={isEditMode}
           />
         );
-      case '타임슬롯':
-        return (
-          <TimeslotFieldBuilder
-            formHandler={formHandler}
-            questionIndex={index}
-            isEditMode={isEditMode}
-          />
-        );
+
       default:
         return null;
     }
@@ -81,11 +73,6 @@ export const FormFieldItem = ({ formHandler, index, onRemove, isEditMode }: Prop
 
     if (newType === 'RADIO' || newType === 'CHECKBOX') {
       setValue(`formQuestions.${index}.optionList`, [{ value: '' }]);
-    } else if (newType === 'TIME_SLOT') {
-      setValue(`formQuestions.${index}.timeSlotOptions`, {
-        date: '',
-        availableTime: { start: '07:00:00', end: '07:00:00' },
-      });
     }
   };
 

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
@@ -39,7 +39,18 @@ export const FormFieldItem = ({ formHandler, index, onRemove, isEditMode }: Prop
 
   const questionType = watch(`formQuestions.${index}.fieldType`);
 
-  const currentDisplayType = reverseTypeMapping[questionType] || '텍스트';
+  const getDisplayType = (qType: typeof questionType): QuestionType => {
+    switch (qType) {
+      case 'TEXT':
+      case 'RADIO':
+      case 'CHECKBOX':
+        return reverseTypeMapping[qType];
+      case 'TIME_SLOT':
+      default:
+        return '텍스트';
+    }
+  };
+  const currentDisplayType = getDisplayType(questionType);
 
   const renderOptionsBuilder = () => {
     switch (currentDisplayType) {

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { useFieldArray } from 'react-hook-form';
 import { AddFieldButton } from './AddFieldButton';
 import { FormFieldItem } from './FormFieldItem';
+import { TimeslotFieldBuilder } from './FormFieldItem/Builders/TimeslotFieldBuilder';
 import type { ApplicationFormData } from '@/pages/admin/ApplicationFormBuilder/types/fieldType';
 
 type Props = {
@@ -35,12 +36,20 @@ export const ApplicationFieldsFormTableSection = ({ formHandler, isEditMode }: P
       {fields.map((data, index) => (
         <div key={data.id}>
           {index !== 0 && <Divider />}
-          <FormFieldItem
-            index={index}
-            formHandler={formHandler}
-            onRemove={() => remove(index)}
-            isEditMode={isEditMode}
-          />
+          {data.fieldType === 'TIME_SLOT' ? (
+            <TimeslotFieldBuilder
+              formHandler={formHandler}
+              questionIndex={index}
+              isEditMode={isEditMode}
+            />
+          ) : (
+            <FormFieldItem
+              index={index}
+              formHandler={formHandler}
+              onRemove={() => remove(index)}
+              isEditMode={isEditMode}
+            />
+          )}
         </div>
       ))}
       {isEditMode && <AddFieldButton onClick={handleAddFormField} />}

--- a/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.styled.ts
@@ -1,0 +1,79 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div(({ theme }) => ({
+  width: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.2rem',
+  padding: '2.5rem 0 1rem 0',
+  boxSizing: 'border-box',
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    padding: '1.5rem 0 0.5rem 0',
+    gap: '0.8rem',
+  },
+}));
+
+export const HeaderWrapper = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const ButtonWrapper = styled.div({
+  display: 'flex',
+  gap: '0.5rem',
+});
+
+export const Title = styled.h1(({ theme }) => ({
+  fontSize: '2.5rem',
+  fontWeight: theme.font.weight.medium,
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    fontSize: '1.5rem',
+  },
+}));
+
+export const CheckboxWrapper = styled.div({
+  display: 'flex',
+  gap: '0.5rem',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+});
+
+export const CustomCheckbox = styled.input(({ theme }) => ({
+  width: '1.15rem',
+  height: '1.15rem',
+  cursor: 'pointer',
+  appearance: 'none',
+  border: `2px solid ${theme.colors.primary}`,
+  borderRadius: '4px',
+  position: 'relative',
+  transition: 'all 0.2s ease',
+
+  '&:checked': {
+    backgroundColor: theme.colors.primary,
+    borderColor: theme.colors.primary,
+  },
+
+  '&:checked::after': {
+    content: '"✓"',
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    color: 'white',
+    fontSize: '1.2rem',
+    fontWeight: 'bold',
+  },
+
+  '&:hover': {
+    borderColor: theme.colors.primary800,
+    boxShadow: `0 0 0 3px ${theme.colors.primary}20`,
+  },
+
+  '&:focus': {
+    outline: 'none',
+    boxShadow: `0 0 0 3px ${theme.colors.primary}40`,
+  },
+}));

--- a/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.styled.ts
@@ -4,13 +4,12 @@ export const Container = styled.div(({ theme }) => ({
   width: '100%',
   display: 'flex',
   flexDirection: 'column',
-  gap: '1.2rem',
-  padding: '2.5rem 0 1rem 0',
+  gap: '2rem',
+  padding: '2.5rem 0 0 0',
   boxSizing: 'border-box',
 
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    padding: '1.5rem 0 0.5rem 0',
-    gap: '0.8rem',
+    gap: '0.5rem',
   },
 }));
 
@@ -30,16 +29,21 @@ export const Title = styled.h1(({ theme }) => ({
   fontWeight: theme.font.weight.medium,
 
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    fontSize: '1.5rem',
+    fontSize: '2rem',
   },
 }));
 
-export const CheckboxWrapper = styled.div({
+export const CheckboxWrapper = styled.div(({ theme }) => ({
   display: 'flex',
   gap: '0.5rem',
   justifyContent: 'flex-end',
   alignItems: 'center',
-});
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    padding: '1.5rem 0 0.5rem 0',
+    justifyContent: 'flex-start',
+  },
+}));
 
 export const CustomCheckbox = styled.input(({ theme }) => ({
   width: '1.15rem',

--- a/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.tsx
@@ -7,6 +7,8 @@ type Props = {
   onEdit: () => void;
   onSave: () => void;
   onCancel: () => void;
+  isInterviewMode: boolean;
+  onInterviewChange: (checked: boolean) => void;
 };
 
 export const ApplicationFormBuilderHeaderSection = ({
@@ -14,6 +16,8 @@ export const ApplicationFormBuilderHeaderSection = ({
   onEdit,
   onSave,
   onCancel,
+  isInterviewMode,
+  onInterviewChange,
 }: Props) => {
   return (
     <S.Container>
@@ -37,7 +41,11 @@ export const ApplicationFormBuilderHeaderSection = ({
       <S.CheckboxWrapper>
         {isEditMode ? (
           <>
-            <S.CustomCheckbox type='checkbox' />
+            <S.CustomCheckbox
+              type='checkbox'
+              checked={isInterviewMode}
+              onChange={(e) => onInterviewChange(e.target.checked)}
+            />
             <Text size='sm' weight='bold' color='#339356'>
               면접 전형을 진행하시면 체크박스를 눌러주세요!
             </Text>

--- a/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.tsx
@@ -34,9 +34,12 @@ export const ApplicationFormBuilderHeaderSection = ({
           </Button>
         )}
       </HeaderWrapper>
-      <Text size='sm' color='#339356'>
-        면접날짜는 타임 슬롯을 이용해서 안내할 수 있어요!
-      </Text>
+      <CheckboxWrapper>
+        <CustomCheckbox type='checkbox' />
+        <Text size='sm' weight='bold' color='#339356'>
+          면접 전형을 진행하시면 체크박스를 눌러주세요!
+        </Text>
+      </CheckboxWrapper>
     </Container>
   );
 };
@@ -72,5 +75,49 @@ const Title = styled.h1(({ theme }) => ({
 
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
     fontSize: '1.5rem',
+  },
+}));
+
+const CheckboxWrapper = styled.div({
+  display: 'flex',
+  gap: '0.5rem',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+});
+
+const CustomCheckbox = styled.input(({ theme }) => ({
+  width: '1.15rem',
+  height: '1.15rem',
+  cursor: 'pointer',
+  appearance: 'none',
+  border: `2px solid ${theme.colors.primary}`,
+  borderRadius: '4px',
+  position: 'relative',
+  transition: 'all 0.2s ease',
+
+  '&:checked': {
+    backgroundColor: theme.colors.primary,
+    borderColor: theme.colors.primary,
+  },
+
+  '&:checked::after': {
+    content: '"✓"',
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    color: 'white',
+    fontSize: '1.2rem',
+    fontWeight: 'bold',
+  },
+
+  '&:hover': {
+    borderColor: theme.colors.primary800,
+    boxShadow: `0 0 0 3px ${theme.colors.primary}20`,
+  },
+
+  '&:focus': {
+    outline: 'none',
+    boxShadow: `0 0 0 3px ${theme.colors.primary}40`,
   },
 }));

--- a/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.tsx
@@ -35,10 +35,18 @@ export const ApplicationFormBuilderHeaderSection = ({
         )}
       </S.HeaderWrapper>
       <S.CheckboxWrapper>
-        <S.CustomCheckbox type='checkbox' />
-        <Text size='sm' weight='bold' color='#339356'>
-          면접 전형을 진행하시면 체크박스를 눌러주세요!
-        </Text>
+        {isEditMode ? (
+          <>
+            <S.CustomCheckbox type='checkbox' />
+            <Text size='sm' weight='bold' color='#339356'>
+              면접 전형을 진행하시면 체크박스를 눌러주세요!
+            </Text>
+          </>
+        ) : (
+          <Text size='sm' weight='bold' color='#339356'>
+            면접날짜는 타임 슬롯을 이용해서 안내할 수 있어요!
+          </Text>
+        )}
       </S.CheckboxWrapper>
     </S.Container>
   );

--- a/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled';
 import { Button } from '@/shared/components/Button';
 import { Text } from '@/shared/components/Text';
+import * as S from './index.styled';
 
 type Props = {
   isEditMode: boolean;
@@ -16,108 +16,30 @@ export const ApplicationFormBuilderHeaderSection = ({
   onCancel,
 }: Props) => {
   return (
-    <Container>
-      <HeaderWrapper>
-        <Title>지원폼 생성</Title>
+    <S.Container>
+      <S.HeaderWrapper>
+        <S.Title>지원폼 생성</S.Title>
         {isEditMode ? (
-          <ButtonWrapper>
+          <S.ButtonWrapper>
             <Button variant='outline' width='4rem' onClick={onCancel}>
               취소
             </Button>
             <Button width='6rem' onClick={onSave}>
               저장하기
             </Button>
-          </ButtonWrapper>
+          </S.ButtonWrapper>
         ) : (
           <Button variant='outline' width='6rem' onClick={onEdit}>
             수정하기
           </Button>
         )}
-      </HeaderWrapper>
-      <CheckboxWrapper>
-        <CustomCheckbox type='checkbox' />
+      </S.HeaderWrapper>
+      <S.CheckboxWrapper>
+        <S.CustomCheckbox type='checkbox' />
         <Text size='sm' weight='bold' color='#339356'>
           면접 전형을 진행하시면 체크박스를 눌러주세요!
         </Text>
-      </CheckboxWrapper>
-    </Container>
+      </S.CheckboxWrapper>
+    </S.Container>
   );
 };
-
-const Container = styled.div(({ theme }) => ({
-  width: '100%',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '1.2rem',
-  padding: '2.5rem 0 1rem 0',
-  boxSizing: 'border-box',
-
-  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    padding: '1.5rem 0 0.5rem 0',
-    gap: '0.8rem',
-  },
-}));
-
-const HeaderWrapper = styled.div({
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-});
-
-const ButtonWrapper = styled.div({
-  display: 'flex',
-  gap: '0.5rem',
-});
-
-const Title = styled.h1(({ theme }) => ({
-  fontSize: '2.5rem',
-  fontWeight: theme.font.weight.medium,
-
-  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    fontSize: '1.5rem',
-  },
-}));
-
-const CheckboxWrapper = styled.div({
-  display: 'flex',
-  gap: '0.5rem',
-  justifyContent: 'flex-end',
-  alignItems: 'center',
-});
-
-const CustomCheckbox = styled.input(({ theme }) => ({
-  width: '1.15rem',
-  height: '1.15rem',
-  cursor: 'pointer',
-  appearance: 'none',
-  border: `2px solid ${theme.colors.primary}`,
-  borderRadius: '4px',
-  position: 'relative',
-  transition: 'all 0.2s ease',
-
-  '&:checked': {
-    backgroundColor: theme.colors.primary,
-    borderColor: theme.colors.primary,
-  },
-
-  '&:checked::after': {
-    content: '"✓"',
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -50%)',
-    color: 'white',
-    fontSize: '1.2rem',
-    fontWeight: 'bold',
-  },
-
-  '&:hover': {
-    borderColor: theme.colors.primary800,
-    boxShadow: `0 0 0 3px ${theme.colors.primary}20`,
-  },
-
-  '&:focus': {
-    outline: 'none',
-    boxShadow: `0 0 0 3px ${theme.colors.primary}40`,
-  },
-}));

--- a/src/pages/admin/ApplicationFormBuilder/styles/timeslot.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/styles/timeslot.styled.ts
@@ -1,19 +1,19 @@
 import styled from '@emotion/styled';
 
-export const Layout = styled.div(({ theme }) => ({
+export const Container = styled.div(({ theme }) => ({
   display: 'flex',
-  maxWidth: '37.6rem',
   justifyContent: 'space-between',
-
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
     flexDirection: 'column',
     gap: '1.5rem',
   },
 }));
 
-export const DatePickerWrapper = styled.div(({ theme }) => ({
-  position: 'relative',
+export const HeaderWrapper = styled.div({
+  marginBottom: '2rem',
+});
 
+export const DatePickerWrapper = styled.div(({ theme }) => ({
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
     width: '100%',
     display: 'block',
@@ -34,7 +34,7 @@ export const CustomInputWrapper = styled.div(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  width: '15rem',
+  width: '20rem',
   cursor: 'pointer',
   position: 'relative',
   borderBottom: `1px solid ${theme.colors.gray200}`,
@@ -74,10 +74,26 @@ export const TimeSelectWrapper = styled.div(({ theme }) => ({
   alignItems: 'center',
   gap: '1rem',
 
+  '& > div:last-child': {
+    minWidth: '12rem',
+  },
+
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
     flexDirection: 'column',
     alignItems: 'flex-start',
     gap: '0.5rem',
     width: '100%',
+
+    '& > div:last-child': {
+      minWidth: 'auto',
+      width: '100%',
+    },
   },
+}));
+
+export const ErrorMessage = styled.span(({ theme }) => ({
+  color: theme.colors.error,
+  fontSize: '0.75rem',
+  marginTop: '0.5rem',
+  display: 'block',
 }));

--- a/src/pages/admin/ApplicationFormBuilder/types/fieldType.ts
+++ b/src/pages/admin/ApplicationFormBuilder/types/fieldType.ts
@@ -22,6 +22,7 @@ export type ApplicationFormData = {
   title: string;
   description: string;
   recruitDate: string;
+  interviewRequired: boolean;
   formQuestions: QuestionFormData[];
 };
 

--- a/src/pages/admin/ApplicationFormBuilder/types/fieldType.ts
+++ b/src/pages/admin/ApplicationFormBuilder/types/fieldType.ts
@@ -1,4 +1,4 @@
-export type QuestionType = '텍스트' | '라디오' | '체크박스' | '타임슬롯';
+export type QuestionType = '텍스트' | '라디오' | '체크박스';
 
 type TimeSlotOption = {
   date: string;

--- a/src/pages/admin/ApplicationFormBuilder/utils/typeMapping.ts
+++ b/src/pages/admin/ApplicationFormBuilder/utils/typeMapping.ts
@@ -1,16 +1,13 @@
 import type { QuestionType } from '../types/fieldType';
 
-export const typeMapping: Record<QuestionType, 'TEXT' | 'RADIO' | 'CHECKBOX' | 'TIME_SLOT'> = {
+export const typeMapping: Record<QuestionType, 'TEXT' | 'RADIO' | 'CHECKBOX'> = {
   텍스트: 'TEXT',
   라디오: 'RADIO',
   체크박스: 'CHECKBOX',
-  타임슬롯: 'TIME_SLOT',
 };
 
-export const reverseTypeMapping: Record<'TEXT' | 'RADIO' | 'CHECKBOX' | 'TIME_SLOT', QuestionType> =
-  {
-    TEXT: '텍스트',
-    RADIO: '라디오',
-    CHECKBOX: '체크박스',
-    TIME_SLOT: '타임슬롯',
-  };
+export const reverseTypeMapping: Record<'TEXT' | 'RADIO' | 'CHECKBOX', QuestionType> = {
+  TEXT: '텍스트',
+  RADIO: '라디오',
+  CHECKBOX: '체크박스',
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #408 

## 📝작업 내용
지원폼 생성 페이지 상단에 면접 전형 체크박스 옵션을 추가하여 체크박스를 클릭 할 시에만 면접 슬롯이 나오게끔 구현하였습니다.
- 지원폼 빌더에 면접 전형 체크박스 옵션 추가
- 면접 모드 활성화 시 TIME_SLOT 필드 자동 추가/제거 기능 구현
- TimeslotFieldBuilder에 질문 입력 필드 및 유효성 검사 추가
- 헤더 섹션 스타일 코드 분리 및 레이아웃 개선

### 스크린샷 (선택)
<img width="800" height="500" alt="image" src="https://github.com/user-attachments/assets/7d4f2e93-b4ad-4664-9103-35a94bb76234" />
