### PR TITLE
[REFACTOR] 동아리원 엑셀등록 실패시 에러처리 (#451)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ const ToastContainer = () => (
   <Toaster
     position='top-center'
     richColors
+    expand
     toastOptions={{
       style: {
         borderRadius: theme.radius.md,

--- a/src/pages/admin/MemberManagement/api/bulkUploadMembers.ts
+++ b/src/pages/admin/MemberManagement/api/bulkUploadMembers.ts
@@ -1,17 +1,12 @@
 import { apiInstance } from '@/app/api/initInstance';
-import { handleAxiosError } from '@/shared/utils/handleAxiosError';
 
 export const bulkUploadMembers = async (clubId: string, file: File): Promise<void> => {
-  try {
-    const formData = new FormData();
-    formData.append('file', file);
+  const formData = new FormData();
+  formData.append('file', file);
 
-    await apiInstance.post(`/clubs/${clubId}/members/upload`, formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
-  } catch (e: unknown) {
-    return handleAxiosError(e, '일괄 등록에 실패했습니다.');
-  }
+  await apiInstance.post(`/clubs/${clubId}/members/upload`, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
 };

--- a/src/pages/admin/MemberManagement/hooks/useMemberMutations.ts
+++ b/src/pages/admin/MemberManagement/hooks/useMemberMutations.ts
@@ -57,7 +57,23 @@ export const useMemberMutations = (clubId: string) => {
   const bulkUploadMutation = useMutation({
     mutationFn: (file: File) => bulkUploadMembers(clubId, file),
     onSuccess: () => {
+      toast.success('엑셀 일괄 등록이 완료되었습니다.');
       queryClient.invalidateQueries({ queryKey: ['members', clubId] });
+    },
+    onError: (error: unknown) => {
+      const data = (error as { response?: { data?: { message?: string; detail?: string } } })
+        .response?.data;
+
+      const detail = data?.detail;
+      if (typeof detail === 'string' && detail.startsWith('[')) {
+        const items = detail.match(/'([^']+)'/g)?.map((s) => s.slice(1, -1));
+        if (items) {
+          items.forEach((item) => toast.error(item));
+          return;
+        }
+      }
+
+      toast.error(data?.message || '일괄 등록에 실패했습니다.');
     },
   });
 

--- a/src/pages/admin/MemberManagement/hooks/useMemberMutations.ts
+++ b/src/pages/admin/MemberManagement/hooks/useMemberMutations.ts
@@ -65,13 +65,17 @@ export const useMemberMutations = (clubId: string) => {
         .response?.data;
 
       const detail = data?.detail;
-      if (typeof detail === 'string' && detail.startsWith('[')) {
-        const items = detail.match(/'([^']+)'/g)?.map((s) => s.slice(1, -1));
-        if (items) {
-          items.forEach((item) => toast.error(item));
-          return;
+      if (typeof detail === 'string') {
+        if (detail.startsWith('[')) {
+          const items = detail.match(/'([^']+)'/g)?.map((s) => s.slice(1, -1));
+          if (items) {
+            items.forEach((item) => toast.error(item));
+            return;
+          }
         }
       }
+      toast.error(detail);
+      return;
 
       toast.error(data?.message || '일괄 등록에 실패했습니다.');
     },

--- a/src/pages/admin/MemberManagement/hooks/useMemberMutations.ts
+++ b/src/pages/admin/MemberManagement/hooks/useMemberMutations.ts
@@ -61,16 +61,25 @@ export const useMemberMutations = (clubId: string) => {
       queryClient.invalidateQueries({ queryKey: ['members', clubId] });
     },
     onError: (error: unknown) => {
-      const data = (error as { response?: { data?: { message?: string; detail?: string } } })
-        .response?.data;
+      const data = (
+        error as {
+          response?: { data?: { message?: string; detail?: string | string[] } };
+        }
+      ).response?.data;
 
       const detail = data?.detail;
       const EXCEL_ERROR_DURATION = 3000;
 
+      if (Array.isArray(detail)) {
+        detail.forEach((item) => toast.error(item, EXCEL_ERROR_DURATION));
+        return;
+      }
+
       if (typeof detail === 'string') {
-        if (detail.startsWith('[')) {
-          const items = detail.match(/'([^']+)'/g)?.map((s) => s.slice(1, -1));
-          if (items) {
+        if (detail.startsWith('[') && detail.endsWith(']')) {
+          const inner = detail.slice(1, -1);
+          const items = inner.split(/,\s*(?=\d+행:|학번)/).map((s) => s.trim());
+          if (items.length > 1) {
             items.forEach((item) => toast.error(item, EXCEL_ERROR_DURATION));
             return;
           }

--- a/src/pages/admin/MemberManagement/hooks/useMemberMutations.ts
+++ b/src/pages/admin/MemberManagement/hooks/useMemberMutations.ts
@@ -65,17 +65,19 @@ export const useMemberMutations = (clubId: string) => {
         .response?.data;
 
       const detail = data?.detail;
+      const EXCEL_ERROR_DURATION = 3000;
+
       if (typeof detail === 'string') {
         if (detail.startsWith('[')) {
           const items = detail.match(/'([^']+)'/g)?.map((s) => s.slice(1, -1));
           if (items) {
-            items.forEach((item) => toast.error(item));
+            items.forEach((item) => toast.error(item, EXCEL_ERROR_DURATION));
             return;
           }
         }
+        toast.error(detail, EXCEL_ERROR_DURATION);
+        return;
       }
-      toast.error(detail);
-      return;
 
       toast.error(data?.message || '일괄 등록에 실패했습니다.');
     },

--- a/src/shared/utils/toast.ts
+++ b/src/shared/utils/toast.ts
@@ -11,9 +11,9 @@ export const toast = {
       onAutoClose,
     });
   },
-  error: (message: string) => {
+  error: (message: string, duration: number = TOAST_DURATION) => {
     sonnerToast.error(message, {
-      duration: TOAST_DURATION,
+      duration,
       style: { backgroundColor: 'white', color: theme.colors.error },
     });
   },


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #451 

## 📝작업 내용

> 엑셀로 동아리원 일괄 등록 시 에러가 발생해도 사용자에게 아무런 피드백이 없어 실패 원인을 알 수 없었음

### 리팩터링한 것

1. 에러 토스트 표시 (useMemberMutations.ts)

  - bulkUploadMutation에 onError 핸들러 추가
  - 에러 응답의 detail / message 필드를 우선순위에 따라 표시
    - detail이 배열 → 항목별 개별 토스트
    - detail이 리스트 형태 문자열([N행: ..., ...]) → 파싱 후 항목별 개별 토스트
    - detail이 단순 문자열 → 단일 토스트
    - detail 없음 → message 필드로 단일 토스트
  - 성공 시에도 toast.success 추가

2. 에러 토스트 표시 시간 연장 (toast.ts)

  - toast.error에 optional duration 파라미터 추가 (기본값 유지, 하위 호환)
  - 엑셀 에러 토스트는 3초간 표시하여 사용자가 내용을 읽을 수 있도록 함


3. 토스트 겹침 해제 (App.tsx)

  - Toaster에 expand prop 추가하여 여러 토스트가 펼쳐진 상태로 표시

4. API 레이어 정리 (bulkUploadMembers.ts)

  - handleAxiosError 제거, axios 에러를 mutation 레이어로 직접 전파하여 응답 데이터(detail, message)에 접근 가능하도록 변경


### 대응하는 에러 응답


상태 코드 | error_code | 토스트 표시 내용
-- | -- | --
400 | INVALID_EXCEL_DATA | detail 리스트의 각 항목을 개별 토스트로 표시
400 | INVALID_FILE | detail 문자열 표시
413 | TOO_LARGE_FILE | message 표시
403 | FORBIDDEN | message 표시



### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
