### PR TITLE
[FEAT] 면접 시간 선택 모달 UI 개선 (#433)

### DIFF
--- a/src/pages/user/Apply/components/ApplicationForm/HorizontalInterviewScheduleSelector.tsx
+++ b/src/pages/user/Apply/components/ApplicationForm/HorizontalInterviewScheduleSelector.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { Button } from '@/shared/components/Button';
+import { DatePickerRow } from './index.styled';
+import { InterviewScheduleSelector } from './InterviewScheduleSelector';
+import type { InterviewSchedule, SelectedInterviewValue } from '@/pages/user/Apply/type/apply';
+
+type Props = {
+  timeSlotOptions: InterviewSchedule[];
+  onChange?: (value: SelectedInterviewValue) => void;
+};
+
+export const HorizontalInterviewScheduleSelector = ({ timeSlotOptions, onChange }: Props) => {
+  const [selectedDateIdx, setSelectedDateIdx] = useState(0);
+
+  return (
+    <div>
+      <DatePickerRow>
+        {timeSlotOptions.map((schedule, idx) => (
+          <Button
+            key={idx}
+            type='button'
+            variant={selectedDateIdx === idx ? undefined : 'outline'}
+            onClick={() => setSelectedDateIdx(idx)}
+            width='8rem'
+          >
+            {schedule.date}
+          </Button>
+        ))}
+      </DatePickerRow>
+
+      {timeSlotOptions.map((schedule, idx) => (
+        <div key={idx} style={{ display: selectedDateIdx === idx ? 'block' : 'none' }}>
+          <InterviewScheduleSelector
+            date={schedule.date}
+            availableTime={schedule.availableTime}
+            onChange={onChange}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/pages/user/Apply/components/ApplicationForm/HorizontalInterviewScheduleSelector.tsx
+++ b/src/pages/user/Apply/components/ApplicationForm/HorizontalInterviewScheduleSelector.tsx
@@ -21,7 +21,7 @@ export const HorizontalInterviewScheduleSelector = ({ timeSlotOptions, onChange 
             type='button'
             variant={selectedDateIdx === idx ? undefined : 'outline'}
             onClick={() => setSelectedDateIdx(idx)}
-            width='8rem'
+            width='7.5rem'
           >
             {schedule.date}
           </Button>

--- a/src/pages/user/Apply/components/ApplicationForm/InterviewScheduleSelector.tsx
+++ b/src/pages/user/Apply/components/ApplicationForm/InterviewScheduleSelector.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useDragSelection } from '@/pages/user/Apply/hooks/useDragSelection';
 import { getTimeSlotsArray } from '@/pages/user/Apply/utils/time';
 import { Text } from '@/shared/components/Text';
-import { TimeSpan, Wrapper, DateText, TimeSlotsContainer } from './index.styled';
+import { TimeSpan, Wrapper, TimeSlotsContainer } from './index.styled';
 import type { InterviewSchedule } from '@/pages/user/Apply/type/apply';
 
 export const InterviewScheduleSelector = ({ availableTime, date, onChange }: InterviewSchedule) => {
@@ -28,7 +28,6 @@ export const InterviewScheduleSelector = ({ availableTime, date, onChange }: Int
 
   return (
     <Wrapper>
-      <DateText>{date}</DateText>
       <TimeSlotsContainer>
         {timeSlotsArray.map((e, idx) => {
           return (

--- a/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
+++ b/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
@@ -131,6 +131,15 @@ export const DateText = styled.span(({ theme }) => ({
   whiteSpace: 'nowrap',
 }));
 
+export const DatePickerRow = styled.div({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: '8px',
+  overflowX: 'auto',
+  paddingBottom: '4px',
+  marginBottom: '1rem',
+});
+
 export const AutoSaveIndicator = styled.span(({ theme }) => ({
   position: 'fixed',
   top: '80px',

--- a/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
+++ b/src/pages/user/Apply/components/ApplicationForm/index.styled.ts
@@ -122,21 +122,10 @@ export const TimeSlotsContainer = styled.div({
   gap: '8px',
 });
 
-export const DateText = styled.span(({ theme }) => ({
-  textAlign: 'left',
-  minWidth: '150px',
-  padding: '10px 0 10px 3px',
-  fontWeight: theme.font.weight.bold,
-  fontSize: theme.font.size.sm,
-  whiteSpace: 'nowrap',
-}));
-
 export const DatePickerRow = styled.div({
   display: 'flex',
-  flexDirection: 'row',
+  flexWrap: 'wrap',
   gap: '8px',
-  overflowX: 'auto',
-  paddingBottom: '4px',
   marginBottom: '1rem',
 });
 

--- a/src/pages/user/Apply/components/ApplicationForm/index.tsx
+++ b/src/pages/user/Apply/components/ApplicationForm/index.tsx
@@ -8,14 +8,9 @@ import { Button } from '@/shared/components/Button';
 import { OutlineInputField } from '@/shared/components/Form/InputField/OutlineInputField';
 import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/OutlineTextareaField';
 import { Text } from '@/shared/components/Text';
+import { HorizontalInterviewScheduleSelector } from './HorizontalInterviewScheduleSelector';
 import * as S from './index.styled';
-import { InterviewScheduleSelector } from './InterviewScheduleSelector';
-import type {
-  FormInputs,
-  InterviewSchedule,
-  Question,
-  SelectedInterviewValue,
-} from '@/pages/user/Apply/type/apply';
+import type { FormInputs, Question } from '@/pages/user/Apply/type/apply';
 
 type Props = {
   questions: Question[];
@@ -231,24 +226,15 @@ export const ApplicationForm = ({ questions }: Props) => {
                     control={methods.control}
                     rules={{ required: '면접 시간을 선택하세요.' }}
                     render={({ field: controllerField }) => (
-                      <>
-                        {field.timeSlotOptions?.map(
-                          (interviewSchedule: InterviewSchedule, idx: number) => (
-                            <InterviewScheduleSelector
-                              key={idx}
-                              availableTime={interviewSchedule.availableTime}
-                              date={interviewSchedule.date}
-                              value={controllerField.value?.value as SelectedInterviewValue}
-                              onChange={(selectedInterviewSchedule) =>
-                                controllerField.onChange({
-                                  value: selectedInterviewSchedule,
-                                  questionType: QuestionTypes.TIME_SLOT,
-                                })
-                              }
-                            />
-                          ),
-                        )}
-                      </>
+                      <HorizontalInterviewScheduleSelector
+                        timeSlotOptions={field.timeSlotOptions ?? []}
+                        onChange={(selectedInterviewSchedule) =>
+                          controllerField.onChange({
+                            value: selectedInterviewSchedule,
+                            questionType: QuestionTypes.TIME_SLOT,
+                          })
+                        }
+                      />
                     )}
                   />
                 </S.ChoiceFormFiled>


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #433 

## 📝작업 내용

> 사용자가 스크롤을 최소화하기 위해 면접 시간 선택 레이아웃을 수직 나열 방식에서 수평 나열 방식으로 리팩토링했습니다.

**날짜별 타임슬롯 조건부 렌더링**
사용자가 상단에서 특정 날짜를 선택하면, 해당 날짜에 할당된 면접 시간대만 하단 영역에 노출되도록 변경

### 스크린샷 (선택)

<img width="779" height="239" alt="image" src="https://github.com/user-attachments/assets/0aac3c54-1db0-482a-bd95-2ed099d1d9d9" />
