### PR TITLE
[FIX] 동아리 후기 폼 중복 제출 방지 로직 추가 (#284)

### DIFF
--- a/src/pages/user/ClubDetail/components/ClubReviewsSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubReviewsSection/index.tsx
@@ -6,7 +6,6 @@ import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/Out
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { SectionHeading } from '@/shared/components/SectionHeading';
 import { Text } from '@/shared/components/Text';
-import { toast } from '@/shared/utils/toast';
 import * as S from './index.styled';
 
 export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
@@ -25,9 +24,6 @@ export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
       if (success) {
         setContent('');
         setStudentId('');
-        toast.success('후기가 등록되었습니다!');
-      } else {
-        toast.error('후기 등록에 실패했습니다.');
       }
     } finally {
       setIsSubmitting(false);

--- a/src/pages/user/ClubDetail/components/ClubReviewsSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubReviewsSection/index.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { toast } from 'sonner';
 import { useClubReviews } from '@/pages/user/ClubDetail/hooks/useClubReviews';
 import { Button } from '@/shared/components/Button';
 import { OutlineInputField } from '@/shared/components/Form/InputField/OutlineInputField';
@@ -7,22 +6,31 @@ import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/Out
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { SectionHeading } from '@/shared/components/SectionHeading';
 import { Text } from '@/shared/components/Text';
+import { toast } from '@/shared/utils/toast';
 import * as S from './index.styled';
 
 export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
   const { reviews, loading, error, addReview } = useClubReviews(clubId);
   const [studentId, setStudentId] = useState('');
   const [content, setContent] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async () => {
-    const success = await addReview(studentId, content);
+    if (isSubmitting) return;
+    setIsSubmitting(true);
 
-    if (success) {
-      setContent('');
-      setStudentId('');
-      toast.success('후기가 등록되었습니다!', { duration: 2000 });
-    } else {
-      toast.error('후기 등록에 실패했습니다.', { duration: 2000 });
+    try {
+      const success = await addReview(studentId, content);
+
+      if (success) {
+        setContent('');
+        setStudentId('');
+        toast.success('후기가 등록되었습니다!');
+      } else {
+        toast.error('후기 등록에 실패했습니다.');
+      }
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -68,8 +76,8 @@ export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
           onChange={(e) => setContent(e.target.value)}
         />
         <S.ButtonWrapper>
-          <Button variant='outline' width='10rem' onClick={handleSubmit}>
-            후기 등록
+          <Button variant='outline' width='10rem' onClick={handleSubmit} disabled={isSubmitting}>
+            {isSubmitting ? '등록 중...' : '후기 등록'}
           </Button>
         </S.ButtonWrapper>
       </S.ReviewForm>


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #284 

## 📝작업 내용
> 동아리 후기 등록 시 버튼 연속 클릭으로 인한 중복 제출을 방지하는 로직을 추가했습니다.

- `isSubmitting` 상태를 추가해 후기 등록 버튼의 중복 클릭 방지
- 제출 중 버튼 `disabled` 처리 및 텍스트를 '등록 중...'으로 변경
- `finally` 블록으로 성공/실패 여부와 관계없이 상태 초기화 보장

