### PR TITLE
[FIX] grid-template-columns 문자열 연결 시 공백 누락으로 인한 레이아웃 깨짐 수정

### DIFF
--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.styled.ts
@@ -7,7 +7,7 @@ export const Container = styled.div({
 export const ApplicantInfoCategoryList = styled.div<{ hasInterview: boolean }>`
   display: grid;
   grid-template-columns: ${({ hasInterview }) =>
-    '1fr 1fr 1fr 1.2fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')};
+    `1fr 1fr 1fr 1.2fr 1.5fr 1fr${hasInterview ? ' 1.2fr' : ''}`};
   background-color: #f9fbfc;
   border-bottom: 1.8px solid ${({ theme }) => theme.colors.gray100};
   padding: 1.7rem 0 1.5rem 0;
@@ -18,7 +18,7 @@ export const ApplicantInfoCategoryList = styled.div<{ hasInterview: boolean }>`
 
   @media (max-width: 1200px) {
     grid-template-columns: ${({ hasInterview }) =>
-      '1fr 1fr 1fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')};
+      `1fr 1fr 1fr 1.5fr 1fr${hasInterview ? ' 1.2fr' : ''}`};
 
     & > div:nth-of-type(4) {
       display: none;
@@ -27,7 +27,7 @@ export const ApplicantInfoCategoryList = styled.div<{ hasInterview: boolean }>`
 
   @media (max-width: ${({ theme }) => theme.breakpoints.web}) {
     grid-template-columns: ${({ hasInterview }) =>
-      '1fr 1fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')};
+      `1fr 1fr 1.5fr 1fr${hasInterview ? ' 1.2fr' : ''}`};
 
     & > div:nth-of-type(3) {
       display: none;
@@ -35,8 +35,7 @@ export const ApplicantInfoCategoryList = styled.div<{ hasInterview: boolean }>`
   }
 
   @media (max-width: 768px) {
-    grid-template-columns: ${({ hasInterview }) =>
-      '1fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')};
+    grid-template-columns: ${({ hasInterview }) => `1fr 1.5fr 1fr${hasInterview ? ' 1.2fr' : ''}`};
 
     & > div:nth-of-type(2) {
       display: none;

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.styled.ts
@@ -7,7 +7,7 @@ export const Container = styled.div({
 export const ApplicantInfoCategoryList = styled.div<{ hasInterview: boolean }>`
   display: grid;
   grid-template-columns: ${({ hasInterview }) =>
-    '1fr 1fr 1fr 1.2fr 1.5fr 1fr' + (hasInterview ? '1.2fr' : '')};
+    '1fr 1fr 1fr 1.2fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')};
   background-color: #f9fbfc;
   border-bottom: 1.8px solid ${({ theme }) => theme.colors.gray100};
   padding: 1.7rem 0 1.5rem 0;
@@ -18,7 +18,7 @@ export const ApplicantInfoCategoryList = styled.div<{ hasInterview: boolean }>`
 
   @media (max-width: 1200px) {
     grid-template-columns: ${({ hasInterview }) =>
-      '1fr 1fr 1fr 1.5fr 1fr' + (hasInterview ? '1.2fr' : '')};
+      '1fr 1fr 1fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')};
 
     & > div:nth-of-type(4) {
       display: none;
@@ -27,7 +27,7 @@ export const ApplicantInfoCategoryList = styled.div<{ hasInterview: boolean }>`
 
   @media (max-width: ${({ theme }) => theme.breakpoints.web}) {
     grid-template-columns: ${({ hasInterview }) =>
-      '1fr 1fr 1.5fr 1fr' + (hasInterview ? '1.2fr' : '')}
+      '1fr 1fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')};
 
     & > div:nth-of-type(3) {
       display: none;
@@ -35,7 +35,8 @@ export const ApplicantInfoCategoryList = styled.div<{ hasInterview: boolean }>`
   }
 
   @media (max-width: 768px) {
-    grid-template-columns: ${({ hasInterview }) => '1fr 1.5fr 1fr' + (hasInterview ? '1.2fr' : '')};
+    grid-template-columns: ${({ hasInterview }) =>
+      '1fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')};
 
     & > div:nth-of-type(2) {
       display: none;

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
@@ -4,7 +4,7 @@ import type { ApplicantData } from '@/pages/admin/Dashboard/types/dashboard';
 export const ItemWrapper = styled.div<{ hasInterview: boolean }>`
   display: grid;
   grid-template-columns: ${({ hasInterview }) =>
-    '1fr 1fr 1fr 1.2fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')};
+    `1fr 1fr 1fr 1.2fr 1.5fr 1fr${hasInterview ? ' 1.2fr' : ''}`};
   gap: 1rem;
   align-items: center;
   padding: 1.5rem 0;
@@ -21,7 +21,7 @@ export const ItemWrapper = styled.div<{ hasInterview: boolean }>`
 
   @media (max-width: 1200px) {
     grid-template-columns: ${({ hasInterview }) =>
-      '1fr 1fr 1fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')};
+      `1fr 1fr 1fr 1.5fr 1fr${hasInterview ? ' 1.2fr' : ''}`};
 
     & > p:nth-of-type(4) {
       display: none;
@@ -30,7 +30,7 @@ export const ItemWrapper = styled.div<{ hasInterview: boolean }>`
 
   @media (max-width: ${({ theme }) => theme.breakpoints.web}) {
     grid-template-columns: ${({ hasInterview }) =>
-      '1fr 1fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')};
+      `1fr 1fr 1.5fr 1fr${hasInterview ? ' 1.2fr' : ''}`};
 
     & > p:nth-of-type(3) {
       display: none;
@@ -38,8 +38,7 @@ export const ItemWrapper = styled.div<{ hasInterview: boolean }>`
   }
 
   @media (max-width: 768px) {
-    grid-template-columns: ${({ hasInterview }) =>
-      '1fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')};
+    grid-template-columns: ${({ hasInterview }) => `1fr 1.5fr 1fr${hasInterview ? ' 1.2fr' : ''}`};
 
     & > p:nth-of-type(2) {
       display: none;

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
@@ -44,19 +44,22 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
         <S.InfoText>{phoneNumber || '-'}</S.InfoText>
         <S.InfoText>{email || '-'}</S.InfoText>
         <S.StatusBadge status={status}>{STATUS_LABEL[status] || '-'}</S.StatusBadge>
-        {interviewRequired && status === 'APPROVED' && (
-          <S.InfoText>
-            {confirmedTime ? (
-              <Text color='#8C8C8C' size='lg'>
-                {formatDateTime(confirmedTime)}
-              </Text>
-            ) : (
-              <S.TimeSetter ref={timeSetterRef} onClick={handleTimeSetterClick}>
-                시간 선택
-              </S.TimeSetter>
-            )}
-          </S.InfoText>
-        )}
+        {interviewRequired &&
+          (status === 'APPROVED' ? (
+            <S.InfoText>
+              {confirmedTime ? (
+                <Text color='#8C8C8C' size='lg'>
+                  {formatDateTime(confirmedTime)}
+                </Text>
+              ) : (
+                <S.TimeSetter ref={timeSetterRef} onClick={handleTimeSetterClick}>
+                  시간 선택
+                </S.TimeSetter>
+              )}
+            </S.InfoText>
+          ) : (
+            <S.InfoText>-</S.InfoText>
+          ))}
       </S.ItemWrapper>
       <Modal
         isOpen={isOpen}


### PR DESCRIPTION

## 📝작업 내용
> `grid-template-columns` 문자열 연결 시 공백이 누락되어 대시보드 칼럼이 세로로 나열되는 문제가 발생

문자열 연결 시 공백을 추가하여 정상적인 그리드 레이아웃이 적용되도록 수정했습니다.

**수정 전**
```js
  grid-template-columns: ${({ hasInterview }) =>
    '1fr 1fr 1fr 1.2fr 1.5fr 1fr' + (hasInterview ? '1.2fr' : '')};
```

**수정 후**
```js
  grid-template-columns: ${({ hasInterview }) =>
    '1fr 1fr 1fr 1.2fr 1.5fr 1fr' + (hasInterview ? ' 1.2fr' : '')}; // 공백 추가
```
