### PR TITLE
[FEAT] 날짜 선택 UI 개선 (#441)

### DIFF
--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.styled.ts
@@ -20,31 +20,33 @@ export const SectionTitle = styled.h3(({ theme }) => ({
   borderBottom: `1px solid ${theme.colors.gray200}`,
 }));
 
-export const ScheduleRow = styled.div({
+export const DateTabsContainer = styled.div({
   display: 'flex',
-  alignItems: 'flex-start',
-  gap: '1rem',
+  flexWrap: 'wrap',
+  gap: '0.5rem',
 });
-export const ScheduleDateLabel = styled.span(({ theme }) => ({
-  fontSize: theme.font.size.sm,
-  fontWeight: 600,
-  color: theme.colors.gray700,
-  minWidth: '2.5rem',
-  paddingTop: '0.5rem',
-}));
 
-export const DateLabel = styled.span(({ theme }) => ({
+export const DateTab = styled.button<{ $active?: boolean }>(({ theme, $active }) => ({
+  padding: '0.375rem 0.75rem',
+  borderRadius: theme.radius.md,
+  border: `1px solid ${$active ? theme.colors.primary : theme.colors.gray300}`,
+  backgroundColor: $active ? theme.colors.primary00 : theme.colors.bg,
+  color: $active ? theme.colors.primary : theme.colors.gray600,
   fontSize: theme.font.size.sm,
-  fontWeight: 600,
-  color: theme.colors.gray700,
-  minWidth: '2.5rem',
+  fontWeight: $active ? 600 : 400,
+  cursor: 'pointer',
+  transition: 'all 0.2s',
+
+  '&:hover': {
+    borderColor: theme.colors.primary,
+    color: theme.colors.primary,
+  },
 }));
 
 export const SlotsContainer = styled.div({
   display: 'flex',
   flexWrap: 'wrap',
   gap: '0.5rem',
-  flex: 1,
 });
 
 export const TimeSlot = styled.button<{ $selected?: boolean }>(({ theme, $selected }) => ({
@@ -82,6 +84,13 @@ export const AvailableTimesRow = styled.div({
   alignItems: 'center',
   gap: '1rem',
 });
+
+export const DateLabel = styled.span(({ theme }) => ({
+  fontSize: theme.font.size.sm,
+  fontWeight: 600,
+  color: theme.colors.gray700,
+  minWidth: '2.5rem',
+}));
 
 export const AvailableTimes = styled.span(({ theme }) => ({
   fontSize: theme.font.size.sm,

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
@@ -18,11 +18,14 @@ export const InterviewTimeContentModal = ({
   onTimeSelect,
 }: Props) => {
   const confirmedDate = confirmedTime?.split('T')[0] ?? '';
-  const [selectedScheduleDate, setSelectedScheduleDate] = useState<string>(
-    interviewSchedule?.find((s) => s.date === confirmedDate)?.date ??
-      interviewSchedule?.[0]?.date ??
-      '',
-  );
+  const getInitialSelectedDate = () => {
+    const confirmedDateExists = interviewSchedule?.some((s) => s.date === confirmedDate);
+    if (confirmedDate && confirmedDateExists) {
+      return confirmedDate;
+    }
+    return interviewSchedule?.[0]?.date ?? '';
+  };
+  const [selectedScheduleDate, setSelectedScheduleDate] = useState<string>(getInitialSelectedDate);
   const handleSlotClick = (date: string, time: string) => {
     onTimeSelect(`${date}T${time}`);
   };

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
@@ -17,14 +17,18 @@ export const InterviewTimeContentModal = ({
   confirmedTime,
   onTimeSelect,
 }: Props) => {
+  const confirmedDate = confirmedTime?.split('T')[0] ?? '';
   const [selectedScheduleDate, setSelectedScheduleDate] = useState<string>(
-    interviewSchedule?.[0]?.date ?? '',
+    interviewSchedule?.find((s) => s.date === confirmedDate)?.date ??
+      interviewSchedule?.[0]?.date ??
+      '',
   );
   const handleSlotClick = (date: string, time: string) => {
     onTimeSelect(`${date}T${time}`);
   };
 
-  const isSelected = (date: string, time: string) => confirmedTime === `${date}T${time}`;
+  const isSelected = (date: string, time: string) =>
+    confirmedTime?.startsWith(`${date}T${time}`) ?? false;
 
   const activeSchedule = interviewSchedule?.find((s) => s.date === selectedScheduleDate);
 

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
@@ -58,7 +58,9 @@ export const InterviewTimeContentModal = ({
             {interviewInfo?.map((info) => (
               <S.AvailableTimesRow key={info.interviewDate}>
                 <S.DateLabel>{formatDateWithoutYear(info.interviewDate)}</S.DateLabel>
-                <S.AvailableTimes>{(info.availableTimes ?? []).join(', ')}</S.AvailableTimes>
+                <S.AvailableTimes>
+                  {(info.availableTimes ?? []).map(formatTime).join(', ')}
+                </S.AvailableTimes>
               </S.AvailableTimesRow>
             ))}
           </>

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
@@ -17,10 +17,10 @@ export const InterviewTimeContentModal = ({
   onTimeSelect,
 }: Props) => {
   const handleSlotClick = (date: string, time: string) => {
-    onTimeSelect(`${date}T${time}:00`);
+    onTimeSelect(`${date}T${time}`);
   };
 
-  const isSelected = (date: string, time: string) => confirmedTime === `${date}T${time}:00`;
+  const isSelected = (date: string, time: string) => confirmedTime === `${date}T${time}`;
 
   return (
     <S.Container>

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@/shared/components/Text';
-import { formatDateWithoutYear } from '@/shared/utils/dateUtils';
+import { formatDateWithoutYear, formatTime } from '@/shared/utils/dateUtils';
 import * as S from './InterviewTimeContentModal.styled';
 import type { InterviewInfo, InterviewSchedule } from '@/pages/admin/Dashboard/types/dashboard';
 
@@ -37,7 +37,7 @@ export const InterviewTimeContentModal = ({
                       $selected={isSelected(schedule.date, slot.time)}
                       onClick={() => handleSlotClick(schedule.date, slot.time)}
                     >
-                      <S.SlotTime>{slot.time}</S.SlotTime>
+                      <S.SlotTime>{formatTime(slot.time)}</S.SlotTime>
                       <S.SlotCount>({slot.assignedCount}명 선택)</S.SlotCount>
                     </S.TimeSlot>
                   ))}

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Text } from '@/shared/components/Text';
 import { formatDateWithoutYear, formatTime } from '@/shared/utils/dateUtils';
 import * as S from './InterviewTimeContentModal.styled';
@@ -16,34 +17,45 @@ export const InterviewTimeContentModal = ({
   confirmedTime,
   onTimeSelect,
 }: Props) => {
+  const [selectedScheduleDate, setSelectedScheduleDate] = useState<string>(
+    interviewSchedule?.[0]?.date ?? '',
+  );
   const handleSlotClick = (date: string, time: string) => {
     onTimeSelect(`${date}T${time}`);
   };
 
   const isSelected = (date: string, time: string) => confirmedTime === `${date}T${time}`;
 
+  const activeSchedule = interviewSchedule?.find((s) => s.date === selectedScheduleDate);
+
   return (
     <S.Container>
       <S.Section>
         {interviewSchedule?.length ? (
           <>
-            {interviewSchedule?.map((schedule) => (
-              <S.ScheduleRow key={schedule.date}>
-                <S.ScheduleDateLabel>{formatDateWithoutYear(schedule.date)}</S.ScheduleDateLabel>
-                <S.SlotsContainer>
-                  {schedule.slots.map((slot) => (
-                    <S.TimeSlot
-                      key={slot.time}
-                      $selected={isSelected(schedule.date, slot.time)}
-                      onClick={() => handleSlotClick(schedule.date, slot.time)}
-                    >
-                      <S.SlotTime>{formatTime(slot.time)}</S.SlotTime>
-                      <S.SlotCount>({slot.assignedCount}명 선택)</S.SlotCount>
-                    </S.TimeSlot>
-                  ))}
-                </S.SlotsContainer>
-              </S.ScheduleRow>
-            ))}
+            <S.DateTabsContainer>
+              {interviewSchedule.map((schedule) => (
+                <S.DateTab
+                  key={schedule.date}
+                  $active={schedule.date === selectedScheduleDate}
+                  onClick={() => setSelectedScheduleDate(schedule.date)}
+                >
+                  {formatDateWithoutYear(schedule.date)}
+                </S.DateTab>
+              ))}
+            </S.DateTabsContainer>
+            <S.SlotsContainer>
+              {activeSchedule?.slots.map((slot) => (
+                <S.TimeSlot
+                  key={slot.time}
+                  $selected={isSelected(selectedScheduleDate, slot.time)}
+                  onClick={() => handleSlotClick(selectedScheduleDate, slot.time)}
+                >
+                  <S.SlotTime>{formatTime(slot.time)}</S.SlotTime>
+                  <S.SlotCount>({slot.assignedCount}명 선택)</S.SlotCount>
+                </S.TimeSlot>
+              ))}
+            </S.SlotsContainer>
           </>
         ) : (
           <Text color='#595959' size='sm'>
@@ -55,7 +67,7 @@ export const InterviewTimeContentModal = ({
         <S.SectionTitle>지원자 면접 희망 시간대</S.SectionTitle>
         {interviewInfo?.length ? (
           <>
-            {interviewInfo?.map((info) => (
+            {interviewInfo.map((info) => (
               <S.AvailableTimesRow key={info.interviewDate}>
                 <S.DateLabel>{formatDateWithoutYear(info.interviewDate)}</S.DateLabel>
                 <S.AvailableTimes>

--- a/src/shared/utils/dateUtils.ts
+++ b/src/shared/utils/dateUtils.ts
@@ -10,7 +10,7 @@ export const formatDateWithoutYear = (date: string | Date) => {
   return `${month}/${day}`;
 };
 
-export const formatTime = (time: string) => time.slice(0, 5);
+export const formatTime = (time: string) => time.split(':').slice(0, 2).join(':');
 
 export const formatDateTime = (date: string | Date) => {
   const dateObj = typeof date === 'string' ? new Date(date) : date;

--- a/src/shared/utils/dateUtils.ts
+++ b/src/shared/utils/dateUtils.ts
@@ -10,6 +10,8 @@ export const formatDateWithoutYear = (date: string | Date) => {
   return `${month}/${day}`;
 };
 
+export const formatTime = (time: string) => time.slice(0, 5);
+
 export const formatDateTime = (date: string | Date) => {
   const dateObj = typeof date === 'string' ? new Date(date) : date;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #441 

## 📝작업 내용

> 예약 가능한 날짜가 많아질수록 사용자가 원하는 날짜를 찾기 위해 과도하게 화면을 스크롤을 해야 하는 문제를 해결하기 위해 상단 날짜 선택부와 하단 시간 선택부로 분리했습니다.

### 스크린샷 (선택)
**Before**: 날짜별로 세로로 길게 나열되어 스크롤이 매우 길었음
<img width="293" height="879" alt="image" src="https://github.com/user-attachments/assets/6540b710-5e2f-4981-a28a-d30df258fd50" />

**After**: 상단 날짜 탭 + 하단 해당 날짜 시간대 그리드 형태로 컴팩트하게 변경
<img width="287" height="125" alt="image" src="https://github.com/user-attachments/assets/a86375a5-5dd1-4195-a63a-ac40afcfd397" />

