### PR TITLE
[FEAT] 면접 탭 내 면접 시간 컬럼 상시 숨김 처리 (#431)

### DIFF
--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.tsx
@@ -30,10 +30,12 @@ export const ApplicantList = ({ filterOption, stage }: Props) => {
     interviewRequired,
   } = useApplicants(Number(clubId), apiStage, filterOption);
 
+  const showInterviewColumn = interviewRequired && stage === '서류';
+
   const categories = useMemo(() => {
     const base: ApplicateInfoCategory[] = ['이름', '학번', '학과', '전화번호', '이메일', '결과'];
-    return interviewRequired ? [...base, '면접 시간'] : base;
-  }, [interviewRequired]);
+    return showInterviewColumn ? [...base, '면접 시간'] : base;
+  }, [showInterviewColumn]);
 
   const handleItemClick = useCallback(
     (applicantId: number) => {
@@ -47,7 +49,7 @@ export const ApplicantList = ({ filterOption, stage }: Props) => {
 
   return (
     <S.Container>
-      <S.ApplicantInfoCategoryList hasInterview={interviewRequired}>
+      <S.ApplicantInfoCategoryList hasInterview={showInterviewColumn}>
         {categories.map((category) => (
           <S.CategoryText key={category}>{category}</S.CategoryText>
         ))}
@@ -68,7 +70,7 @@ export const ApplicantList = ({ filterOption, stage }: Props) => {
               confirmedTime={applicant.confirmedTime}
               interviewInfo={applicant.interviewInfo}
               interviewSchedule={interviewSchedule}
-              interviewRequired={interviewRequired}
+              interviewRequired={showInterviewColumn}
               onClick={handleItemClick}
             />
           ))


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #431

## 📝작업 내용

> 면접 단계 지원자를 관리하는 '면접 탭'에서 정보 중복을 방지하기 위해 '면접 시간' 컬럼을 상시 숨김 처리했습니다.


- 기존: interviewRequired가 true이면 컬럼 노출.
- 변경: interviewRequired가 true이면서 동시에 현재 탭이 '면접 탭'이 아닐 때만 컬럼이 노출되도록 분기 처리