### PR TITLE
[FIX] 면접 시간 선택 시 모든 날짜의 선택이 POST 요청에 포함되도록 수정 (#437)

### DIFF
--- a/src/pages/user/Apply/api/mappers/apply.ts
+++ b/src/pages/user/Apply/api/mappers/apply.ts
@@ -1,3 +1,4 @@
+import { QuestionTypes } from '../../constants/questionType';
 import type { FormInputs } from '../../type/apply';
 
 export const toApplyRequest = (formData: FormInputs, questions: string[]) => {
@@ -9,10 +10,22 @@ export const toApplyRequest = (formData: FormInputs, questions: string[]) => {
     studentId: formData.studentId,
     phoneNumber: formData.phoneNumber,
     department: formData.department,
-    answers: formDataAnswers.map((answer, index) => ({
-      questionNum: index,
-      question: questions[index],
-      answer,
-    })),
+    answers: formDataAnswers.map((answer, index) => {
+      if (answer?.questionType === QuestionTypes.TIME_SLOT) {
+        return {
+          questionNum: index,
+          question: questions[index],
+          answer: {
+            value: formData.selectedInterviewSchedule,
+            questionType: QuestionTypes.TIME_SLOT,
+          },
+        };
+      }
+      return {
+        questionNum: index,
+        question: questions[index],
+        answer,
+      };
+    }),
   };
 };

--- a/src/pages/user/Apply/api/mappers/apply.ts
+++ b/src/pages/user/Apply/api/mappers/apply.ts
@@ -1,5 +1,5 @@
-import { QuestionTypes } from '../../constants/questionType';
-import type { FormInputs } from '../../type/apply';
+import { QuestionTypes } from '@/pages/user/Apply/constants/questionType';
+import type { FormInputs } from '@/pages/user/Apply/type/apply';
 
 export const toApplyRequest = (formData: FormInputs, questions: string[]) => {
   const formDataAnswers = [...formData.answers];


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #437
## 원인
`toApplyRequest` 매퍼가 `answers` 필드의 `SelectedInterviewValue`(단일 날짜)를 사용함. 이 값은 `InterviewScheduleSelector`의 useEffect에서 onChange 호출 시마다 덮어씌워짐.

반면 `selectedInterviewSchedule`(모든 날짜 누적 배열)은 `useInterviewScheduleUpdater`에 의해 정상적으로 관리되고 있었으나, 매퍼에서 무시됨.

## 📝 변경 사항
`toApplyRequest` 매퍼에서 `TIME_SLOT` 타입 답변을 처리할 때 `answers`의 단일 `SelectedInterviewValue` 대신 `formData.selectedInterviewSchedule` 배열을 사용하도록 수정
