### PR TITLE
[FEAT] 대시보드 및 헤더 텍스트 오버플로우 방지를 위한 말줄임표(...) 적용 (#443)

### DIFF
--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.styled.ts
@@ -57,8 +57,10 @@ export const ItemWrapper = styled.div<{ hasInterview: boolean }>`
 
 export const InfoText = styled.p(({ theme }) => ({
   fontSize: theme.font.size.lg,
-
   color: '#434547',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
 }));
 
 export const TimeSetter = styled.button(({ theme }) => ({

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/index.tsx
@@ -47,9 +47,9 @@ export const ApplicantListItem = React.memo(function ApplicantListItem({
       <S.ItemWrapper hasInterview={interviewRequired} onClick={() => onClick(applicantId)}>
         <S.InfoText>{name || '-'}</S.InfoText>
         <S.InfoText>{studentId || '-'}</S.InfoText>
-        <S.InfoText>{department || '-'}</S.InfoText>
-        <S.InfoText>{phoneNumber || '-'}</S.InfoText>
-        <S.InfoText>{email || '-'}</S.InfoText>
+        <S.InfoText title={department}>{department || '-'}</S.InfoText>
+        <S.InfoText title={phoneNumber}>{phoneNumber || '-'}</S.InfoText>
+        <S.InfoText title={email}>{email || '-'}</S.InfoText>
         <S.StatusBadge status={status}>{STATUS_LABEL[status] || '-'}</S.StatusBadge>
         {interviewRequired &&
           (status === 'APPROVED' ? (

--- a/src/shared/components/Navigation/components/ClubSelector/index.styled.ts
+++ b/src/shared/components/Navigation/components/ClubSelector/index.styled.ts
@@ -21,6 +21,13 @@ export const Selected = styled.div(({ theme }) => ({
   },
 }));
 
+export const ClubNameText = styled.span({
+  maxWidth: '8rem',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
 export const ChevronDownIcon = styled(FiChevronDown)(({ theme }) => ({
   color: theme.colors.gray400,
   transition: 'transform 0.2s ease-in-out, color 0.2s ease-in-out',

--- a/src/shared/components/Navigation/components/ClubSelector/index.tsx
+++ b/src/shared/components/Navigation/components/ClubSelector/index.tsx
@@ -25,7 +25,7 @@ export const ClubSelector = () => {
   return (
     <S.Wrapper>
       <S.Selected onClick={() => hasMultiple && setIsOpen((prev) => !prev)}>
-        <span>{displayName}</span>
+        <S.ClubNameText title={displayName}>{displayName}</S.ClubNameText>
         {hasMultiple && <S.ChevronDownIcon size={24} />}
       </S.Selected>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #443

## 📝작업 내용

> 긴 텍스트 입력 시 레이아웃이 두 줄로 깨지는 현상을 방지하기 위해 CSS의 text-overflow: ellipsis를 사용하여 말줄임표 처리를 적용했습니다.

**대시보드 테이블 컬럼 스타일 수정**
- '학과' 및 '이메일' 데이터 셀에 `white-space: nowrap`, `overflow: hidden`, `text-overflow: ellipsis` 스타일 적용

**헤더 동아리 이름 영역 개선**
- 헤더 우측의 동아리 이름 영역에 max-width 지정
- 이름이 길어지더라도 '지원폼 관리', '동아리페이지 관리' 등의 탭이 아래로 밀리지 않도록 고정
 