### PR TITLE
[REFACTOR] API 에러 처리 로직 통일 및 토스트 처리 (#450)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ const ToastContainer = () => (
         fontWeight: theme.font.weight.bold,
         fontSize: theme.font.size.base,
         boxShadow: theme.shadow.md,
+        width: '380px',
       },
     }}
   />

--- a/src/app/providers/auth.tsx
+++ b/src/app/providers/auth.tsx
@@ -89,7 +89,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
             break;
         }
         return response;
-      } catch (e) {
+      } catch (e: unknown) {
         if (e instanceof Error && e.name === 'CanceledError') throw e;
         return handleAxiosError(e, '로그인 중 오류가 발생했습니다.');
       }
@@ -103,7 +103,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       clearAuthData();
       const kakaoLogoutUrl = `https://kauth.kakao.com/oauth/logout?client_id=${REST_API_KEY}&logout_redirect_uri=${LOGOUT_REDIRECT_URI}`;
       window.location.href = kakaoLogoutUrl;
-    } catch (e) {
+    } catch (e: unknown) {
       handleAxiosError(e, '로그아웃 중 오류가 발생했습니다.');
     }
   }, []);

--- a/src/pages/admin/ApplicationDetail/api/comments.ts
+++ b/src/pages/admin/ApplicationDetail/api/comments.ts
@@ -1,4 +1,5 @@
 import { apiInstance } from '@/app/api/initInstance';
+import { handleAxiosError } from '@/shared/utils/handleAxiosError';
 import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
 
 export const fetchComments = async (applicationId: number): Promise<Comment[]> => {
@@ -17,13 +18,17 @@ export const createComment = async (
       rating,
     });
     return data;
-  } catch {
-    throw new Error('Failed to fetch comments');
+  } catch (error: unknown) {
+    return handleAxiosError(error);
   }
 };
 
 export const deleteComment = async (applicationId: number, commentId: number): Promise<void> => {
-  await apiInstance.delete(`/applications/${applicationId}/comments/${commentId}`);
+  try {
+    await apiInstance.delete(`/applications/${applicationId}/comments/${commentId}`);
+  } catch (error: unknown) {
+    return handleAxiosError(error);
+  }
 };
 
 export const updateComment = async (
@@ -41,7 +46,7 @@ export const updateComment = async (
       },
     );
     return data;
-  } catch {
-    throw new Error('Failed to create comment');
+  } catch (error: unknown) {
+    return handleAxiosError(error);
   }
 };

--- a/src/pages/admin/ApplicationDetail/api/detailApplication.ts
+++ b/src/pages/admin/ApplicationDetail/api/detailApplication.ts
@@ -1,4 +1,5 @@
 import { apiInstance } from '@/app/api/initInstance';
+import { handleAxiosError } from '@/shared/utils/handleAxiosError';
 import type { DetailApplication } from '@/pages/admin/ApplicationDetail/types/detailApplication';
 
 export const fetchDetailApplication = async (
@@ -10,8 +11,8 @@ export const fetchDetailApplication = async (
       `/clubs/${clubId}/applicants/${applicantId}/application`,
     );
     return data;
-  } catch {
-    throw new Error('지원서 상세 정보를 가져오지 못했습니다');
+  } catch (error: unknown) {
+    return handleAxiosError(error);
   }
 };
 
@@ -26,7 +27,7 @@ export const updateApplicationStatus = async (
       { status },
     );
     return data;
-  } catch {
-    throw new Error('지원서 상태를 업데이트하지 못했습니다');
+  } catch (error: unknown) {
+    return handleAxiosError(error);
   }
 };

--- a/src/pages/admin/ApplicationDetail/hooks/useComments.ts
+++ b/src/pages/admin/ApplicationDetail/hooks/useComments.ts
@@ -5,6 +5,7 @@ import {
   deleteComment,
   updateComment,
 } from '@/pages/admin/ApplicationDetail/api/comments';
+import { toast } from '@/shared/utils/toast';
 import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
 import type { UseApiQueryResult } from '@/shared/types/useApiQueryResult';
 
