### PR TITLE
[FIX] 면접 시간 선택 팝오버 모달 스크롤 및 뷰포트 가림 버그 수정

### DIFF
--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.styled.ts
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantListItem/InterviewTimeContentModal.styled.ts
@@ -44,8 +44,8 @@ export const DateTab = styled.button<{ $active?: boolean }>(({ theme, $active })
 }));
 
 export const SlotsContainer = styled.div({
-  display: 'flex',
-  flexWrap: 'wrap',
+  display: 'grid',
+  gridTemplateColumns: 'repeat(4, 1fr)',
   gap: '0.5rem',
 });
 
@@ -77,6 +77,7 @@ export const SlotCount = styled.span(({ theme }) => ({
   fontSize: theme.font.size.xs,
   color: theme.colors.gray500,
   marginTop: '0.125rem',
+  whiteSpace: 'nowrap',
 }));
 
 export const AvailableTimesRow = styled.div({

--- a/src/shared/components/Modal/index.styled.ts
+++ b/src/shared/components/Modal/index.styled.ts
@@ -79,7 +79,7 @@ export const Content = styled.div<ContentProps>(
         position: 'fixed',
         top: $position.top - 10,
         left: $position.left - 30,
-        maxHeight: $position.maxHeight != null ? `${$position.maxHeight}px` : '80vh',
+        maxHeight: $position.maxHeight != null ? `min(30rem, ${$position.maxHeight}px)` : '30rem',
       }),
 
     [`@media (max-width: ${theme.breakpoints.mobile})`]: {

--- a/src/shared/components/Modal/index.styled.ts
+++ b/src/shared/components/Modal/index.styled.ts
@@ -136,4 +136,8 @@ export const Body = styled.div({
   flexDirection: 'column',
   overflowY: 'auto',
   overscrollBehavior: 'contain',
+  scrollbarWidth: 'none',
+  '&::-webkit-scrollbar': {
+    display: 'none',
+  },
 });

--- a/src/shared/components/Modal/index.styled.ts
+++ b/src/shared/components/Modal/index.styled.ts
@@ -40,7 +40,7 @@ export const Overlay = styled.div<OverlayProps>(({ $variant = 'modal' }) => ({
 type ContentProps = {
   $size?: 'sm' | 'md' | 'lg';
   $variant?: 'modal' | 'popover';
-  $position?: { top: number; left: number };
+  $position?: { top: number; left: number; maxHeight?: number };
 };
 
 const sizeMap = {
@@ -60,7 +60,7 @@ export const Content = styled.div<ContentProps>(
     width: sizeMap[$size],
     maxWidth: '100%',
     maxHeight: $variant === 'popover' ? '80vh' : '90vh',
-    overflow: 'auto',
+    overflow: 'hidden',
     padding: $variant === 'popover' ? '1.5rem' : '2rem',
     animation: `${scaleIn} 0.2s ease-out`,
     display: 'flex',
@@ -79,6 +79,7 @@ export const Content = styled.div<ContentProps>(
         position: 'fixed',
         top: $position.top - 10,
         left: $position.left - 30,
+        maxHeight: $position.maxHeight != null ? `${$position.maxHeight}px` : '80vh',
       }),
 
     [`@media (max-width: ${theme.breakpoints.mobile})`]: {
@@ -130,6 +131,9 @@ export const Header = styled.div({
 
 export const Body = styled.div({
   flex: 1,
+  minHeight: 0,
   display: 'flex',
   flexDirection: 'column',
+  overflowY: 'auto',
+  overscrollBehavior: 'contain',
 });

--- a/src/shared/components/Modal/index.tsx
+++ b/src/shared/components/Modal/index.tsx
@@ -68,13 +68,14 @@ export const Modal = ({
           modalWidthRef.current = modalWidth;
         }
 
+        const VIEWPORT_BOTTOM_MARGIN = 36;
         const topPos = anchorRect.top;
-        const availableHeight = window.innerHeight - topPos - 36;
+        const availableHeight = window.innerHeight - topPos - VIEWPORT_BOTTOM_MARGIN;
 
         setPosition({
           top: topPos,
           left: anchorRect.left - modalWidth,
-          maxHeight: Math.max(200, availableHeight),
+          maxHeight: Math.max(0, availableHeight),
         });
       }
     },

--- a/src/shared/components/Modal/index.tsx
+++ b/src/shared/components/Modal/index.tsx
@@ -45,7 +45,11 @@ export const Modal = ({
   const modalWidthRef = useRef<number>(0);
   const titleId = useId();
   const descriptionId = useId();
-  const [position, setPosition] = useState<{ top: number; left: number } | null>(null);
+  const [position, setPosition] = useState<{
+    top: number;
+    left: number;
+    maxHeight?: number;
+  } | null>(null);
 
   // popover 위치 계산 함수
   const updatePosition = useCallback(
@@ -64,9 +68,13 @@ export const Modal = ({
           modalWidthRef.current = modalWidth;
         }
 
+        const topPos = anchorRect.top;
+        const availableHeight = window.innerHeight - topPos - 36;
+
         setPosition({
-          top: anchorRect.top,
+          top: topPos,
           left: anchorRect.left - modalWidth,
+          maxHeight: Math.max(200, availableHeight),
         });
       }
     },


### PR DESCRIPTION

## 📝작업 내용

> 면접 시간 선택 팝오버 모달에서 스크롤이 동작하지 않던 문제를 수정하였습니다.

## 문제
* **스크롤 전파 문제:** 모달 내에서 스크롤 시 내부 내용이 아닌 배경 페이지가 스크롤되는 현상 발생
* **내용 잘림 현상:** 시간 슬롯이 많아질 경우 모달의 끝부분이 뷰포트 아래로 가려져 보이지 않음
* **공간 계산 오류:** 모달이 화면 하단에 위치할 때 고정된 `maxHeight` 값이 실제 화면의 공간을 초과하여 배정 인원 등 하단 정보가 누락됨

## 변경 사항
- Content의 overflow: auto → overflow: hidden 변경 (스크롤 처리를 Body로 일원화)
- Body에 overscrollBehavior: 'contain' 추가 → 모달 내부 스크롤 끝에 도달해도 배경 페이지로 전파되지 않음
- Body에 minHeight: 0 추가 → flex 컨테이너 내 스크롤 버그 해결
- popover 위치 지정 시 maxHeight를 min(30rem, 가용높이px)로 동적 계산 → 화면 하단 잘림 방지

## 변경 후 동작
> 슬롯이 적어 30rem 미만 -> 내용 크기에 맞게 자동 축소
> 슬롯이 많아 30rem 초과 -> 30rem 고정 후 내부 스크롤
> 3열에서 4열로 수정


### 스크린샷 (선택)

<img width="404" height="547" alt="image" src="https://github.com/user-attachments/assets/c6a70fd1-b771-439c-a8e3-a3323f41ce38" />
