### PR TITLE
[FIX] 서비싱 전 동아리원 관리 및 지원 기능 다건 수정

### DIFF
--- a/src/app/mocks/repositories/club.ts
+++ b/src/app/mocks/repositories/club.ts
@@ -279,6 +279,9 @@ export const mockClubDetail: ClubDetail[] = [
     recruitStart: '2025-09-03T00:00:00',
     recruitEnd: '2025-09-20T23:59:00',
     applicationNotice: '현재 지원은 휴학생을 제외한 1~3학년만 받고 있습니다.',
+    isRegistered: true,
+    everyTimeUrl: '',
+    googleFormUrl: '',
   },
   {
     clubId: 2,
@@ -319,6 +322,9 @@ export const mockClubDetail: ClubDetail[] = [
     recruitStart: '2025-09-05T00:00:00',
     recruitEnd: '2025-09-25T23:59:00',
     applicationNotice: '1~4학년 모두 지원 가능합니다.',
+    isRegistered: true,
+    everyTimeUrl: '',
+    googleFormUrl: '',
   },
   {
     clubId: 3,
@@ -359,6 +365,9 @@ export const mockClubDetail: ClubDetail[] = [
     recruitStart: '2025-09-07T00:00:00',
     recruitEnd: '2025-09-30T23:59:00',
     applicationNotice: '모든 학년 지원 가능, 특별한 조건 없음.',
+    isRegistered: true,
+    everyTimeUrl: '',
+    googleFormUrl: '',
   },
 ];
 

--- a/src/app/providers/guards/ClubGuard.tsx
+++ b/src/app/providers/guards/ClubGuard.tsx
@@ -1,8 +1,14 @@
 import { Outlet } from 'react-router-dom';
 import { EmptyState } from '@/shared/components/EmptyState';
 import { useAuth } from '../auth';
+
 export const ClubGuard = () => {
   const { user } = useAuth();
+
+  if (import.meta.env.DEV) {
+    return <Outlet />;
+  }
+
   if (!user?.clubId) {
     return <EmptyState />;
   }

--- a/src/app/providers/guards/ClubGuard.tsx
+++ b/src/app/providers/guards/ClubGuard.tsx
@@ -1,14 +1,8 @@
 import { Outlet } from 'react-router-dom';
 import { EmptyState } from '@/shared/components/EmptyState';
 import { useAuth } from '../auth';
-
 export const ClubGuard = () => {
   const { user } = useAuth();
-
-  if (import.meta.env.DEV) {
-    return <Outlet />;
-  }
-
   if (!user?.clubId) {
     return <EmptyState />;
   }

--- a/src/pages/admin/ApplicationFormBuilder/Page.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/Page.tsx
@@ -7,6 +7,7 @@ import {
   useAdaptedPatchApplicationForm,
 } from '@/pages/admin/ApplicationFormBuilder/hooks/useApplicationFormAdapter';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { toast } from '@/shared/utils/toast';
 import { ApplicationInfoSection } from './components/ApplicationInfoSection';
 import { ApplicationFieldsFormTableSection } from './components/FieldsFormTableSection';
 import { ApplicationFormBuilderHeaderSection } from './components/HeaderSection';
@@ -46,6 +47,9 @@ export const ApplicationFormBuilderPage = () => {
     adaptedPatchForm(formData, {
       onSuccess: () => {
         setIsEditMode(false);
+      },
+      onError: (error) => {
+        toast.error(error.message || '지원서 저장에 실패했습니다.');
       },
     });
   });

--- a/src/pages/admin/ApplicationFormBuilder/api/apply-form.ts
+++ b/src/pages/admin/ApplicationFormBuilder/api/apply-form.ts
@@ -1,4 +1,4 @@
-import { type AxiosResponse } from 'axios';
+import axios, { type AxiosResponse } from 'axios';
 import { apiInstance } from '@/app/api/initInstance';
 import { handleAxiosError } from '@/shared/utils/handleAxiosError';
 import type { ApplicationForm } from '../types/fieldType';
@@ -42,6 +42,12 @@ export const patchApplicationForm = async ({
     );
     return response.data;
   } catch (e) {
+    if (axios.isAxiosError(e)) {
+      const detail = e.response?.data?.detail;
+      if (typeof detail === 'string') {
+        throw new Error(detail.split(': ').pop());
+      }
+    }
     return handleAxiosError(e, '지원서 저장에 실패했습니다.');
   }
 };

--- a/src/pages/admin/ApplicationFormBuilder/api/apply-form.ts
+++ b/src/pages/admin/ApplicationFormBuilder/api/apply-form.ts
@@ -35,9 +35,13 @@ export const patchApplicationForm = async ({
   clubId: number;
   form: Partial<ApplicationForm>;
 }): Promise<ApplicationForm> => {
-  const response: AxiosResponse<ApplicationForm> = await apiInstance.patch(
-    `/clubs/${clubId}/dashboard/apply-form`,
-    form,
-  );
-  return response.data;
+  try {
+    const response: AxiosResponse<ApplicationForm> = await apiInstance.patch(
+      `/clubs/${clubId}/dashboard/apply-form`,
+      form,
+    );
+    return response.data;
+  } catch (e) {
+    return handleAxiosError(e, '지원서 저장에 실패했습니다.');
+  }
 };

--- a/src/pages/admin/ApplicationFormBuilder/api/apply-form.ts
+++ b/src/pages/admin/ApplicationFormBuilder/api/apply-form.ts
@@ -1,4 +1,4 @@
-import axios, { type AxiosResponse } from 'axios';
+import { type AxiosResponse } from 'axios';
 import { apiInstance } from '@/app/api/initInstance';
 import { handleAxiosError } from '@/shared/utils/handleAxiosError';
 import type { ApplicationForm } from '../types/fieldType';
@@ -42,12 +42,6 @@ export const patchApplicationForm = async ({
     );
     return response.data;
   } catch (e) {
-    if (axios.isAxiosError(e)) {
-      const detail = e.response?.data?.detail;
-      if (typeof detail === 'string') {
-        throw new Error(detail.split(': ').pop());
-      }
-    }
-    return handleAxiosError(e, '지원서 저장에 실패했습니다.');
+    return handleAxiosError(e, '지원서 저장에 실패했습니다.', { useDetail: true });
   }
 };