@@ -36,6 +37,9 @@ export const useComments = (applicationId: number): UseCommentsResult => {
         return [newComment];
       });
     },
+    onError: (error: Error) => {
+      toast.error(error.message || '댓글 작성에 실패했습니다.');
+    },
   });
 
   const { mutate: deleteCommentMutation } = useMutation({
@@ -47,6 +51,9 @@ export const useComments = (applicationId: number): UseCommentsResult => {
         }
         return [];
       });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || '댓글 삭제에 실패했습니다.');
     },
   });
 
@@ -69,6 +76,9 @@ export const useComments = (applicationId: number): UseCommentsResult => {
         }
         return [];
       });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || '댓글 수정에 실패했습니다.');
     },
   });
 

--- a/src/pages/admin/ApplicationDetail/hooks/useDetailApplication.ts
+++ b/src/pages/admin/ApplicationDetail/hooks/useDetailApplication.ts
@@ -3,6 +3,7 @@ import {
   fetchDetailApplication,
   updateApplicationStatus,
 } from '@/pages/admin/ApplicationDetail/api/detailApplication';
+import { toast } from '@/shared/utils/toast';
 import type { DetailApplication } from '@/pages/admin/ApplicationDetail/types/detailApplication';
 import type { UseApiQueryResult } from '@/shared/types/useApiQueryResult';
 
@@ -41,6 +42,9 @@ export const useDetailApplications = (
       );
       queryClient.invalidateQueries({ queryKey: ['applicants', clubId] });
       queryClient.invalidateQueries({ queryKey: ['dashboardSummary', clubId] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || '지원서 상태 변경에 실패했습니다.');
     },
   });
 

--- a/src/pages/admin/ApplicationFormBuilder/api/apply-form.ts
+++ b/src/pages/admin/ApplicationFormBuilder/api/apply-form.ts
@@ -9,7 +9,7 @@ export const fetchApplicationForm = async (clubId: number): Promise<ApplicationF
       `/clubs/${clubId}/dashboard/apply-form`,
     );
     return response.data;
-  } catch (e) {
+  } catch (e: unknown) {
     return handleAxiosError(e);
   }
 };
@@ -27,7 +27,7 @@ export const postApplicationForm = async ({
       form,
     );
     return response.data;
-  } catch (e) {
+  } catch (e: unknown) {
     return handleAxiosError(e);
   }
 };
@@ -45,7 +45,7 @@ export const patchApplicationForm = async ({
       form,
     );
     return response.data;
-  } catch (e) {
+  } catch (e: unknown) {
     return handleAxiosError(e, '지원서 저장에 실패했습니다.', { useDetail: true });
   }
 };

--- a/src/pages/admin/ApplicationFormBuilder/api/apply-form.ts
+++ b/src/pages/admin/ApplicationFormBuilder/api/apply-form.ts
@@ -21,11 +21,15 @@ export const postApplicationForm = async ({
   clubId: number;
   form: ApplicationForm;
 }): Promise<ApplicationForm> => {
-  const response: AxiosResponse<ApplicationForm> = await apiInstance.post(
-    `/clubs/${clubId}/dashboard/apply-form`,
-    form,
-  );
-  return response.data;
+  try {
+    const response: AxiosResponse<ApplicationForm> = await apiInstance.post(
+      `/clubs/${clubId}/dashboard/apply-form`,
+      form,
+    );
+    return response.data;
+  } catch (e) {
+    return handleAxiosError(e);
+  }
 };
 
 export const patchApplicationForm = async ({

--- a/src/pages/admin/ApplicationFormBuilder/hooks/useApplicationForm.ts
+++ b/src/pages/admin/ApplicationFormBuilder/hooks/useApplicationForm.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from '@/shared/utils/toast';
 import { fetchApplicationForm, patchApplicationForm, postApplicationForm } from '../api/apply-form';
 import type { ApplicationForm } from '../types/fieldType';
 
@@ -22,6 +23,9 @@ export const usePostApplicationForm = (clubId: number) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['apply-form', clubId] });
     },
