### PR TITLE
[FEAT] 공통 모달 구현 (#248)

### DIFF
--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.styles.ts
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.styles.ts
@@ -21,6 +21,12 @@ export const AuthorInfo = styled.div({
   marginRight: '1rem',
 });
 
+export const RatingWrapper = styled.div({
+  marginLeft: '0.5rem',
+  display: 'flex',
+  alignItems: 'center',
+});
+
 export const NameRatingGroup = styled.div({
   display: 'flex',
   alignItems: 'center',
@@ -66,4 +72,11 @@ export const EditButtonContainer = styled.div({
   display: 'flex',
   justifyContent: 'flex-end',
   gap: '0.5rem',
+});
+
+export const ButtonGroup = styled.div({
+  display: 'flex',
+  gap: '0.5rem',
+  justifyContent: 'flex-end',
+  marginTop: '1.5rem',
 });

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/CommentItem/CommentItem.tsx
@@ -1,10 +1,12 @@
-import styled from '@emotion/styled';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAuth } from '@/app/providers/auth';
 import { ApplicantStarRating } from '@/pages/admin/ApplicationDetail/components/CommentSection/ApplicantStarRating';
 import { useComments } from '@/pages/admin/ApplicationDetail/hooks/useComments';
+import { Button } from '@/shared/components/Button';
+import { Modal } from '@/shared/components/Modal';
 import { Text } from '@/shared/components/Text';
+import { useModal } from '@/shared/hooks/useModal';
 import { CommentEditForm } from './CommentEditForm';
 import * as S from './CommentItem.styles';
 import type { Comment, CommentFormData } from '@/pages/admin/ApplicationDetail/types/comments';
@@ -17,6 +19,8 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
   const { deleteComment, updateComment } = useComments(Number(applicantId));
   const [isEditing, setIsEditing] = useState(false);
   const [editableRating, setEditableRating] = useState(rating);
+
+  const { isOpen, openModal, closeModal } = useModal();
 
   const handleEdit = () => {
     setIsEditing(true);
@@ -39,54 +43,60 @@ export const CommentItem = ({ author, commentId, content, createdAt, rating }: P
   };
 
   const handleDelete = () => {
-    deleteComment(commentId);
+    openModal();
   };
 
   return (
-    <S.Layout>
-      <S.Header>
-        <S.AuthorInfo>
-          <S.NameRatingGroup>
-            <Text size={'base'} weight={'medium'}>
-              {author.name}
-            </Text>
-            {rating !== undefined && (
-              <RatingWrapper>
-                <ApplicantStarRating
-                  rating={isEditing ? editableRating : rating}
-                  readOnly={!isEditing}
-                  onRatingChange={setEditableRating}
-                />
-              </RatingWrapper>
+    <>
+      <S.Layout>
+        <S.Header>
+          <S.AuthorInfo>
+            <S.NameRatingGroup>
+              <Text size={'base'} weight={'medium'}>
+                {author.name}
+              </Text>
+              {rating !== undefined && (
+                <S.RatingWrapper>
+                  <ApplicantStarRating
+                    rating={isEditing ? editableRating : rating}
+                    readOnly={!isEditing}
+                    onRatingChange={setEditableRating}
+                  />
+                </S.RatingWrapper>
+              )}
+            </S.NameRatingGroup>
+            {!isEditing && user?.userId === author.id && (
+              <S.ButtonContainer>
+                <S.ActionButton onClick={handleEdit}>수정</S.ActionButton>
+                <S.Divider>|</S.Divider>
+                <S.ActionButton onClick={handleDelete}>삭제</S.ActionButton>
+              </S.ButtonContainer>
             )}
-          </S.NameRatingGroup>
-          {!isEditing && user?.userId === author.id && (
-            <S.ButtonContainer>
-              <S.ActionButton onClick={handleEdit}>수정</S.ActionButton>
-              <S.Divider>|</S.Divider>
-              <S.ActionButton onClick={handleDelete}>삭제</S.ActionButton>
-            </S.ButtonContainer>
-          )}
-        </S.AuthorInfo>
+          </S.AuthorInfo>
 
-        <Text size={'xs'} weight={'medium'} color={'#616677'}>
-          {createdAt}
-        </Text>
-      </S.Header>
+          <Text size={'xs'} weight={'medium'} color={'#616677'}>
+            {createdAt}
+          </Text>
+        </S.Header>
 
-      {isEditing ? (
-        <CommentEditForm content={content} onSave={handleSave} onCancel={handleCancel} />
-      ) : (
-        <S.CommentContent>
-          <Text size={'sm'}>{content}</Text>
-        </S.CommentContent>
-      )}
-    </S.Layout>
+        {isEditing ? (
+          <CommentEditForm content={content} onSave={handleSave} onCancel={handleCancel} />
+        ) : (
+          <S.CommentContent>
+            <Text size={'sm'}>{content}</Text>
+          </S.CommentContent>
+        )}
+      </S.Layout>
+
+      <Modal isOpen={isOpen} onClose={closeModal} title='댓글 삭제' size='sm'>
+        <Text>댓글을 완전히 삭제할까요?</Text>
+        <S.ButtonGroup>
+          <Button onClick={closeModal} variant='outline'>
+            취소
+          </Button>
+          <Button onClick={() => deleteComment(commentId)}>삭제</Button>
+        </S.ButtonGroup>
+      </Modal>
+    </>
   );
 };
-
-const RatingWrapper = styled.div({
-  marginLeft: '0.5rem',
-  display: 'flex',
-  alignItems: 'center',
-});

--- a/src/shared/components/Modal/index.styled.ts
+++ b/src/shared/components/Modal/index.styled.ts
@@ -1,0 +1,131 @@
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
+
+const scaleIn = keyframes`
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+`;
+
+type OverlayProps = {
+  $variant?: 'modal' | 'popover';
+};
+
+export const Overlay = styled.div<OverlayProps>(({ $variant = 'modal' }) => ({
+  position: 'fixed',
+  inset: 0,
+  backgroundColor: $variant === 'popover' ? 'transparent' : 'rgba(0, 0, 0, 0.5)',
+  display: $variant === 'popover' ? 'block' : 'flex',
+  alignItems: $variant === 'popover' ? undefined : 'center',
+  justifyContent: $variant === 'popover' ? undefined : 'center',
+  zIndex: 50,
+  padding: $variant === 'popover' ? 0 : '1rem',
+  animation: `${fadeIn} 0.2s ease-out`,
+}));
+
+type ContentProps = {
+  $size?: 'sm' | 'md' | 'lg';
+  $variant?: 'modal' | 'popover';
+  $position?: { top: number; left: number };
+};
+
+const sizeMap = {
+  sm: '13rem',
+  md: '20rem',
+  lg: '30rem',
+};
+
+export const Content = styled.div<ContentProps>(
+  ({ theme, $size = 'md', $variant = 'modal', $position }) => ({
+    backgroundColor: '#fff',
+    borderRadius: theme.radius.lg,
+    boxShadow:
+      $variant === 'popover'
+        ? '0 4px 20px rgba(0, 0, 0, 0.15), 0 0 1px rgba(0, 0, 0, 0.1)'
+        : '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
+    width: sizeMap[$size],
+    maxWidth: '100%',
+    maxHeight: $variant === 'popover' ? '80vh' : '90vh',
+    overflow: 'auto',
+    padding: $variant === 'popover' ? '1.5rem' : '2rem',
+    animation: `${scaleIn} 0.2s ease-out`,
+
+    // popover일 때 position 계산 전에는 숨김
+    ...($variant === 'popover' &&
+      !$position && {
+        visibility: 'hidden',
+        position: 'fixed',
+      }),
+
+    // popover일 때 위치 지정 (fixed로 스크롤 시 따라감)
+    ...($variant === 'popover' &&
+      $position && {
+        position: 'fixed',
+        top: $position.top - 10,
+        left: $position.left - 30,
+      }),
+
+    [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+      padding: '1.5rem',
+      maxHeight: '85vh',
+    },
+  }),
+);
+
+export const Title = styled.h2(({ theme }) => ({
+  fontSize: theme.font.size.base,
+  fontWeight: 700,
+  color: theme.colors.gray900,
+  marginBottom: '0.5rem',
+
+  '&:focus': {
+    outline: 'none',
+  },
+}));
+
+export const Description = styled.p(({ theme }) => ({
+  fontSize: '1rem',
+  color: theme.colors.gray500,
+  marginBottom: '1.5rem',
+}));
+
+export const CloseButton = styled.button(({ theme }) => ({
+  position: 'absolute',
+  top: '1rem',
+  right: '1rem',
+  background: 'none',
+  border: 'none',
+  padding: '0.5rem',
+  cursor: 'pointer',
+  color: theme.colors.gray400,
+  borderRadius: theme.radius.sm,
+  transition: 'color 0.2s, background-color 0.2s',
+
+  '&:hover': {
+    color: theme.colors.gray600,
+    backgroundColor: theme.colors.gray100,
+  },
+}));
+
+export const Header = styled.div({
+  position: 'relative',
+  marginBottom: '1rem',
+});
+
+export const Body = styled.div({
+  marginBottom: '1.5rem',
+});

--- a/src/shared/components/Modal/index.styled.ts
+++ b/src/shared/components/Modal/index.styled.ts
@@ -28,7 +28,7 @@ type OverlayProps = {
 export const Overlay = styled.div<OverlayProps>(({ $variant = 'modal' }) => ({
   position: 'fixed',
   inset: 0,
-  backgroundColor: $variant === 'popover' ? 'transparent' : 'rgba(0, 0, 0, 0.5)',
+  backgroundColor: $variant === 'popover' ? 'transparent' : 'rgba(0, 0, 0, 0.3)',
   display: $variant === 'popover' ? 'block' : 'flex',
   alignItems: $variant === 'popover' ? undefined : 'center',
   justifyContent: $variant === 'popover' ? undefined : 'center',
@@ -63,6 +63,8 @@ export const Content = styled.div<ContentProps>(
     overflow: 'auto',
     padding: $variant === 'popover' ? '1.5rem' : '2rem',
     animation: `${scaleIn} 0.2s ease-out`,
+    display: 'flex',
+    flexDirection: 'column',
 
     // popover일 때 position 계산 전에는 숨김
     ...($variant === 'popover' &&
@@ -127,5 +129,7 @@ export const Header = styled.div({
 });
 
 export const Body = styled.div({
-  marginBottom: '1.5rem',
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
 });

--- a/src/shared/components/Modal/index.tsx
+++ b/src/shared/components/Modal/index.tsx
@@ -156,14 +156,19 @@ export const Modal = ({
 
       // 배경 스크롤 방지 (modal variant만)
       const originalOverflow = document.body.style.overflow;
+      const originalPaddingRight = document.body.style.paddingRight;
       if (variant === 'modal') {
+        // 스크롤바 너비 계산
+        const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
         document.body.style.overflow = 'hidden';
+        document.body.style.paddingRight = `${scrollbarWidth}px`;
       }
 
       return () => {
         document.removeEventListener('keydown', handleKeyDown);
         if (variant === 'modal') {
           document.body.style.overflow = originalOverflow;
+          document.body.style.paddingRight = originalPaddingRight;
         }
       };
     }

--- a/src/shared/components/Modal/index.tsx
+++ b/src/shared/components/Modal/index.tsx
@@ -1,0 +1,215 @@
+import {
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import * as S from './index.styled';
+
+type ModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  description?: string;
+  size?: 'sm' | 'md' | 'lg';
+  variant?: 'modal' | 'popover';
+  anchorRef?: RefObject<HTMLElement | null>;
+};
+
+/**
+ * 접근성을 고려한 모달 컴포넌트
+ * - ESC 키로 닫기
+ * - 포커스 트래핑
+ * - 배경 클릭으로 닫기
+ * - 스크린리더 지원 (aria-modal, aria-labelledby 등)
+ */
+export const Modal = ({
+  isOpen,
+  onClose,
+  title,
+  size,
+  children,
+  description,
+  variant = 'modal',
+  anchorRef,
+}: ModalProps) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const modalWidthRef = useRef<number>(0);
+  const titleId = useId();
+  const descriptionId = useId();
+  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+
+  // popover 위치 계산 함수
+  const updatePosition = useCallback(
+    (useStoredWidth = false) => {
+      if (variant === 'popover' && anchorRef?.current && modalRef.current) {
+        const anchorRect = anchorRef.current.getBoundingClientRect();
+
+        // 스크롤 시에는 저장된 width 사용, 초기에는 새로 계산
+        const modalWidth =
+          useStoredWidth && modalWidthRef.current > 0
+            ? modalWidthRef.current
+            : modalRef.current.getBoundingClientRect().width;
+
+        // 초기 width 저장
+        if (!useStoredWidth) {
+          modalWidthRef.current = modalWidth;
+        }
+
+        setPosition({
+          top: anchorRect.top,
+          left: anchorRect.left - modalWidth,
+        });
+      }
+    },
+    [variant, anchorRef],
+  );
+
+  // popover 위치 계산 - useLayoutEffect로 깜빡임 방지
+  useLayoutEffect(() => {
+    if (isOpen && variant === 'popover') {
+      updatePosition(false);
+    } else if (!isOpen) {
+      setPosition(null);
+      modalWidthRef.current = 0;
+    }
+  }, [isOpen, variant, updatePosition]);
+
+  // 스크롤 시 popover 위치 업데이트
+  useEffect(() => {
+    if (isOpen && variant === 'popover') {
+      const handleScroll = () => updatePosition(true);
+      window.addEventListener('scroll', handleScroll, true);
+      return () => window.removeEventListener('scroll', handleScroll, true);
+    }
+  }, [isOpen, variant, updatePosition]);
+
+  // 포커스 가능한 요소들 찾기
+  const getFocusableElements = useCallback((container: HTMLElement): HTMLElement[] => {
+    const selectors = [
+      'button:not([disabled])',
+      'input:not([disabled])',
+      'textarea:not([disabled])',
+      'select:not([disabled])',
+      'a[href]',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(', ');
+
+    return Array.from(container.querySelectorAll(selectors));
+  }, []);
+
+  // 포커스 트래핑
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (!modalRef.current) return;
+
+      // ESC 키로 닫기
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      // Tab 키 포커스 트래핑
+      if (event.key === 'Tab') {
+        const focusableElements = getFocusableElements(modalRef.current);
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (event.shiftKey) {
+          if (document.activeElement === firstElement) {
+            event.preventDefault();
+            lastElement?.focus();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            event.preventDefault();
+            firstElement?.focus();
+          }
+        }
+      }
+    },
+    [getFocusableElements, onClose],
+  );
+
+  // 모달 열림 시 포커스 관리 & 이벤트 리스너
+  useEffect(() => {
+    if (isOpen) {
+      // 현재 포커스 저장
+      previousFocusRef.current = document.activeElement as HTMLElement;
+
+      // 제목으로 포커스 이동
+      setTimeout(() => {
+        titleRef.current?.focus();
+      }, 100);
+
+      // 키보드 이벤트 리스너
+      document.addEventListener('keydown', handleKeyDown);
+
+      // 배경 스크롤 방지 (modal variant만)
+      const originalOverflow = document.body.style.overflow;
+      if (variant === 'modal') {
+        document.body.style.overflow = 'hidden';
+      }
+
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown);
+        if (variant === 'modal') {
+          document.body.style.overflow = originalOverflow;
+        }
+      };
+    }
+  }, [isOpen, handleKeyDown]);
+
+  // 모달 닫힘 시 포커스 복원
+  useEffect(() => {
+    if (!isOpen && previousFocusRef.current) {
+      setTimeout(() => {
+        previousFocusRef.current?.focus();
+      }, 100);
+    }
+  }, [isOpen]);
+
+  // 오버레이 클릭 시 닫기
+  const handleOverlayClick = (event: React.MouseEvent) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <S.Overlay onClick={handleOverlayClick} role='presentation' $variant={variant}>
+      <S.Content
+        ref={modalRef}
+        $size={size}
+        $variant={variant}
+        $position={position ?? undefined}
+        role='dialog'
+        aria-modal='true'
+        aria-labelledby={titleId}
+        aria-describedby={description ? descriptionId : undefined}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <S.Header>
+          <S.Title id={titleId} ref={titleRef} tabIndex={-1}>
+            {title}
+          </S.Title>
+          {description && <S.Description id={descriptionId}>{description}</S.Description>}
+        </S.Header>
+
+        <S.Body>{children}</S.Body>
+      </S.Content>
+    </S.Overlay>,
+    document.body,
+  );
+};

--- a/src/shared/hooks/useModal.ts
+++ b/src/shared/hooks/useModal.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from 'react';
+
+type UseModalReturn = {
+  isOpen: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+  toggle: () => void;
+};
+
+/**
+ * 모달 상태 관리 훅
+ *
+ * @example
+ * const { isOpen, openModal, closeModal } = useModal();
+ *
+ * <button onClick={openModal}>모달 열기</button>
+ * <Modal isOpen={isOpen} onClose={closeModal} title="제목">
+ *   모달 내용
+ * </Modal>
+ */
+export const useModal = (initialState = false): UseModalReturn => {
+  const [isOpen, setIsOpen] = useState(initialState);
+
+  const openModal = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  return {
+    isOpen,
+    openModal,
+    closeModal,
+    toggle,
+  };
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #248

## 📝작업 내용

### 1. Modal 컴포넌트 (Modal/index.tsx)

**Props:**
```
isOpen - 모달 열림/닫힘 상태
onClose - 모달 닫기 함수
title - 모달 제목
children - 모달 내용
description - 모달 설명 (선택)
size - 모달 크기 (sm | md | lg)
variant - 스타일 variant (modal | popover)
anchorRef - popover일 때 기준 요소 ref
```

**주요 기능:**
- React Portal: document.body에 렌더링
- 접근성: ESC 키 닫기, 포커스 트래핑, aria-modal, aria-labelledby
- Popover variant: 기준 요소 옆에 위치, 스크롤 시 따라감 (position: fixed)
- useLayoutEffect: popover 위치 계산 시 깜빡임 방지
- modalWidthRef: 스크롤 시 width 재계산 방지

### 2. useModal Hook (useModal.ts)
```js
const { isOpen, openModal, closeModal, toggle } = useModal();

isOpen - 모달 상태
openModal() - 모달 열기
closeModal() - 모달 닫기
toggle() - 토글
```
### 3. Modal 스타일 (Modal/index.styled.ts)
- fadeIn / scaleIn 애니메이션
- Overlay: modal은 반투명 배경, popover는 투명
- Content:
  - 크기: sm(13rem), md(20rem), lg(30rem)
  - popover일 때 position: fixed로 스크롤 따라감
  - position 계산 전 visibility: hidden (깜빡임 방지)