### PR TITLE
[REFACTOR] 동아리 상세 페이지 개선 등

### DIFF
--- a/src/pages/admin/MemberManagement/hooks/useMemberMutations.ts
+++ b/src/pages/admin/MemberManagement/hooks/useMemberMutations.ts
@@ -68,10 +68,9 @@ export const useMemberMutations = (clubId: string) => {
       ).response?.data;
 
       const detail = data?.detail;
-      const EXCEL_ERROR_DURATION = 3000;
 
       if (Array.isArray(detail)) {
-        detail.forEach((item) => toast.error(item, EXCEL_ERROR_DURATION));
+        detail.forEach((item) => toast.error(item));
         return;
       }
 
@@ -80,11 +79,11 @@ export const useMemberMutations = (clubId: string) => {
           const inner = detail.slice(1, -1);
           const items = inner.split(/,\s*(?=\d+행:|학번)/).map((s) => s.trim());
           if (items.length > 1) {
-            items.forEach((item) => toast.error(item, EXCEL_ERROR_DURATION));
+            items.forEach((item) => toast.error(item));
             return;
           }
         }
-        toast.error(detail, EXCEL_ERROR_DURATION);
+        toast.error(detail);
         return;
       }
 

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -35,7 +35,9 @@ export const ClubDetailPage = () => {
               club.category in engToKorCategory ? (club.category as ClubCategoryEng) : 'ALL'
             }
           />
-          <ClubActivityPhotosSection images={club.introductionImages} />
+          {club.introductionImages.length > 0 && (
+            <ClubActivityPhotosSection images={club.introductionImages} />
+          )}
           <ClubDescriptionSection
             introductionOverview={club.introductionOverview}
             introductionActivity={club.introductionActivity}

--- a/src/pages/user/ClubDetail/components/ClubActivityPhotosSection/index.styled.ts
+++ b/src/pages/user/ClubDetail/components/ClubActivityPhotosSection/index.styled.ts
@@ -23,7 +23,7 @@ export const PhotosContainer = styled.div({
 
 export const Photo = styled.img({
   flex: '0 0 auto',
-  height: 'clamp(320px, 50vw, 500px)',
+  height: 'clamp(320px, 50vw, 400px)',
   width: 'auto',
   borderRadius: '8px',
   objectFit: 'cover',

--- a/src/pages/user/ClubDetail/components/ClubActivityPhotosSection/index.styled.ts
+++ b/src/pages/user/ClubDetail/components/ClubActivityPhotosSection/index.styled.ts
@@ -23,8 +23,30 @@ export const PhotosContainer = styled.div({
 
 export const Photo = styled.img({
   flex: '0 0 auto',
-  height: 'clamp(120px, 15vw, 250px)',
+  height: 'clamp(320px, 50vw, 500px)',
   width: 'auto',
   borderRadius: '8px',
   objectFit: 'cover',
+  cursor: 'pointer',
+});
+
+export const Overlay = styled.div({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100vw',
+  height: '100vh',
+  backgroundColor: 'rgba(0, 0, 0, 0.85)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 9999,
+  cursor: 'pointer',
+});
+
+export const OverlayImage = styled.img({
+  maxWidth: '90vw',
+  maxHeight: '90vh',
+  objectFit: 'contain',
+  borderRadius: '8px',
 });

--- a/src/pages/user/ClubDetail/components/ClubActivityPhotosSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubActivityPhotosSection/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { SectionHeading } from '@/shared/components/SectionHeading';
 import * as S from './index.styled';
 
@@ -6,6 +7,8 @@ interface ClubActivityPhotosSectionProps {
 }
 
 export const ClubActivityPhotosSection = ({ images }: ClubActivityPhotosSectionProps) => {
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+
   return (
     <>
       <S.TitleWrapper>
@@ -14,10 +17,21 @@ export const ClubActivityPhotosSection = ({ images }: ClubActivityPhotosSectionP
       <S.PhotosWrapper>
         <S.PhotosContainer>
           {images.map((image) => (
-            <S.Photo key={image.id} src={image.url} alt={`활동 사진 ${image.id}`} />
+            <S.Photo
+              key={image.id}
+              src={image.url}
+              alt={`활동 사진 ${image.id}`}
+              onClick={() => setSelectedImage(image.url)}
+            />
           ))}
         </S.PhotosContainer>
       </S.PhotosWrapper>
+
+      {selectedImage && (
+        <S.Overlay onClick={() => setSelectedImage(null)}>
+          <S.OverlayImage src={selectedImage} alt='활동 사진 확대' />
+        </S.Overlay>
+      )}
     </>
   );
 };

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -36,7 +36,9 @@ export const ClubInfoSidebarSection = ({
   return (
     <SidebarContainer>
       <InfoItem>회장 이름: {presidentName}</InfoItem>
-      <InfoItem>연락처: {presidentPhoneNumber}</InfoItem>
+      {!/^010-0000/.test(presidentPhoneNumber) && (
+        <InfoItem>연락처: {presidentPhoneNumber}</InfoItem>
+      )}
       <InfoItem>동방 위치: {location}</InfoItem>
       <InfoItem>
         모집 기간: {formatDate(recruitStart)} ~ {formatDate(recruitEnd)}

--- a/src/shared/utils/toast.ts
+++ b/src/shared/utils/toast.ts
@@ -1,7 +1,7 @@
 import { toast as sonnerToast } from 'sonner';
 import { theme } from '@/app/styles/theme';
 
-const TOAST_DURATION = 1000;
+const TOAST_DURATION = 3000;
 
 export const toast = {
   success: (message: string, onAutoClose?: () => void) => {
@@ -11,9 +11,9 @@ export const toast = {
       onAutoClose,
     });
   },
-  error: (message: string, duration: number = TOAST_DURATION) => {
+  error: (message: string) => {
     sonnerToast.error(message, {
-      duration,
+      duration: TOAST_DURATION,
       style: { backgroundColor: 'white', color: theme.colors.error },
     });
   },


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용


1. 토스트 duration 통일 (toast.ts)

- 전체 토스트 표시 시간을 1초 → 3초로 변경하여 사용자가 내용을 읽을 수 있도록 개선
  - 다음 커밋과 내용 연결을 위해 파라미터로 받는 것을 파라미터로 받지 않도록 수정

2. 활동 사진 섹션 개선 (ClubActivityPhotosSection)

- 사진 세로 크기 확대 (clamp(320px, 50vw, 400px))
  - 스크럼에서 나온 내용 반영
- 사진 클릭 시 전체화면 오버레이로 확대 보기 기능 추가
- 활동 사진이 없는 동아리의 경우 섹션 자체를 숨김 처리 (Page.tsx)
  - 부자연스러운 페이지로직 수정반영

3. 사이드바 연락처 필터링 (ClubInfoSidebarSection)

- 010-0000으로 시작하는 미등록 더미 번호인 경우 연락처 줄을 숨김 처리
  - 백엔드 요청에 따른 작업