+    onError: (error: Error) => {
+      toast.error(error.message || '지원서 양식 저장에 실패했습니다.');
+    },
   });
   return { postForm, isSuccess };
 };
@@ -36,6 +40,9 @@ export const usePatchApplicationForm = (clubId: number) => {
     mutationFn: (form: Partial<ApplicationForm>) => patchApplicationForm({ clubId, form }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['apply-form', clubId] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || '지원서 양식 수정에 실패했습니다.');
     },
   });
 

--- a/src/pages/admin/ClubDetailEdit/Page.tsx
+++ b/src/pages/admin/ClubDetailEdit/Page.tsx
@@ -2,13 +2,12 @@ import styled from '@emotion/styled';
 import { useEffect } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { useParams, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
-import { theme } from '@/app/styles/theme';
 import { Button } from '@/shared/components/Button';
 import { TwoColumnLayout } from '@/shared/components/Layout/TwoColumnLayout';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { PageHeader } from '@/shared/components/PageHeader';
 import { engToKorCategory } from '@/shared/utils/formatting';
+import { toast } from '@/shared/utils/toast';
 import { updateClubDetailEdit } from './api/clubDetailEdit';
 import { updateClubImages } from './api/clubImagesEdit';
 import { ClubActivityPhotosEditSection } from './components/ClubActivityPhotosEditSection';
@@ -45,17 +44,10 @@ export const ClubDetailEditPage = () => {
 
     updateClubDetailEdit(clubId ?? '', payload)
       .then(() => {
-        toast.success('수정 성공!', {
-          style: { backgroundColor: theme.colors.primary, color: 'white' },
-          duration: 1000,
-          onAutoClose: () => navigate(`/clubs/${clubId}`),
-        });
+        toast.success('수정 성공!', () => navigate(`/clubs/${clubId}`));
       })
-      .catch(() => {
-        toast.error('수정 실패!', {
-          duration: 1000,
-          style: { backgroundColor: 'white', color: theme.colors.error },
-        });
+      .catch((error: Error) => {
+        toast.error(error.message || '수정 실패!');
       });
   };
   if (isLoading) return <LoadingSpinner />;

--- a/src/pages/admin/ClubDetailEdit/api/clubImagesEdit.ts
+++ b/src/pages/admin/ClubDetailEdit/api/clubImagesEdit.ts
@@ -17,6 +17,6 @@ export const updateClubImages = async (
     const { data } = await apiInstance.put(`/clubs/${clubId}/images`, formData);
     return data;
   } catch (e: unknown) {
-    handleAxiosError(e, '이미지 업데이트 실패');
+    return handleAxiosError(e, '이미지 업데이트 실패');
   }
 };

--- a/src/pages/admin/ClubDetailEdit/hooks/useClubActivityPhotos.ts
+++ b/src/pages/admin/ClubDetailEdit/hooks/useClubActivityPhotos.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { apiInstance } from '@/app/api/initInstance';
+import { updateClubImages } from '@/pages/admin/ClubDetailEdit/api/clubImagesEdit';
+import { toast } from '@/shared/utils/toast';
 
 const MAX_FILE_SIZE_MB = 5;
 const MAX_TOTAL_SIZE_MB = 50;
@@ -13,14 +14,14 @@ export const useClubActivityPhotos = (
   const validateFiles = (files: File[]) => {
     for (const file of files) {
       if (file.size / 1024 / 1024 > MAX_FILE_SIZE_MB) {
-        alert(`${file.name} 파일이 ${MAX_FILE_SIZE_MB}MB를 초과합니다.`);
+        toast.error(`${file.name} 파일이 ${MAX_FILE_SIZE_MB}MB를 초과합니다.`);
         return false;
       }
     }
 
     const totalSizeMB = files.reduce((acc, f) => acc + f.size / 1024 / 1024, 0);
     if (totalSizeMB > MAX_TOTAL_SIZE_MB) {
-      alert(`전체 업로드 이미지 합이 ${MAX_TOTAL_SIZE_MB}MB를 초과합니다.`);
+      toast.error(`전체 업로드 이미지 합이 ${MAX_TOTAL_SIZE_MB}MB를 초과합니다.`);
       return false;
     }
 
@@ -31,17 +32,10 @@ export const useClubActivityPhotos = (
     const updated = images.filter((img) => img.id !== id);
     setImages(updated);
 
-    const keepImageIds = updated.map((img) => img.id);
-    const formData = new FormData();
-    formData.append('keepImageIds', JSON.stringify(keepImageIds));
-
     try {
-      await apiInstance.put(`/clubs/${clubId}/images`, formData);
-    } catch (err) {
-      console.error('이미지 삭제 반영 실패:', err);
-      alert('삭제 반영에 실패했습니다. 새로고침 후 다시 시도해 주세요.');
-      // 실패 시 UI 롤백이 필요하다면 아래처럼 복구 고려
-      // setImages((prev) => [...prev, images.find((img) => img.id === id)!]);
+      await updateClubImages(clubId, [], updated);
+    } catch (err: unknown) {
+      toast.error((err as Error).message || '이미지 삭제에 실패했습니다.');
     }
   };
 
@@ -49,18 +43,11 @@ export const useClubActivityPhotos = (
     if (files.length === 0) return;
     if (!validateFiles(files)) return;
 
-    const keepImageIds = images.map((img) => img.id);
-
-    const formData = new FormData();
-    formData.append('keepImageIds', JSON.stringify(keepImageIds));
-    files.forEach((file) => formData.append('newImages', file, file.name));
-
     try {
-      const { data } = await apiInstance.put(`/clubs/${clubId}/images`, formData);
+      const data = await updateClubImages(clubId, files, images);
       if (Array.isArray(data)) setImages(data);
-    } catch (err) {
-      console.error('이미지 업로드 실패:', err);
-      alert('이미지 업로드에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+    } catch (err: unknown) {
+      toast.error((err as Error).message || '이미지 업로드에 실패했습니다.');
     }
   };
 

--- a/src/pages/admin/Dashboard/api/applicant.ts
+++ b/src/pages/admin/Dashboard/api/applicant.ts
@@ -10,8 +10,7 @@ export const fetchApplicants = async (
     const { data } = await apiInstance.get(`/clubs/${clubId}/dashboard/applicants?stage=${stage}`);
     return data;
   } catch (error: unknown) {
-    handleAxiosError(error);
-    throw error;
+    return handleAxiosError(error);
   }
 };
 
@@ -25,6 +24,6 @@ export const updateInterviewTime = async (
       interviewAt,
     });
   } catch (error: unknown) {
-    handleAxiosError(error);
+    return handleAxiosError(error);
   }
 };

--- a/src/pages/admin/Dashboard/api/applicant.ts
+++ b/src/pages/admin/Dashboard/api/applicant.ts
@@ -26,6 +26,5 @@ export const updateInterviewTime = async (
     });
   } catch (error: unknown) {
     handleAxiosError(error);
-    throw error;
   }
 };

