### PR TITLE
[FEAT] 대시보드 지원자 면접 시간 선택 PATCH API 연동 (#419)

### DIFF
--- a/src/app/mocks/handler/dashboard.ts
+++ b/src/app/mocks/handler/dashboard.ts
@@ -11,6 +11,18 @@ const getApplicantsResolver = () => {
   return HttpResponse.json(applicants, { status: 200 });
 };
 
+const updateInterviewTimeResolver: Parameters<typeof http.patch>[1] = async ({
+  params,
+  request,
+}) => {
+  const body = (await request.json()) as { interviewAt: string };
+  console.log(
+    `[Mock] PATCH /clubs/${params.clubId}/applicants/${params.applicantId}/interview`,
+    body,
+  );
+  return HttpResponse.json({ message: '면접 시간이 설정되었습니다.' }, { status: 200 });
+};
+
 export const dashboardHandlers = [
   http.get(
     import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/dashboard',
@@ -19,5 +31,9 @@ export const dashboardHandlers = [
   http.get(
     import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/dashboard/applicants',
     getApplicantsResolver,
+  ),
+  http.patch(
+    import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/applicants/:applicantId/interview',
+    updateInterviewTimeResolver,
   ),
 ];

--- a/src/pages/admin/Dashboard/api/applicant.ts
+++ b/src/pages/admin/Dashboard/api/applicant.ts
@@ -14,3 +14,18 @@ export const fetchApplicants = async (
     throw error;
   }
 };
+
+export const updateInterviewTime = async (
+  clubId: number,
+  applicantId: number,
+  interviewAt: string,
+): Promise<void> => {
+  try {
+    await apiInstance.patch(`/clubs/${clubId}/applicants/${applicantId}/interview`, {
+      interviewAt,
+    });
+  } catch (error: unknown) {
+    handleAxiosError(error);
+    throw error;
+  }
+};

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
@@ -6,9 +6,18 @@ import type { InterviewInfo, InterviewSchedule } from '@/pages/admin/Dashboard/t
 type Props = {
   interviewInfo: InterviewInfo[];
   interviewSchedule: InterviewSchedule[];
+  onTimeSelect: (interviewAt: string) => void;
 };
 
-export const InterviewTimeContentModal = ({ interviewInfo, interviewSchedule }: Props) => {
+export const InterviewTimeContentModal = ({
+  interviewInfo,
+  interviewSchedule,
+  onTimeSelect,
+}: Props) => {
+  const handleSlotClick = (date: string, time: string) => {
+    onTimeSelect(`${date}T${time}:00`);
+  };
+
   return (
     <S.Container>
       <S.Section>
@@ -19,7 +28,10 @@ export const InterviewTimeContentModal = ({ interviewInfo, interviewSchedule }: 
                 <S.ScheduleDateLabel>{formatDateWithoutYear(schedule.date)}</S.ScheduleDateLabel>
                 <S.SlotsContainer>
                   {schedule.slots.map((slot) => (
-                    <S.TimeSlot key={slot.time}>
+                    <S.TimeSlot
+                      key={slot.time}
+                      onClick={() => handleSlotClick(schedule.date, slot.time)}
+                    >
                       <S.SlotTime>{slot.time}</S.SlotTime>
                       <S.SlotCount>({slot.assignedCount}명 선택)</S.SlotCount>
                     </S.TimeSlot>

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
@@ -6,17 +6,21 @@ import type { InterviewInfo, InterviewSchedule } from '@/pages/admin/Dashboard/t
 type Props = {
   interviewInfo: InterviewInfo[];
   interviewSchedule: InterviewSchedule[];
+  confirmedTime?: string | null;
   onTimeSelect: (interviewAt: string) => void;
 };
 
 export const InterviewTimeContentModal = ({
   interviewInfo,
   interviewSchedule,
+  confirmedTime,
   onTimeSelect,
 }: Props) => {
   const handleSlotClick = (date: string, time: string) => {
     onTimeSelect(`${date}T${time}:00`);
   };
+
+  const isSelected = (date: string, time: string) => confirmedTime === `${date}T${time}:00`;
 
   return (
     <S.Container>
@@ -30,6 +34,7 @@ export const InterviewTimeContentModal = ({
                   {schedule.slots.map((slot) => (
                     <S.TimeSlot
                       key={slot.time}
+                      $selected={isSelected(schedule.date, slot.time)}
                       onClick={() => handleSlotClick(schedule.date, slot.time)}
                     >
                       <S.SlotTime>{slot.time}</S.SlotTime>

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
@@ -71,6 +71,16 @@ export const TimeSetter = styled.button(({ theme }) => ({
   cursor: 'pointer',
 }));
 
+export const ConfirmedTimeSetter = styled.button(({ theme }) => ({
+  color: '#8C8C8C',
+  background: 'none',
+  fontSize: theme.font.size.lg,
+  border: 'none',
+  textDecoration: 'underline',
+  textUnderlineOffset: '5px',
+  cursor: 'pointer',
+}));
+
 export const StatusBadge = styled.p<Pick<ApplicantData, 'status'>>(({ theme, status }) => {
   const styles = {
     APPROVED: {

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
@@ -3,7 +3,6 @@ import { useParams } from 'react-router-dom';
 import { useUpdateInterviewTime } from '@/pages/admin/Dashboard/hooks/useUpdateInterviewTime';
 import { STATUS_LABEL } from '@/pages/admin/Dashboard/utils/labelMap';
 import { Modal } from '@/shared/components/Modal';
-import { Text } from '@/shared/components/Text';
 import { useModal } from '@/shared/hooks/useModal';
 import { formatDateTime } from '@/shared/utils/dateUtils';
 import * as S from './index.styled';
@@ -56,9 +55,9 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
           (status === 'APPROVED' ? (
             <S.InfoText>
               {confirmedTime ? (
-                <Text color='#8C8C8C' size='lg'>
+                <S.ConfirmedTimeSetter ref={timeSetterRef} onClick={handleTimeSetterClick}>
                   {formatDateTime(confirmedTime)}
-                </Text>
+                </S.ConfirmedTimeSetter>
               ) : (
                 <S.TimeSetter ref={timeSetterRef} onClick={handleTimeSetterClick}>
                   시간 선택
@@ -80,6 +79,7 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
         <InterviewTimeContentModal
           interviewInfo={interviewInfo}
           interviewSchedule={interviewSchedule}
+          confirmedTime={confirmedTime}
           onTimeSelect={handleTimeSelect}
         />
       </Modal>

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
@@ -1,4 +1,6 @@
 import React, { useRef } from 'react';
+import { useParams } from 'react-router-dom';
+import { useUpdateInterviewTime } from '@/pages/admin/Dashboard/hooks/useUpdateInterviewTime';
 import { STATUS_LABEL } from '@/pages/admin/Dashboard/utils/labelMap';
 import { Modal } from '@/shared/components/Modal';
 import { Text } from '@/shared/components/Text';
@@ -28,12 +30,18 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
   interviewRequired,
   onClick,
 }: Props) {
+  const { clubId } = useParams();
   const { isOpen, openModal, closeModal } = useModal();
+  const { updateTime } = useUpdateInterviewTime(Number(clubId), applicantId);
   const timeSetterRef = useRef<HTMLButtonElement>(null);
 
   const handleTimeSetterClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     openModal();
+  };
+
+  const handleTimeSelect = (interviewAt: string) => {
+    updateTime(interviewAt, { onSuccess: closeModal });
   };
   return (
     <>
@@ -72,6 +80,7 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
         <InterviewTimeContentModal
           interviewInfo={interviewInfo}
           interviewSchedule={interviewSchedule}
+          onTimeSelect={handleTimeSelect}
         />
       </Modal>
     </>

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
@@ -31,7 +31,7 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
 }: Props) {
   const { clubId } = useParams();
   const { isOpen, openModal, closeModal } = useModal();
-  const { updateTime } = useUpdateInterviewTime(Number(clubId), applicantId);
+  const { updateTime } = useUpdateInterviewTime(parseInt(clubId ?? '', 10), applicantId);
   const timeSetterRef = useRef<HTMLButtonElement>(null);
 
   const handleTimeSetterClick = (e: React.MouseEvent) => {

--- a/src/pages/admin/Dashboard/hooks/useUpdateInterviewTime.ts
+++ b/src/pages/admin/Dashboard/hooks/useUpdateInterviewTime.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateInterviewTime } from '@/pages/admin/Dashboard/api/applicant';
+
+export const useUpdateInterviewTime = (clubId: number, applicantId: number) => {
+  const queryClient = useQueryClient();
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (interviewAt: string) => updateInterviewTime(clubId, applicantId, interviewAt),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['applicants', clubId] });
+    },
+  });
+
+  return { updateTime: mutate, isPending };
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #419 

## 📝작업 내용
**1. useUpdateInterviewTime 훅 추가**  
- useMutation으로 PATCH 요청 후 invalidateQueries로 목록 자동 갱신
- 성공 시 invalidateQueries를 호출하여 지원자 목록 데이터 자동 갱신

**2. 면접 시간 선택 모달 개선**
- InterviewTimeContentModal 슬롯 클릭 시 onTimeSelect 콜백 호출
- confirmedTime과 비교하여 선택된 슬롯 하이라이트 표시

**3.  확정된 면접 시간의 재수정 기능 지원**
- 면접 시간이 이미 확정된 경우에도 클릭하여 시간 변경 가능하도록 수정 
- 변경이 가능함을 직관적으로 알 수 있도록 underline 버튼 스타일 적용
