### PR TITLE
[FIX] 포커스 설정과 이벤트 리스너 로직 분리로 모달 입력창 포커스 이탈 해결 (#428)

### DIFF
--- a/src/shared/components/Modal/index.tsx
+++ b/src/shared/components/Modal/index.tsx
@@ -140,37 +140,37 @@ export const Modal = ({
     [getFocusableElements, onClose],
   );
 
-  // 모달 열림 시 포커스 관리 & 이벤트 리스너
+  // 모달 열림 시 초기 포커스 & 스크롤 방지
   useEffect(() => {
     if (isOpen) {
-      // 현재 포커스 저장
       previousFocusRef.current = document.activeElement as HTMLElement;
 
-      // 제목으로 포커스 이동
       setTimeout(() => {
         titleRef.current?.focus();
       }, 100);
 
-      // 키보드 이벤트 리스너
-      document.addEventListener('keydown', handleKeyDown);
-
-      // 배경 스크롤 방지 (modal variant만)
       const originalOverflow = document.body.style.overflow;
       const originalPaddingRight = document.body.style.paddingRight;
       if (variant === 'modal') {
-        // 스크롤바 너비 계산
         const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
         document.body.style.overflow = 'hidden';
         document.body.style.paddingRight = `${scrollbarWidth}px`;
       }
 
       return () => {
-        document.removeEventListener('keydown', handleKeyDown);
         if (variant === 'modal') {
           document.body.style.overflow = originalOverflow;
           document.body.style.paddingRight = originalPaddingRight;
         }
       };
+    }
+  }, [isOpen, variant]);
+
+  // 키보드 이벤트 리스너 (handleKeyDown 변경 시 리스너만 교체)
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
     }
   }, [isOpen, handleKeyDown]);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #428 

## 📝작업 내용

문제 :  모달 내에서 UnderlineInputField를 사용하는 입력창들이 한글자 치면 수정이 안되게 포커스가 풀려버리는 문제가 있었음
원인 :  Modal/index.tsx:144-175에서 useEffect의 의존성 배열에 handleKeyDown이 포함되어 있음

  
입력 → formData 변경 → AddMemberModal 리렌더
handleClose 함수 재생성 → Modal의 onClose prop 변경
handleKeyDown이 onClose에 의존 → handleKeyDown 재생성
useEffect([isOpen, handleKeyDown]) 재실행 → 100ms 후 제목으로 포커스 이동
입력 중인 input에서 포커스가 빠짐

Modal의 useEffect에서 초기 포커스 설정과 키보드 이벤트 리스너 등록을 분리하여 해결함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