--- a/src/pages/admin/Dashboard/api/sentMessage.ts
+++ b/src/pages/admin/Dashboard/api/sentMessage.ts
@@ -13,6 +13,6 @@ export const sentMessage = async (
       message,
     });
   } catch (error: unknown) {
-    handleAxiosError(error);
+    return handleAxiosError(error);
   }
 };

--- a/src/pages/admin/Dashboard/api/sentMessage.ts
+++ b/src/pages/admin/Dashboard/api/sentMessage.ts
@@ -1,4 +1,5 @@
 import { apiInstance } from '@/app/api/initInstance';
+import { handleAxiosError } from '@/shared/utils/handleAxiosError';
 import { STAGE_LABEL } from '../utils/labelMap';
 import type { ApplicationStage } from '@/pages/admin/Dashboard/types/dashboard';
 
@@ -7,14 +8,11 @@ export const sentMessage = async (
   message: string,
   stage: ApplicationStage,
 ): Promise<void> => {
-  const apiStage = STAGE_LABEL[stage];
-
   try {
-    await apiInstance.patch(`/clubs/${clubId}/club-apply-form/result?stage=${apiStage}`, {
+    await apiInstance.patch(`/clubs/${clubId}/club-apply-form/result?stage=${STAGE_LABEL[stage]}`, {
       message,
     });
-  } catch (error) {
-    console.error('메시지 전송에 실패하였습니다:', error);
-    throw error;
+  } catch (error: unknown) {
+    handleAxiosError(error);
   }
 };

--- a/src/pages/admin/Dashboard/hooks/useSentMessage.ts
+++ b/src/pages/admin/Dashboard/hooks/useSentMessage.ts
@@ -1,13 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
 import { sentMessage } from '@/pages/admin/Dashboard/api/sentMessage';
 import { toast } from '@/shared/utils/toast';
 import type { ApplicationStage } from '@/pages/admin/Dashboard/types/dashboard';
-
-interface BackendErrorResponse {
-  error_code: string;
-  message: string;
-}
 
 export const useSentMessage = (clubId: number, stage: ApplicationStage) => {
   const queryClient = useQueryClient();
@@ -18,18 +12,8 @@ export const useSentMessage = (clubId: number, stage: ApplicationStage) => {
       queryClient.invalidateQueries({ queryKey: ['applicants', clubId] });
       toast.success('결과가 전송되었습니다.');
     },
-    onError: (error: AxiosError) => {
-      const backendError = error.response?.data as BackendErrorResponse;
-      const errorMessage = backendError?.message;
-      const errorCode = backendError?.error_code;
-
-      if (errorCode === 'PENDING_APPLICATION_EXISTS') {
-        toast.error(errorMessage);
-      } else if (errorMessage) {
-        toast.error(errorMessage);
-      } else {
-        toast.error('결과 전송이 실패하였습니다.');
-      }
+    onError: (error: Error) => {
+      toast.error(error.message || '결과 전송이 실패하였습니다.');
     },
   });
 

--- a/src/pages/admin/Dashboard/hooks/useUpdateInterviewTime.ts
+++ b/src/pages/admin/Dashboard/hooks/useUpdateInterviewTime.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateInterviewTime } from '@/pages/admin/Dashboard/api/applicant';
+import { toast } from '@/shared/utils/toast';
 
 export const useUpdateInterviewTime = (clubId: number, applicantId: number) => {
   const queryClient = useQueryClient();
@@ -8,6 +9,9 @@ export const useUpdateInterviewTime = (clubId: number, applicantId: number) => {
     mutationFn: (interviewAt: string) => updateInterviewTime(clubId, applicantId, interviewAt),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['applicants', clubId] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || '면접 시간 저장에 실패했습니다.');
     },
   });
 

