### PR TITLE
[FIX] 공지사항 리스트 호버 시 날짜 영역 레이아웃 깨짐 수정(#414)

### DIFF
--- a/src/pages/user/Notice/components/NoticeListCardSection/index.styled.ts
+++ b/src/pages/user/Notice/components/NoticeListCardSection/index.styled.ts
@@ -72,6 +72,7 @@ export const NoticeDate = styled.span(({ theme }) => ({
   color: theme.colors.textSecondary,
   width: '80px',
   textAlign: 'right',
+  whiteSpace: 'nowrap',
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
     width: 'auto',
     textAlign: 'left',
@@ -84,6 +85,7 @@ export const NoticeAuthor = styled.span(({ theme }) => ({
   color: theme.colors.textSecondary,
   width: '60px',
   textAlign: 'right',
+  whiteSpace: 'nowrap',
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
     width: 'auto',
     textAlign: 'left',


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #414 

## 📝작업 내용

> 🐛 Bug Fix: 공지사항 리스트 호버 UI 개선

- 문제점
공지사항 리스트에서 행 호버 시 `fontWeight: bold`가 적용되면서 날짜 영역이 두 줄로 줄바꿈되는 레이아웃 이슈

- 변경 사항
  - `NoticeDate`, `NoticeAuthor` 컴포넌트에 `white-space: nowrap` 속성 추가
  - 고정된 너비 내에서 텍스트가 한 줄로 유지되도록 처리


### 스크린샷 (선택)

<img width="668" height="145" alt="스크린샷 2026-02-05 오후 9 51 01" src="https://github.com/user-attachments/assets/b053ba6e-5e26-4f1b-8947-c4ad152a9c37" />

## 💬리뷰 요구사항(선택)


