### PR TITLE
[FIX] 메인페이지 동아리검색 : 대소문자 구분없이 검색 가능하도록 수정

### DIFF
--- a/src/pages/user/Main/utils/searchClubs.ts
+++ b/src/pages/user/Main/utils/searchClubs.ts
@@ -7,7 +7,7 @@ export const searchClubs = (clubs: Club[], searchKeyword: string): Club[] => {
   return searchKeyword
     ? clubs.filter(
         (club) =>
-          club.name.replace(/\s+/g, '').includes(searchKeyword) ||
+          club.name.replace(/\s+/g, '').toLowerCase().includes(searchKeyword.toLowerCase()) ||
           club.category.includes(searchKeyword) ||
           club.shortIntroduction.replace(/\s+/g, '').includes(searchKeyword),
       )


### PR DESCRIPTION


## 📝작업 내용

- 메인페이지 동아리검색 : 대소문자 구분없이 검색 가능하도록 수정

- 로컬에서 버그 없는지 확인