--- a/src/pages/admin/Login/hooks/useKakaoLogin.ts
+++ b/src/pages/admin/Login/hooks/useKakaoLogin.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ROUTE_PATH } from '@/app/constants/routerPath';
 import { useAuth } from '@/app/providers/auth';
-import { handleAxiosError } from '@/shared/utils/handleAxiosError';
+import { toast } from '@/shared/utils/toast';
 import type { LoginResponse } from '../api/auth';
 
 export function useKakaoLogin() {
@@ -31,7 +31,10 @@ export function useKakaoLogin() {
         if (isAxiosError(e) && e.code === 'ERR_CANCELED') {
           return;
         }
-        handleAxiosError(e, '로그인 중 오류가 발생했습니다.');
+        const message = isAxiosError(e)
+          ? e.response?.data?.message || '로그인 중 오류가 발생했습니다.'
+          : '로그인 중 오류가 발생했습니다.';
+        toast.error(message);
       } finally {
         setIsLoading(false);
       }

--- a/src/pages/admin/Login/hooks/useKakaoLogin.ts
+++ b/src/pages/admin/Login/hooks/useKakaoLogin.ts
@@ -31,9 +31,12 @@ export function useKakaoLogin() {
         if (isAxiosError(e) && e.code === 'ERR_CANCELED') {
           return;
         }
-        const message = isAxiosError(e)
-          ? e.response?.data?.message || '로그인 중 오류가 발생했습니다.'
-          : '로그인 중 오류가 발생했습니다.';
+        let message = '로그인 중 오류가 발생했습니다.';
+        if (isAxiosError(e)) {
+          message = e.response?.data?.message || message;
+        } else if (e instanceof Error) {
+          message = e.message;
+        }
         toast.error(message);
       } finally {
         setIsLoading(false);

--- a/src/pages/admin/Signup/hooks/useSignup.ts
+++ b/src/pages/admin/Signup/hooks/useSignup.ts
@@ -1,9 +1,8 @@
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 import { ROUTE_PATH } from '@/app/constants/routerPath';
 import { useAuth } from '@/app/providers/auth';
-import { theme } from '@/app/styles/theme';
 import { getTemporaryToken, removeTemporaryToken } from '@/shared/auth/token';
+import { toast } from '@/shared/utils/toast';
 import type { SignupFormInputs } from '../type/signup';
 
 export const useSignup = () => {
@@ -21,21 +20,11 @@ export const useSignup = () => {
     try {
       completeSignup(signupFormValue, temporaryToken);
 
-      toast.success('회원가입 완료!', {
-        style: { backgroundColor: theme.colors.primary, color: 'white' },
-        duration: 1000,
-        onAutoClose: () => navigate(ROUTE_PATH.COMMON.MAIN),
-      });
+      toast.success('회원가입 완료!', () => navigate(ROUTE_PATH.COMMON.MAIN));
       removeTemporaryToken();
     } catch (e: unknown) {
       if (e instanceof Error) {
-        toast.error(e.message, {
-          duration: 1000,
-          style: {
-            backgroundColor: 'white',
-            color: theme.colors.error,
-          },
-        });
+        toast.error(e.message);
       }
     }
   };

--- a/src/pages/user/Apply/api/apply.ts
+++ b/src/pages/user/Apply/api/apply.ts
@@ -10,7 +10,7 @@ export const fetchApplicationForm = async (clubId: number): Promise<ApplicationF
       `/clubs/${clubId}/apply`,
     );
     return response.data;
-  } catch (e) {
+  } catch (e: unknown) {
     return handleAxiosError(e);
   }
 };

