### PR TITLE
[FEAT] 지원자 목록 면접 시간 컬럼 추가 및 시간 선택 모달 구현 (#411)

### DIFF
--- a/src/app/mocks/repositories/applicant.ts
+++ b/src/app/mocks/repositories/applicant.ts
@@ -10,6 +10,13 @@ const applicants: ApplicantData[] = [
     phoneNumber: '010-1010-1010',
     email: 'ddd@naver.com',
     status: 'PENDING',
+    confirmedTime: '2026-09-02T15:00:00',
+    interviewInfo: [
+      {
+        interviewDate: '2026-09-02',
+        availableTimes: ['10:00', '11:00', '15:00'],
+      },
+    ],
   },
   {
     applicantId: 2,
@@ -19,6 +26,13 @@ const applicants: ApplicantData[] = [
     phoneNumber: '010-1010-1010',
     email: 'ddd@naver.com',
     status: 'APPROVED',
+    confirmedTime: '2026-09-03T14:00:00',
+    interviewInfo: [
+      {
+        interviewDate: '2026-09-03',
+        availableTimes: ['14:00', '15:00'],
+      },
+    ],
   },
   {
     applicantId: 3,
@@ -28,6 +42,13 @@ const applicants: ApplicantData[] = [
     phoneNumber: '010-1010-1010',
     email: 'ddd@naver.com',
     status: 'REJECTED',
+    confirmedTime: '2026-09-02T16:00:00',
+    interviewInfo: [
+      {
+        interviewDate: '2026-09-02',
+        availableTimes: ['16:00'],
+      },
+    ],
   },
   {
     applicantId: 4,
@@ -37,6 +58,12 @@ const applicants: ApplicantData[] = [
     phoneNumber: '010-1010-1010',
     email: 'ddd@naver.com',
     status: 'PENDING',
+    interviewInfo: [
+      {
+        interviewDate: '2026-09-04',
+        availableTimes: ['10:00', '11:00', '14:00'],
+      },
+    ],
   },
 ];
 

--- a/src/app/mocks/repositories/applicant.ts
+++ b/src/app/mocks/repositories/applicant.ts
@@ -10,13 +10,6 @@ const applicants: ApplicantData[] = [
     phoneNumber: '010-1010-1010',
     email: 'ddd@naver.com',
     status: 'PENDING',
-    confirmedTime: '2026-09-02T15:00:00',
-    interviewInfo: [
-      {
-        interviewDate: '2026-09-02',
-        availableTimes: ['10:00', '11:00', '15:00'],
-      },
-    ],
   },
   {
     applicantId: 2,
@@ -26,13 +19,6 @@ const applicants: ApplicantData[] = [
     phoneNumber: '010-1010-1010',
     email: 'ddd@naver.com',
     status: 'APPROVED',
-    confirmedTime: '2026-09-03T14:00:00',
-    interviewInfo: [
-      {
-        interviewDate: '2026-09-03',
-        availableTimes: ['14:00', '15:00'],
-      },
-    ],
   },
   {
     applicantId: 3,
@@ -42,13 +28,6 @@ const applicants: ApplicantData[] = [
     phoneNumber: '010-1010-1010',
     email: 'ddd@naver.com',
     status: 'REJECTED',
-    confirmedTime: '2026-09-02T16:00:00',
-    interviewInfo: [
-      {
-        interviewDate: '2026-09-02',
-        availableTimes: ['16:00'],
-      },
-    ],
   },
   {
     applicantId: 4,
@@ -58,12 +37,6 @@ const applicants: ApplicantData[] = [
     phoneNumber: '010-1010-1010',
     email: 'ddd@naver.com',
     status: 'PENDING',
-    interviewInfo: [
-      {
-        interviewDate: '2026-09-04',
-        availableTimes: ['10:00', '11:00', '14:00'],
-      },
-    ],
   },
 ];
 

--- a/src/app/mocks/repositories/dashboard.ts
+++ b/src/app/mocks/repositories/dashboard.ts
@@ -37,7 +37,7 @@ const MOCK_APPLICANTS: ApplicantData[] = [
     phoneNumber: '010-2345-6789',
     email: 'test2@example.com',
     status: 'APPROVED',
-    confirmedTime: '2026-09-02T15:00:00',
+    confirmedTime: '',
     interviewInfo: [
       {
         interviewDate: '2026-09-02',

--- a/src/app/mocks/repositories/dashboard.ts
+++ b/src/app/mocks/repositories/dashboard.ts
@@ -40,7 +40,7 @@ const MOCK_APPLICANTS: ApplicantData[] = [
     phoneNumber: '010-1234-5678',
     email: 'test1@example.com',
     status: 'APPROVED',
-    confirmedTime: undefined,
+    confirmedTime: '2026-09-02T15:00:00',
     interviewInfo: [
       {
         interviewDate: '2026-09-02',

--- a/src/app/mocks/repositories/dashboard.ts
+++ b/src/app/mocks/repositories/dashboard.ts
@@ -12,57 +12,6 @@ const MOCK_DASHBOARD_SUMMARY: DashboardSummary = {
   endDay: '2024-03-31',
 };
 
-const MOCK_APPLICANTS: ApplicantData[] = [
-  {
-    applicantId: 1,
-    name: '김철수',
-    studentId: '202401',
-    department: '컴퓨터공학과',
-    phoneNumber: '010-1234-5678',
-    email: 'test1@example.com',
-    status: 'PENDING',
-    confirmedTime: '2026-09-02T14:00:00',
-    interviewInfo: [
-      {
-        interviewDate: '2026-09-02',
-        availableTimes: ['14:00', '15:00', '16:00'],
-      },
-    ],
-  },
-  {
-    applicantId: 2,
-    name: '이영희',
-    studentId: '202402',
-    department: '경영학과',
-    phoneNumber: '010-2345-6789',
-    email: 'test2@example.com',
-    status: 'APPROVED',
-    confirmedTime: '',
-    interviewInfo: [
-      {
-        interviewDate: '2026-09-02',
-        availableTimes: ['10:00', '11:00'],
-      },
-    ],
-  },
-  {
-    applicantId: 3,
-    name: '박민수',
-    studentId: '202403',
-    department: '전자공학과',
-    phoneNumber: '010-3456-7890',
-    email: 'test3@example.com',
-    status: 'REJECTED',
-    confirmedTime: '2026-09-03T10:00:00',
-    interviewInfo: [
-      {
-        interviewDate: '2026-09-03',
-        availableTimes: ['10:00', '11:00', '14:00'],
-      },
-    ],
-  },
-];
-
 const MOCK_INTERVIEW_SCHEDULE: InterviewSchedule[] = [
   {
     date: '2026-09-02',
@@ -78,6 +27,59 @@ const MOCK_INTERVIEW_SCHEDULE: InterviewSchedule[] = [
       { time: '10:00', assignedCount: 1 },
       { time: '11:00', assignedCount: 0 },
       { time: '14:00', assignedCount: 0 },
+    ],
+  },
+];
+
+const MOCK_APPLICANTS: ApplicantData[] = [
+  {
+    applicantId: 1,
+    name: '김철수',
+    studentId: '202401',
+    department: '컴퓨터공학과',
+    phoneNumber: '010-1234-5678',
+    email: 'test1@example.com',
+    status: 'APPROVED',
+    confirmedTime: undefined,
+    interviewInfo: [
+      {
+        interviewDate: '2026-09-02',
+        availableTimes: ['14:00', '15:00', '16:00'],
+      },
+    ],
+    interviewSchedule: MOCK_INTERVIEW_SCHEDULE,
+  },
+  {
+    applicantId: 2,
+    name: '이영희',
+    studentId: '202402',
+    department: '경영학과',
+    phoneNumber: '010-2345-6789',
+    email: 'test2@example.com',
+    status: 'APPROVED',
+    confirmedTime: undefined,
+    interviewInfo: [
+      {
+        interviewDate: '2026-09-02',
+        availableTimes: ['10:00', '11:00'],
+      },
+    ],
+    interviewSchedule: MOCK_INTERVIEW_SCHEDULE,
+  },
+  {
+    applicantId: 3,
+    name: '박민수',
+    studentId: '202403',
+    department: '전자공학과',
+    phoneNumber: '010-3456-7890',
+    email: 'test3@example.com',
+    status: 'REJECTED',
+    confirmedTime: '2026-09-03T10:00:00',
+    interviewInfo: [
+      {
+        interviewDate: '2026-09-03',
+        availableTimes: ['10:00', '11:00', '14:00'],
+      },
     ],
   },
 ];

--- a/src/app/mocks/repositories/dashboard.ts
+++ b/src/app/mocks/repositories/dashboard.ts
@@ -2,6 +2,7 @@ import type {
   DashboardSummary,
   ApplicantsApiResponse,
   ApplicantData,
+  InterviewSchedule,
 } from '@/pages/admin/Dashboard/types/dashboard';
 
 const MOCK_DASHBOARD_SUMMARY: DashboardSummary = {
@@ -20,6 +21,13 @@ const MOCK_APPLICANTS: ApplicantData[] = [
     phoneNumber: '010-1234-5678',
     email: 'test1@example.com',
     status: 'PENDING',
+    confirmedTime: '2026-09-02T14:00:00',
+    interviewInfo: [
+      {
+        interviewDate: '2026-09-02',
+        availableTimes: ['14:00', '15:00', '16:00'],
+      },
+    ],
   },
   {
     applicantId: 2,
@@ -29,6 +37,13 @@ const MOCK_APPLICANTS: ApplicantData[] = [
     phoneNumber: '010-2345-6789',
     email: 'test2@example.com',
     status: 'APPROVED',
+    confirmedTime: '2026-09-02T15:00:00',
+    interviewInfo: [
+      {
+        interviewDate: '2026-09-02',
+        availableTimes: ['10:00', '11:00'],
+      },
+    ],
   },
   {
     applicantId: 3,
@@ -38,6 +53,32 @@ const MOCK_APPLICANTS: ApplicantData[] = [
     phoneNumber: '010-3456-7890',
     email: 'test3@example.com',
     status: 'REJECTED',
+    confirmedTime: '2026-09-03T10:00:00',
+    interviewInfo: [
+      {
+        interviewDate: '2026-09-03',
+        availableTimes: ['10:00', '11:00', '14:00'],
+      },
+    ],
+  },
+];
+
+const MOCK_INTERVIEW_SCHEDULE: InterviewSchedule[] = [
+  {
+    date: '2026-09-02',
+    slots: [
+      { time: '14:00', assignedCount: 1 },
+      { time: '15:00', assignedCount: 1 },
+      { time: '16:00', assignedCount: 0 },
+    ],
+  },
+  {
+    date: '2026-09-03',
+    slots: [
+      { time: '10:00', assignedCount: 1 },
+      { time: '11:00', assignedCount: 0 },
+      { time: '14:00', assignedCount: 0 },
+    ],
   },
 ];
 
@@ -49,6 +90,7 @@ export const dashboardRepository = {
   getApplicants: (): ApplicantsApiResponse => {
     return {
       applicants: MOCK_APPLICANTS,
+      interviewSchedule: MOCK_INTERVIEW_SCHEDULE,
       message: null,
     };
   },

--- a/src/pages/admin/ApplicationDetail/Page.tsx
+++ b/src/pages/admin/ApplicationDetail/Page.tsx
@@ -6,7 +6,6 @@ import { ApplicantProfileSection } from './components/ApplicantProfileSection/in
 import { ApplicantQuestionSection } from './components/ApplicationQuestionSection';
 import { CommentSection } from './components/CommentSection';
 import { useDetailApplications } from './hooks/useDetailApplication';
-
 import * as S from './index.styled';
 
 export const ApplicationDetailPage = () => {

--- a/src/pages/admin/Dashboard/api/sentMessage.ts
+++ b/src/pages/admin/Dashboard/api/sentMessage.ts
@@ -1,5 +1,5 @@
 import { apiInstance } from '@/app/api/initInstance';
-import { stageMap } from '../utils/stageMap';
+import { STAGE_LABEL } from '../utils/labelMap';
 import type { ApplicationStage } from '@/pages/admin/Dashboard/types/dashboard';
 
 export const sentMessage = async (
@@ -7,7 +7,7 @@ export const sentMessage = async (
   message: string,
   stage: ApplicationStage,
 ): Promise<void> => {
-  const apiStage = stageMap[stage];
+  const apiStage = STAGE_LABEL[stage];
 
   try {
     await apiInstance.patch(`/clubs/${clubId}/club-apply-form/result?stage=${apiStage}`, {

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/Filter/ApplicationFilter.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/Filter/ApplicationFilter.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useApplicants } from '@/pages/admin/Dashboard/hooks/useApplicants';
-import { stageMap } from '@/pages/admin/Dashboard/utils/stageMap';
+import { STAGE_LABEL } from '@/pages/admin/Dashboard/utils/labelMap';
 import { ApplicantFilterButton } from './ApplicationFilterButton';
 
 import type {
@@ -16,7 +16,7 @@ export type Props = {
 };
 
 export const ApplicationStatusFilter = ({ option, onOptionChange, stage, clubId }: Props) => {
-  const apiStage = stageMap[stage];
+  const apiStage = STAGE_LABEL[stage];
   const { counts } = useApplicants(clubId, apiStage);
 
   return (

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.styled.ts
@@ -6,7 +6,7 @@ export const Container = styled.div({
 
 export const ApplicantInfoCategoryList = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr 1.5fr 1.5fr 2fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr 1.2fr 1.5fr 1fr 1.2fr;
   background-color: #f9fbfc;
   border-bottom: 1.8px solid ${({ theme }) => theme.colors.gray100};
   padding: 1.7rem 0 1.5rem 0;
@@ -16,29 +16,34 @@ export const ApplicantInfoCategoryList = styled.div`
   }
 
   @media (max-width: 1200px) {
-    grid-template-columns: 1fr 1fr 1.5fr 1.5fr 1fr;
-    & > div:nth-of-type(5) {
-      display: none;
-    }
-  }
+    grid-template-columns: 1fr 1fr 1fr 1.5fr 1fr 1.2fr;
 
-  @media (max-width: ${({ theme }) => theme.breakpoints.web}) {
-    grid-template-columns: 1fr 1fr 1.5fr 1fr;
     & > div:nth-of-type(4) {
       display: none;
     }
   }
 
-  @media (max-width: 768px) {
-    grid-template-columns: 1fr 1fr 1fr;
+  @media (max-width: ${({ theme }) => theme.breakpoints.web}) {
+    grid-template-columns: 1fr 1fr 1.5fr 1fr 1.2fr;
+
     & > div:nth-of-type(3) {
       display: none;
     }
   }
 
-  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
-    grid-template-columns: 1.5fr 1fr;
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr 1.5fr 1fr 1.2fr;
+
     & > div:nth-of-type(2) {
+      display: none;
+    }
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
+    grid-template-columns: 1fr 1fr;
+
+    & > div:nth-of-type(5),
+    & > div:nth-of-type(7) {
       display: none;
     }
   }

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useApplicants } from '@/pages/admin/Dashboard/hooks/useApplicants';
-import { stageMap } from '@/pages/admin/Dashboard/utils/stageMap';
+import { STAGE_LABEL } from '@/pages/admin/Dashboard/utils/labelMap';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { ApplicantListItem } from '../ApplicantListItem';
 import * as S from './index.styled';
@@ -31,7 +31,7 @@ export const ApplicantList = ({ filterOption, stage }: Props) => {
 
   const navigate = useNavigate();
 
-  const apiStage = stageMap[stage];
+  const apiStage = STAGE_LABEL[stage];
 
   const {
     data: applicants,
@@ -69,6 +69,8 @@ export const ApplicantList = ({ filterOption, stage }: Props) => {
               email={applicant.email}
               status={applicant.status}
               confirmedTime={applicant.confirmedTime}
+              interviewInfo={applicant.interviewInfo}
+              interviewSchedule={applicant.interviewSchedule}
               onClick={handleItemClick}
             />
           ))

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.tsx
@@ -6,6 +6,7 @@ import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { ApplicantListItem } from '../ApplicantListItem';
 import * as S from './index.styled';
 import type {
+  ApplicateInfoCategory,
   ApplicationFilterOption,
   ApplicationStage,
 } from '@/pages/admin/Dashboard/types/dashboard';
@@ -15,7 +16,6 @@ type Props = {
   stage: ApplicationStage;
 };
 
-type ApplicateInfoCategory = '이름' | '학번' | '학과' | '전화번호' | '이메일' | '결과';
 const INFO_CATEGORY: ApplicateInfoCategory[] = [
   '이름',
   '학번',
@@ -23,6 +23,7 @@ const INFO_CATEGORY: ApplicateInfoCategory[] = [
   '전화번호',
   '이메일',
   '결과',
+  '면접 시간',
 ];
 
 export const ApplicantList = ({ filterOption, stage }: Props) => {

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.tsx
@@ -68,6 +68,7 @@ export const ApplicantList = ({ filterOption, stage }: Props) => {
               phoneNumber={applicant.phoneNumber}
               email={applicant.email}
               status={applicant.status}
+              confirmedTime={applicant.confirmedTime}
               onClick={handleItemClick}
             />
           ))

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.styled.ts
@@ -1,0 +1,89 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.8rem',
+});
+
+export const Section = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+});
+
+export const SectionTitle = styled.h3(({ theme }) => ({
+  fontSize: theme.font.size.sm,
+  fontWeight: 600,
+  color: theme.colors.gray700,
+  paddingBottom: '0.5rem',
+  borderBottom: `1px solid ${theme.colors.gray200}`,
+}));
+
+export const ScheduleRow = styled.div({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '1rem',
+});
+export const SchedulDateLabel = styled.span(({ theme }) => ({
+  fontSize: theme.font.size.sm,
+  fontWeight: 600,
+  color: theme.colors.gray700,
+  minWidth: '2.5rem',
+  paddingTop: '0.5rem',
+}));
+
+export const DateLabel = styled.span(({ theme }) => ({
+  fontSize: theme.font.size.sm,
+  fontWeight: 600,
+  color: theme.colors.gray700,
+  minWidth: '2.5rem',
+}));
+
+export const SlotsContainer = styled.div({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '0.5rem',
+  flex: 1,
+});
+
+export const TimeSlot = styled.button<{ $selected?: boolean }>(({ theme, $selected }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '0.5rem 0.75rem',
+  borderRadius: theme.radius.md,
+  border: `1px solid ${$selected ? theme.colors.primary : theme.colors.gray300}`,
+  backgroundColor: $selected ? theme.colors.primary00 : theme.colors.bg,
+  cursor: 'pointer',
+  transition: 'all 0.2s',
+  minWidth: '4rem',
+
+  '&:hover': {
+    borderColor: theme.colors.primary,
+    backgroundColor: theme.colors.primary00,
+  },
+}));
+
+export const SlotTime = styled.span(({ theme }) => ({
+  fontSize: theme.font.size.sm,
+  fontWeight: 500,
+  color: theme.colors.gray800,
+}));
+
+export const SlotCount = styled.span(({ theme }) => ({
+  fontSize: theme.font.size.xs,
+  color: theme.colors.gray500,
+  marginTop: '0.125rem',
+}));
+
+export const AvailableTimesRow = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '1rem',
+});
+
+export const AvailableTimes = styled.span(({ theme }) => ({
+  fontSize: theme.font.size.sm,
+  color: theme.colors.gray600,
+}));

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.styled.ts
@@ -25,7 +25,7 @@ export const ScheduleRow = styled.div({
   alignItems: 'flex-start',
   gap: '1rem',
 });
-export const SchedulDateLabel = styled.span(({ theme }) => ({
+export const ScheduleDateLabel = styled.span(({ theme }) => ({
   fontSize: theme.font.size.sm,
   fontWeight: 600,
   color: theme.colors.gray700,

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
@@ -1,0 +1,40 @@
+import { formatDateWithoutYear } from '@/shared/utils/dateUtils';
+import * as S from './InterviewTimeContentModal.styled';
+import type { InterviewInfo, InterviewSchedule } from '@/pages/admin/Dashboard/types/dashboard';
+
+type Props = {
+  interviewInfo?: InterviewInfo[];
+  interviewSchedule?: InterviewSchedule[];
+};
+
+export const InterviewTimeContentModal = ({ interviewInfo, interviewSchedule }: Props) => {
+  return (
+    <S.Container>
+      <S.Section>
+        {interviewSchedule?.map((schedule) => (
+          <S.ScheduleRow key={schedule.date}>
+            <S.SchedulDateLabel>{formatDateWithoutYear(schedule.date)}</S.SchedulDateLabel>
+            <S.SlotsContainer>
+              {schedule.slots.map((slot) => (
+                <S.TimeSlot key={slot.time}>
+                  <S.SlotTime>{slot.time}</S.SlotTime>
+                  <S.SlotCount>({slot.assignedCount}명 선택)</S.SlotCount>
+                </S.TimeSlot>
+              ))}
+            </S.SlotsContainer>
+          </S.ScheduleRow>
+        ))}
+      </S.Section>
+
+      <S.Section>
+        <S.SectionTitle>지원자 면접 희망 시간대</S.SectionTitle>
+        {interviewInfo?.map((info) => (
+          <S.AvailableTimesRow key={info.interviewDate}>
+            <S.DateLabel>{formatDateWithoutYear(info.interviewDate)}</S.DateLabel>
+            <S.AvailableTimes>{info.availableTimes.join(', ')}</S.AvailableTimes>
+          </S.AvailableTimesRow>
+        ))}
+      </S.Section>
+    </S.Container>
+  );
+};

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
@@ -13,7 +13,7 @@ export const InterviewTimeContentModal = ({ interviewInfo, interviewSchedule }: 
       <S.Section>
         {interviewSchedule?.map((schedule) => (
           <S.ScheduleRow key={schedule.date}>
-            <S.SchedulDateLabel>{formatDateWithoutYear(schedule.date)}</S.SchedulDateLabel>
+            <S.ScheduleDateLabel>{formatDateWithoutYear(schedule.date)}</S.ScheduleDateLabel>
             <S.SlotsContainer>
               {schedule.slots.map((slot) => (
                 <S.TimeSlot key={slot.time}>

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
@@ -3,8 +3,8 @@ import type { ApplicantData } from '@/pages/admin/Dashboard/types/dashboard';
 
 export const ItemWrapper = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr 1.5fr 1.5fr 2fr 1fr;
-  gap: 2rem;
+  grid-template-columns: 1fr 1fr 1fr 1.2fr 1.5fr 1fr 1.2fr;
+  gap: 1rem;
   align-items: center;
   padding: 1.5rem 0;
   transition: background-color 0.2s ease;
@@ -19,29 +19,34 @@ export const ItemWrapper = styled.div`
   }
 
   @media (max-width: 1200px) {
-    grid-template-columns: 1fr 1fr 1.5fr 1.5fr 1fr;
-    & > p:nth-of-type(5) {
-      display: none;
-    }
-  }
+    grid-template-columns: 1fr 1fr 1fr 1.5fr 1fr 1.2fr;
 
-  @media (max-width: ${({ theme }) => theme.breakpoints.web}) {
-    grid-template-columns: 1fr 1fr 1.5fr 1fr;
     & > p:nth-of-type(4) {
       display: none;
     }
   }
 
-  @media (max-width: ${({ theme }) => theme.breakpoints.tablet}) {
-    grid-template-columns: 1fr 1fr 1fr;
+  @media (max-width: ${({ theme }) => theme.breakpoints.web}) {
+    grid-template-columns: 1fr 1fr 1.5fr 1fr 1.2fr;
+
     & > p:nth-of-type(3) {
       display: none;
     }
   }
 
-  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
-    grid-template-columns: 1.5fr 1fr;
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr 1.5fr 1fr 1.2fr;
+
     & > p:nth-of-type(2) {
+      display: none;
+    }
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
+    grid-template-columns: 1fr 1fr;
+
+    & > p:nth-of-type(5),
+    & > p:nth-of-type(7) {
       display: none;
     }
   }

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
@@ -52,10 +52,21 @@ export const ItemWrapper = styled.div`
   }
 `;
 
-export const InfoText = styled.p({
-  fontSize: '1.1rem',
+export const InfoText = styled.p(({ theme }) => ({
+  fontSize: theme.font.size.lg,
+
   color: '#434547',
-});
+}));
+
+export const TimeSetter = styled.button(({ theme }) => ({
+  color: theme.colors.gray500,
+  background: 'none',
+  fontSize: theme.font.size.lg,
+  border: 'none',
+  textDecoration: 'underline',
+  textUnderlineOffset: '5px',
+  cursor: 'pointer',
+}));
 
 export const StatusBadge = styled.p<Pick<ApplicantData, 'status'>>(({ theme, status }) => {
   const styles = {

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
@@ -1,7 +1,9 @@
 import React, { useRef } from 'react';
 import { STATUS_LABEL } from '@/pages/admin/Dashboard/utils/labelMap';
 import { Modal } from '@/shared/components/Modal';
+import { Text } from '@/shared/components/Text';
 import { useModal } from '@/shared/hooks/useModal';
+import { formatDateTime } from '@/shared/utils/dateUtils';
 import * as S from './index.styled';
 import { InterviewTimeContentModal } from './InterviewTimeContentModal';
 import type { ApplicantData } from '@/pages/admin/Dashboard/types/dashboard';
@@ -40,16 +42,18 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
         <S.InfoText>{phoneNumber || '-'}</S.InfoText>
         <S.InfoText>{email || '-'}</S.InfoText>
         <S.StatusBadge status={status}>{STATUS_LABEL[status] || '-'}</S.StatusBadge>
-        {status === 'APPROVED' ? (
+        {status === 'APPROVED' && (
           <S.InfoText>
-            {confirmedTime || (
+            {confirmedTime ? (
+              <Text color='#8C8C8C' size='lg'>
+                {formatDateTime(confirmedTime)}
+              </Text>
+            ) : (
               <S.TimeSetter ref={timeSetterRef} onClick={handleTimeSetterClick}>
                 시간 선택
               </S.TimeSetter>
             )}
           </S.InfoText>
-        ) : (
-          <S.InfoText>-</S.InfoText>
         )}
       </S.ItemWrapper>
       <Modal

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
@@ -1,15 +1,13 @@
-import React from 'react';
+import React, { useRef } from 'react';
+import { STATUS_LABEL } from '@/pages/admin/Dashboard/utils/labelMap';
+import { Modal } from '@/shared/components/Modal';
+import { useModal } from '@/shared/hooks/useModal';
 import * as S from './index.styled';
+import { InterviewTimeContentModal } from './InterviewTimeContentModal';
 import type { ApplicantData } from '@/pages/admin/Dashboard/types/dashboard';
 
 type Props = ApplicantData & {
   onClick: (id: number) => void;
-};
-
-const STATUS_LABEL: Record<ApplicantData['status'], string> = {
-  PENDING: '미정',
-  REJECTED: '불합격',
-  APPROVED: '합격',
 };
 
 export const ApplicantListItem = React.memo(function ApplicantListItem({
@@ -21,28 +19,52 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
   email,
   status,
   confirmedTime,
+  interviewInfo,
+  interviewSchedule,
   onClick,
 }: Props) {
+  const { isOpen, openModal, closeModal } = useModal();
+  const timeSetterRef = useRef<HTMLButtonElement>(null);
+
   const handleTimeSetterClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    // 모달 열기
+    openModal();
   };
 
   return (
-    <S.ItemWrapper onClick={() => onClick(applicantId)}>
-      <S.InfoText>{name || '-'}</S.InfoText>
-      <S.InfoText>{studentId || '-'}</S.InfoText>
-      <S.InfoText>{department || '-'}</S.InfoText>
-      <S.InfoText>{phoneNumber || '-'}</S.InfoText>
-      <S.InfoText>{email || '-'}</S.InfoText>
-      <S.StatusBadge status={status}>{STATUS_LABEL[status] || '-'}</S.StatusBadge>
-      {status === 'APPROVED' ? (
-        <S.InfoText>
-          {confirmedTime || <S.TimeSetter onClick={handleTimeSetterClick}>시간 선택</S.TimeSetter>}
-        </S.InfoText>
-      ) : (
-        <S.InfoText>-</S.InfoText>
-      )}
-    </S.ItemWrapper>
+    <>
+      <S.ItemWrapper onClick={() => onClick(applicantId)}>
+        <S.InfoText>{name || '-'}</S.InfoText>
+        <S.InfoText>{studentId || '-'}</S.InfoText>
+        <S.InfoText>{department || '-'}</S.InfoText>
+        <S.InfoText>{phoneNumber || '-'}</S.InfoText>
+        <S.InfoText>{email || '-'}</S.InfoText>
+        <S.StatusBadge status={status}>{STATUS_LABEL[status] || '-'}</S.StatusBadge>
+        {status === 'APPROVED' ? (
+          <S.InfoText>
+            {confirmedTime || (
+              <S.TimeSetter ref={timeSetterRef} onClick={handleTimeSetterClick}>
+                시간 선택
+              </S.TimeSetter>
+            )}
+          </S.InfoText>
+        ) : (
+          <S.InfoText>-</S.InfoText>
+        )}
+      </S.ItemWrapper>
+      <Modal
+        isOpen={isOpen}
+        onClose={closeModal}
+        title='동아리 면접 공지 일정'
+        size='md'
+        variant='popover'
+        anchorRef={timeSetterRef}
+      >
+        <InterviewTimeContentModal
+          interviewInfo={interviewInfo}
+          interviewSchedule={interviewSchedule}
+        />
+      </Modal>
+    </>
   );
 });

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
@@ -1,11 +1,11 @@
 import React, { useRef } from 'react';
 import { STATUS_LABEL } from '@/pages/admin/Dashboard/utils/labelMap';
-import { Modal } from '@/shared/components/Modal';
+// import { Modal } from '@/shared/components/Modal';
 import { Text } from '@/shared/components/Text';
-import { useModal } from '@/shared/hooks/useModal';
+// import { useModal } from '@/shared/hooks/useModal';
 import { formatDateTime } from '@/shared/utils/dateUtils';
 import * as S from './index.styled';
-import { InterviewTimeContentModal } from './InterviewTimeContentModal';
+// import { InterviewTimeContentModal } from './InterviewTimeContentModal';
 import type { ApplicantData } from '@/pages/admin/Dashboard/types/dashboard';
 
 type Props = ApplicantData & {
@@ -21,16 +21,16 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
   email,
   status,
   confirmedTime,
-  interviewInfo,
-  interviewSchedule,
+  // interviewInfo,
+  // interviewSchedule,
   onClick,
 }: Props) {
-  const { isOpen, openModal, closeModal } = useModal();
+  // const { isOpen, openModal, closeModal } = useModal();
   const timeSetterRef = useRef<HTMLButtonElement>(null);
 
   const handleTimeSetterClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    openModal();
+    // openModal();
   };
 
   return (
@@ -56,7 +56,7 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
           </S.InfoText>
         )}
       </S.ItemWrapper>
-      <Modal
+      {/* <Modal
         isOpen={isOpen}
         onClose={closeModal}
         title='동아리 면접 공지 일정'
@@ -68,7 +68,7 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
           interviewInfo={interviewInfo}
           interviewSchedule={interviewSchedule}
         />
-      </Modal>
+      </Modal> */}
     </>
   );
 });

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
@@ -20,8 +20,14 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
   phoneNumber,
   email,
   status,
+  confirmedTime,
   onClick,
 }: Props) {
+  const handleTimeSetterClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    // 모달 열기
+  };
+
   return (
     <S.ItemWrapper onClick={() => onClick(applicantId)}>
       <S.InfoText>{name || '-'}</S.InfoText>
@@ -30,6 +36,13 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
       <S.InfoText>{phoneNumber || '-'}</S.InfoText>
       <S.InfoText>{email || '-'}</S.InfoText>
       <S.StatusBadge status={status}>{STATUS_LABEL[status] || '-'}</S.StatusBadge>
+      {status === 'APPROVED' ? (
+        <S.InfoText>
+          {confirmedTime || <S.TimeSetter onClick={handleTimeSetterClick}>시간 선택</S.TimeSetter>}
+        </S.InfoText>
+      ) : (
+        <S.InfoText>-</S.InfoText>
+      )}
     </S.ItemWrapper>
   );
 });

--- a/src/pages/admin/Dashboard/hooks/useApplicants.ts
+++ b/src/pages/admin/Dashboard/hooks/useApplicants.ts
@@ -30,7 +30,7 @@ export const useApplicants = (
     enabled: !!stage,
   });
 
-  const applicants = responseData?.applicants || [];
+  const applicants = useMemo(() => responseData?.applicants || [], [responseData?.applicants]);
 
   const filteredData = useMemo(() => {
     if (!Array.isArray(applicants)) return [];

--- a/src/pages/admin/Dashboard/types/dashboard.ts
+++ b/src/pages/admin/Dashboard/types/dashboard.ts
@@ -8,6 +8,11 @@ export type StatusLabel = '합격' | '불합격' | '미정';
 export type ApplicationStatus = 'APPROVED' | 'REJECTED' | 'PENDING';
 export type ApplicationFilterOption = 'ALL' | ApplicationStatus;
 
+export type InterviewInfo = {
+  interviewDate: string;
+  availableTimes: string[];
+};
+
 export type ApplicantData = {
   applicantId: number;
   name: string;
@@ -16,6 +21,8 @@ export type ApplicantData = {
   phoneNumber: string;
   email: string;
   status: ApplicationStatus;
+  confirmedTime?: string;
+  interviewInfo?: InterviewInfo[];
 };
 
 export type DashboardSummary = {

--- a/src/pages/admin/Dashboard/types/dashboard.ts
+++ b/src/pages/admin/Dashboard/types/dashboard.ts
@@ -32,6 +32,7 @@ export type ApplicantData = {
   status: ApplicationStatus;
   confirmedTime?: string;
   interviewInfo?: InterviewInfo[];
+  interviewSchedule?: InterviewSchedule[];
 };
 
 export type DashboardSummary = {

--- a/src/pages/admin/Dashboard/types/dashboard.ts
+++ b/src/pages/admin/Dashboard/types/dashboard.ts
@@ -4,6 +4,15 @@ export type DashboardCard = {
   value: string | number;
 };
 
+export type ApplicateInfoCategory =
+  | '이름'
+  | '학번'
+  | '학과'
+  | '전화번호'
+  | '이메일'
+  | '결과'
+  | '면접 시간';
+
 export type StatusLabel = '합격' | '불합격' | '미정';
 export type ApplicationStatus = 'APPROVED' | 'REJECTED' | 'PENDING';
 export type ApplicationFilterOption = 'ALL' | ApplicationStatus;

--- a/src/pages/admin/Dashboard/types/dashboard.ts
+++ b/src/pages/admin/Dashboard/types/dashboard.ts
@@ -42,7 +42,18 @@ export type ApplicantCounts = {
 export type ApplicationStage = '서류' | '면접';
 export type ApiStage = 'INTERVIEW' | 'FINAL';
 
+export type InterviewSlot = {
+  time: string;
+  assignedCount: number;
+};
+
+export type InterviewSchedule = {
+  date: string;
+  slots: InterviewSlot[];
+};
+
 export type ApplicantsApiResponse = {
   applicants: ApplicantData[];
+  interviewSchedule: InterviewSchedule[];
   message: string | null;
 };

--- a/src/pages/admin/Dashboard/utils/labelMap.ts
+++ b/src/pages/admin/Dashboard/utils/labelMap.ts
@@ -1,0 +1,12 @@
+import type { ApplicationStage, ApiStage, ApplicantData } from '../types/dashboard';
+
+export const STAGE_LABEL: Record<ApplicationStage, ApiStage> = {
+  서류: 'INTERVIEW',
+  면접: 'FINAL',
+};
+
+export const STATUS_LABEL: Record<ApplicantData['status'], string> = {
+  PENDING: '미정',
+  REJECTED: '불합격',
+  APPROVED: '합격',
+};

--- a/src/pages/admin/Dashboard/utils/stageMap.ts
+++ b/src/pages/admin/Dashboard/utils/stageMap.ts
@@ -1,6 +1,0 @@
-import type { ApplicationStage, ApiStage } from '../types/dashboard';
-
-export const stageMap: Record<ApplicationStage, ApiStage> = {
-  서류: 'INTERVIEW',
-  면접: 'FINAL',
-};

--- a/src/pages/user/Apply/hooks/useApplicationAutoSave.ts
+++ b/src/pages/user/Apply/hooks/useApplicationAutoSave.ts
@@ -1,5 +1,5 @@
 import type { UseFormReset, UseFormWatch } from 'react-hook-form';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { debounce } from '@/shared/utils/debounce';
 import type { FormInputs } from '../type/apply';
 
@@ -12,11 +12,12 @@ interface UseApplicationAutoSaveProps {
 export const useApplicationAutoSave = ({ clubId, watch, reset }: UseApplicationAutoSaveProps) => {
   const [isSaving, setIsSaving] = useState(false);
 
-  const debouncedSave = useCallback(
-    debounce((data: FormInputs) => {
-      localStorage.setItem(`application-form-${clubId}`, JSON.stringify(data));
-      setIsSaving(false);
-    }, 3000),
+  const debouncedSave = useMemo(
+    () =>
+      debounce((data: FormInputs) => {
+        localStorage.setItem(`application-form-${clubId}`, JSON.stringify(data));
+        setIsSaving(false);
+      }, 3000),
     [clubId],
   );
 

--- a/src/shared/utils/dateUtils.ts
+++ b/src/shared/utils/dateUtils.ts
@@ -9,3 +9,17 @@ export const formatDateWithoutYear = (date: string | Date) => {
   const day = dateObj.getDate();
   return `${month}/${day}`;
 };
+
+export const formatDateTime = (date: string | Date) => {
+  const dateObj = typeof date === 'string' ? new Date(date) : date;
+
+  const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+
+  const month = dateObj.getMonth() + 1;
+  const day = dateObj.getDate();
+  const dayOfWeek = dayNames[dateObj.getDay()];
+  const hours = dateObj.getHours();
+  const minutes = dateObj.getMinutes().toString().padStart(2, '0');
+
+  return `${month}/${day}(${dayOfWeek}) ${hours}:${minutes}`;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #411

## 📝작업 내용
대시보드 지원자 목록에 '면접 시간' 컬럼을 추가하고, 서류 합격자를 대상으로 면접 시간을 배정할 수 있는 기능을 구현했습니다.

### 1. 지원자 목록 테이블 컬럼 추가
- 테이블 헤더에 **면접 시간** 컬럼 추가
- 지원자의 상태가 **APPROVED**인 경우에만 **시간 선택** 버튼(또는 선택된 시간) 노출
### 2. 면접 시간 선택 Popover 구현 
- 시간 선택 버튼 클릭 시 면접 스케줄을 선택할 수 있는 모달
### 3. MSW Mock 데이터 추가 
- 면접 시간 배정 기능을 테스트할 수 있도록, 가상의 면접 스케줄 데이터를 핸들러에 추가

### 스크린샷 (선택)
<img width="1239" height="841" alt="image" src="https://github.com/user-attachments/assets/6f5baaf5-5afa-4fd1-a2fb-45bb4193a9cf" />

## 💬리뷰 요구사항(선택)

> 모달 코드는 따로 pr 올리겠습니다