### PR TITLE
[FIX] availableTimes → availableTime 필드명 불일치 수정

### DIFF
--- a/src/app/mocks/repositories/dashboard.ts
+++ b/src/app/mocks/repositories/dashboard.ts
@@ -44,7 +44,7 @@ const MOCK_APPLICANTS: ApplicantData[] = [
     interviewInfo: [
       {
         interviewDate: '2026-09-02',
-        availableTimes: ['14:00', '15:00', '16:00'],
+        availableTime: ['14:00', '15:00', '16:00'],
       },
     ],
   },
@@ -60,7 +60,7 @@ const MOCK_APPLICANTS: ApplicantData[] = [
     interviewInfo: [
       {
         interviewDate: '2026-09-02',
-        availableTimes: ['10:00', '11:00'],
+        availableTime: ['10:00', '11:00'],
       },
     ],
   },
@@ -76,7 +76,7 @@ const MOCK_APPLICANTS: ApplicantData[] = [
     interviewInfo: [
       {
         interviewDate: '2026-09-03',
-        availableTimes: ['10:00', '11:00', '14:00'],
+        availableTime: ['10:00', '11:00', '14:00'],
       },
     ],
   },

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.tsx
@@ -78,7 +78,7 @@ export const InterviewTimeContentModal = ({
               <S.AvailableTimesRow key={info.interviewDate}>
                 <S.DateLabel>{formatDateWithoutYear(info.interviewDate)}</S.DateLabel>
                 <S.AvailableTimes>
-                  {(info.availableTimes ?? []).map(formatTime).join(', ')}
+                  {(info.availableTime ?? []).map(formatTime).join(', ')}
                 </S.AvailableTimes>
               </S.AvailableTimesRow>
             ))}

--- a/src/pages/admin/Dashboard/types/dashboard.ts
+++ b/src/pages/admin/Dashboard/types/dashboard.ts
@@ -19,7 +19,7 @@ export type ApplicationFilterOption = 'ALL' | ApplicationStatus;
 
 export type InterviewInfo = {
   interviewDate: string;
-  availableTimes: string[];
+  availableTime: string[];
 };
 
 export type ApplicantData = {


### PR DESCRIPTION

## 📝작업 내용
- 백엔드 응답 필드(availableTime)와 프론트 타입/사용 코드 불일치 수정
- info.availableTimes가 undefined가 되어 시간 목록이 렌더링되지 않던 문제 해결