--- a/src/shared/utils/toast.ts
+++ b/src/shared/utils/toast.ts
@@ -1,7 +1,7 @@
 import { toast as sonnerToast } from 'sonner';
 import { theme } from '@/app/styles/theme';
 
-const TOAST_DURATION = 1000;
+const TOAST_DURATION = 3000;
 
 export const toast = {
   success: (message: string, onAutoClose?: () => void) => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #450 

## 📝작업 내용
> API 에러 발생 시 사용자에게 피드백이 없거나, 백엔드 에러 메시지가 무시되고 하드코딩된 메시지만 표시되는 문제를 해결했습니다.

### 에러 처리 패턴 통일
- 모든 API 함수에 handleAxiosError 적용 및 `return handleAxiosError(error)` 패턴으로 통일
- 백엔드 응답의 message 필드를 그대로 토스트에 표시하도록 변경

### mutation onError 토스트 추가
- useDetailApplications (지원서 합/불 상태 변경)
- useComments (댓글 작성/수정/삭제)
- usePostApplicationForm / usePatchApplicationForm (지원서 양식 저장/수정)

### 이벤트 핸들러 에러 처리 수정
- useClubActivityPhotos: alert() 제거 → toast, apiInstance 직접 호출 → updateClubImages 위임
- useKakaoLogin: handleAxiosError throw → isAxiosError로 메시지 추출 후 toast
- ClubDetailEdit/Page.tsx: sonner 직접 import → 공유 toast 유틸로 교체

### 토스트 UX 개선
- 표시 시간 1초 → 3초
- 너비 380px 고정


## 💬리뷰 요구사항(선택)

> 동아리원 관리 페이지 수정하는 것 같아서, 해당 페이지에서 호출 중인 API는 건드리지 않았습니다.