### PR TITLE
[FIX] 면접 시간 모달에서 availableTimes가 null/undefined일 때 에러 방지 (#439)

### DIFF
--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
@@ -58,7 +58,7 @@ export const InterviewTimeContentModal = ({
             {interviewInfo?.map((info) => (
               <S.AvailableTimesRow key={info.interviewDate}>
                 <S.DateLabel>{formatDateWithoutYear(info.interviewDate)}</S.DateLabel>
-                <S.AvailableTimes>{info.availableTimes.join(', ')}</S.AvailableTimes>
+                <S.AvailableTimes>{(info.availableTimes ?? []).join(', ')}</S.AvailableTimes>
               </S.AvailableTimesRow>
             ))}
           </>


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #439 

## 원인

InterviewTimeContentModal에서 info.availableTimes.join(', ') 호출 시, 실제 API가 availableTimes 필드를 null 또는 undefined로 반환하는 경우 에러 발생.

## 📝작업 내용

```js
// 변경 전
<S.AvailableTimes>{info.availableTimes.join(', ')}</S.AvailableTimes>
```

```js
// 변경 후
<S.AvailableTimes>{(info.availableTimes ?? []).join(', ')}</S.AvailableTimes>
```