--- a/src/pages/admin/MemberManagement/Page.tsx
+++ b/src/pages/admin/MemberManagement/Page.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { useAuth } from '@/app/providers/auth';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { useModal } from '@/shared/hooks/useModal';
 import { MemberHeaderSection } from './components/MemberHeaderSection';
@@ -15,6 +16,7 @@ import type { AddMemberFormData } from './types/member';
 
 export const MemberManagementPage = () => {
   const { clubId } = useParams<{ clubId: string }>();
+  const { user } = useAuth();
 
   // Modal states
   const addMemberModal = useModal();
@@ -70,7 +72,7 @@ export const MemberManagementPage = () => {
       <S.Container>
         <S.ContentWrapper>
           <MemberHeaderSection
-            clubName='인터엑스'
+            clubName={user?.clubName ?? ''}
             searchText={searchText}
             sortBy={sortBy}
             onSearchChange={setSearchText}

--- a/src/pages/admin/MemberManagement/api/downloadRegistrationForm.ts
+++ b/src/pages/admin/MemberManagement/api/downloadRegistrationForm.ts
@@ -1,0 +1,5 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export const downloadRegistrationForm = () => {
+  window.open(`${API_BASE_URL}/clubs/members/registration-form`, '_blank');
+};

--- a/src/pages/admin/MemberManagement/components/MemberTableSection/MemberTableRow.tsx
+++ b/src/pages/admin/MemberManagement/components/MemberTableSection/MemberTableRow.tsx
@@ -10,7 +10,7 @@ type MemberTableRowProps = {
   onMemberUpdate: (memberId: number, field: keyof Member, value: string) => void;
 };
 
-const ROLES: MemberRole[] = ['회장단', '운영팀', '동아리원'];
+const ROLES: MemberRole[] = ['회장', '운영팀', '동아리원'];
 
 export const MemberTableRow = ({
   member,

--- a/src/pages/admin/MemberManagement/components/modals/AddMemberModal.tsx
+++ b/src/pages/admin/MemberManagement/components/modals/AddMemberModal.tsx
@@ -37,7 +37,7 @@ const ROLE_OPTIONS: ApiRole[] = ['CLUB_MEMBER', 'CLUB_EXECUTIVE', 'CLUB_ADMIN'];
 const ROLE_LABELS: Record<ApiRole, string> = {
   CLUB_MEMBER: '동아리원',
   CLUB_EXECUTIVE: '운영팀',
-  CLUB_ADMIN: '회장단',
+  CLUB_ADMIN: '회장',
 };
 
 const getCurrentYearMonth = (): string => {

--- a/src/pages/admin/MemberManagement/components/modals/BulkUploadModal.styled.ts
+++ b/src/pages/admin/MemberManagement/components/modals/BulkUploadModal.styled.ts
@@ -57,6 +57,23 @@ export const Notice = styled.p(({ theme }) => ({
   lineHeight: 1.5,
 }));
 
+export const DownloadLink = styled.button(({ theme }) => ({
+  fontSize: theme.font.size.sm,
+  color: theme.colors.textPrimary,
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  margin: 0,
+  textDecoration: 'underline',
+  cursor: 'pointer',
+  transition: 'color 0.2s, transform 0.2s',
+
+  '&:hover': {
+    color: theme.colors.blue700,
+    transform: 'translateY(-2px)',
+  },
+}));
+
 export const ButtonWrapper = styled.div({
   display: 'flex',
   justifyContent: 'center',

--- a/src/pages/admin/MemberManagement/components/modals/BulkUploadModal.tsx
+++ b/src/pages/admin/MemberManagement/components/modals/BulkUploadModal.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
+import { downloadRegistrationForm } from '@/pages/admin/MemberManagement/api/downloadRegistrationForm';
 import { Button } from '@/shared/components/Button';
 import { Modal } from '@/shared/components/Modal';
+import { toast } from '@/shared/utils/toast';
 import * as S from './BulkUploadModal.styled';
 
 type BulkUploadModalProps = {
@@ -22,6 +24,14 @@ export const BulkUploadModal = ({ isOpen, onClose, onUpload }: BulkUploadModalPr
       } else {
         alert('엑셀 파일(.xlsx, .xls)만 업로드 가능합니다.');
       }
+    }
+  };
+
+  const handleDownloadTemplate = async () => {
+    try {
+      await downloadRegistrationForm();
+    } catch {
+      toast.error('양식 파일 다운로드에 실패했습니다.');
     }
   };
 
@@ -56,6 +66,9 @@ export const BulkUploadModal = ({ isOpen, onClose, onUpload }: BulkUploadModalPr
         {file && <S.FileName>선택된 파일: {file.name}</S.FileName>}
 
         <S.Notice>※ 주의: 엑셀 파일의 첫번째 줄(헤더)는 정해진 양식을 따라야 합니다.</S.Notice>
+        <S.DownloadLink type='button' onClick={handleDownloadTemplate}>
+          양식 다운로드하기!
+        </S.DownloadLink>
 
         <S.ButtonWrapper>
           <Button onClick={handleSubmit} disabled={!file}>

--- a/src/pages/admin/MemberManagement/hooks/useMemberFilter.ts
+++ b/src/pages/admin/MemberManagement/hooks/useMemberFilter.ts
@@ -1,5 +1,11 @@
 import { useState, useMemo } from 'react';
-import type { Member, SortOption } from '../types/member';
+import type { Member, MemberRole, SortOption } from '../types/member';
+
+const ROLE_PRIORITY: Record<MemberRole, number> = {
+  회장: 0,
+  운영팀: 1,
+  동아리원: 2,
+};
 
 export const useMemberFilter = (members: Member[]) => {
   const [searchText, setSearchText] = useState('');
@@ -13,12 +19,14 @@ export const useMemberFilter = (members: Member[]) => {
       ),
     );
 
-    // 2. 정렬
+    // 2. 정렬 (역할 우선, 같은 역할 내에서 이름순/등록순)
     const sorted = [...filtered].sort((a, b) => {
+      const roleDiff = ROLE_PRIORITY[a.role] - ROLE_PRIORITY[b.role];
+      if (roleDiff !== 0) return roleDiff;
+
       if (sortBy === '이름순') {
         return a.name.localeCompare(b.name, 'ko');
       }
-      // 등록순 (joinDate 기준)
       return new Date(a.joinDate).getTime() - new Date(b.joinDate).getTime();
     });
 

--- a/src/pages/admin/MemberManagement/types/member.ts
+++ b/src/pages/admin/MemberManagement/types/member.ts
@@ -1,22 +1,22 @@
 // UI용 역할 타입 (화면 표시용)
-export type MemberRole = '회장단' | '운영팀' | '동아리원';
+export type MemberRole = '회장' | '운영팀' | '동아리원';
 
 // API용 역할 타입
 export type ApiRole =
-  | 'CLUB_ADMIN' // 회장단
+  | 'CLUB_ADMIN' // 회장
   | 'CLUB_EXECUTIVE' // 운영팀
   | 'CLUB_MEMBER'; // 동아리원
 
 // API → UI 역할 매핑
 export const API_ROLE_TO_UI: Record<ApiRole, MemberRole> = {
-  CLUB_ADMIN: '회장단',
+  CLUB_ADMIN: '회장',
   CLUB_EXECUTIVE: '운영팀',
   CLUB_MEMBER: '동아리원',
 };
 
 // UI → API 역할 매핑
 export const UI_ROLE_TO_API: Record<MemberRole, ApiRole> = {
-  회장단: 'CLUB_ADMIN',
+  회장: 'CLUB_ADMIN',
   운영팀: 'CLUB_EXECUTIVE',
   동아리원: 'CLUB_MEMBER',
 };

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -55,6 +55,9 @@ export const ClubDetailPage = () => {
           recruitStatus={club.recruitStatus}
           applicationNotice={club.applicationNotice}
           clubId={club.clubId}
+          isRegistered={club.isRegistered}
+          everyTimeUrl={club.everyTimeUrl}
+          googleFormUrl={club.googleFormUrl}
         />
       }
     />

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ApplyButton.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ApplyButton.tsx
@@ -28,18 +28,20 @@ const ApplyButton = ({
     disabled: !isRecruiting,
   };
 
+  const isValidUrl = (url: string) => /^https?:\/\//.test(url);
+
   const handleApplyClick = () => {
     if (isRegistered) {
       navigate(to);
       return;
     }
 
-    if (googleFormUrl) {
+    if (googleFormUrl && isValidUrl(googleFormUrl)) {
       window.open(googleFormUrl, '_blank');
       return;
     }
 
-    if (everyTimeUrl) {
+    if (everyTimeUrl && isValidUrl(everyTimeUrl)) {
       window.open(everyTimeUrl, '_blank');
       return;
     }

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ApplyButton.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ApplyButton.tsx
@@ -1,15 +1,25 @@
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/shared/components/Button';
+import { toast } from '@/shared/utils/toast';
 import type { RecruitStatus } from '@/pages/user/Main/types/club';
 
 type Props = {
   recruitStatus: RecruitStatus;
   to: string;
   width?: string;
-  children?: React.ReactNode;
+  isRegistered: boolean;
+  everyTimeUrl: string;
+  googleFormUrl: string;
 };
 
-const ApplyButton = ({ recruitStatus, to, width }: Props) => {
+const ApplyButton = ({
+  recruitStatus,
+  to,
+  width,
+  isRegistered,
+  everyTimeUrl,
+  googleFormUrl,
+}: Props) => {
   const navigate = useNavigate();
   const isRecruiting = recruitStatus === '모집중';
 
@@ -19,7 +29,22 @@ const ApplyButton = ({ recruitStatus, to, width }: Props) => {
   };
 
   const handleApplyClick = () => {
-    navigate(to);
+    if (isRegistered) {
+      navigate(to);
+      return;
+    }
+
+    if (googleFormUrl) {
+      window.open(googleFormUrl, '_blank');
+      return;
+    }
+
+    if (everyTimeUrl) {
+      window.open(everyTimeUrl, '_blank');
+      return;
+    }
+
+    toast.error('지원하기 링크를 확인할 수 없는 동아리입니다.');
   };
 
   return <Button {...applyButtonProps} width={width} onClick={handleApplyClick} />;

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -14,6 +14,9 @@ type ClubInfoSidebarSectionProps = Pick<
   | 'regularMeetingInfo'
   | 'recruitStatus'
   | 'applicationNotice'
+  | 'isRegistered'
+  | 'everyTimeUrl'
+  | 'googleFormUrl'
 >;
 
 export const ClubInfoSidebarSection = ({
@@ -26,6 +29,9 @@ export const ClubInfoSidebarSection = ({
   regularMeetingInfo,
   recruitStatus,
   applicationNotice,
+  isRegistered,
+  everyTimeUrl,
+  googleFormUrl,
 }: ClubInfoSidebarSectionProps) => {
   return (
     <SidebarContainer>
@@ -37,7 +43,14 @@ export const ClubInfoSidebarSection = ({
       </InfoItem>
       <InfoItem>정기 모임: {regularMeetingInfo}</InfoItem>
       <InfoItem>모집 상태: {recruitStatus}</InfoItem>
-      <ApplyButton recruitStatus={recruitStatus} to={`/clubs/${clubId}/apply`} width={'auto'} />
+      <ApplyButton
+        recruitStatus={recruitStatus}
+        to={`/clubs/${clubId}/apply`}
+        width={'auto'}
+        isRegistered={isRegistered}
+        everyTimeUrl={everyTimeUrl}
+        googleFormUrl={googleFormUrl}
+      />
       <Notice>{applicationNotice}</Notice>
     </SidebarContainer>
   );

--- a/src/pages/user/ClubDetail/types/clubDetail.ts
+++ b/src/pages/user/ClubDetail/types/clubDetail.ts
@@ -20,4 +20,7 @@ export type ClubDetail = {
   recruitStart: string;
   recruitEnd: string;
   applicationNotice: string;
+  isRegistered: boolean;
+  everyTimeUrl: string;
+  googleFormUrl: string;
 };

--- a/src/shared/utils/handleAxiosError.ts
+++ b/src/shared/utils/handleAxiosError.ts
@@ -1,6 +1,20 @@
-export const handleAxiosError = (error: unknown, defaultMessage?: string): never => {
+export const handleAxiosError = (
+  error: unknown,
+  defaultMessage?: string,
+  { useDetail = false }: { useDetail?: boolean } = {},
+): never => {
   if (error && typeof error === 'object' && 'response' in error) {
-    const axiosError = error as { response?: { data?: { message?: string } } };
+    const axiosError = error as {
+      response?: { data?: { message?: string; detail?: string } };
+    };
+
+    if (useDetail) {
+      const detail = axiosError.response?.data?.detail;
+      if (typeof detail === 'string') {
+        throw new Error(detail.split(': ').pop());
+      }
+    }
+
     const message = axiosError.response?.data?.message || defaultMessage;
     throw new Error(message);
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 2026.02.28 백엔드 두명(준서, 지민) 과 모여서 내일 서비싱하는 것 대비한 급한 수정사항들을 전반적으로 커밋했습니다. 
급한 사항들로 인해 이슈가 선행되지 않았으며, 하나하나 따로 브랜치를 파지 않았으니 pr메세지를 자세히 올립니다!

## 📝작업 내용

### 동아리 상세페이지
- 지원하기 버튼에 isRegistered 여부에 따른 외부 링크(googleFormUrl/everyTimeUrl) 분기 처리 추가, api연결

### 동아리원 관리 페이지
- 동아리 이름이 동적으로 적용되지 않은 이슈 해결
- 동아리원 역할 표시명 '회장단' → '회장'으로 변경 (1명이기 때문에)
- 동아리원 목록 정렬 시 역할 우선순위(회장 → 운영팀 → 동아리원 순서이고, 그 안에서 이름순 및 등록순이 적용되도록) 적용
### 동아리원 관리 페이지 - 엑셀로 회원등록 모달
- 엑셀 일괄 등록 모달에 양식 다운로드 기능 및 API 추가 (다운로드 및 등록 되는지까지 확인 완료)

### 지원폼 생성 페이지
- 지원서 빌더에서 면접 시간 유효성 에러 시 토스트 알림 추가
- 에러 디테일을 띄우기 위해 api도 살짝 수정




## 💬리뷰 요구사항(선택)

> 하은이가 쓴 코드 페이지 (지원서빌더 페이지)에 에러메세지 띄워달라는 요청에 의해 수정한 것들이 있습니다
