### PR TITLE
[FEAT] 등록 동아리 우선 표시 및 인스타그램 링크 기능 추가

### DIFF
--- a/src/app/mocks/repositories/club.ts
+++ b/src/app/mocks/repositories/club.ts
@@ -282,6 +282,7 @@ export const mockClubDetail: ClubDetail[] = [
     isRegistered: true,
     everyTimeUrl: '',
     googleFormUrl: '',
+    instagramUrl: '',
   },
   {
     clubId: 2,
@@ -325,6 +326,7 @@ export const mockClubDetail: ClubDetail[] = [
     isRegistered: true,
     everyTimeUrl: '',
     googleFormUrl: '',
+    instagramUrl: '',
   },
   {
     clubId: 3,
@@ -368,6 +370,7 @@ export const mockClubDetail: ClubDetail[] = [
     isRegistered: true,
     everyTimeUrl: '',
     googleFormUrl: '',
+    instagramUrl: '',
   },
 ];
 

--- a/src/pages/admin/ClubDetailEdit/components/ClubInfoSidebarEditSection/index.tsx
+++ b/src/pages/admin/ClubDetailEdit/components/ClubInfoSidebarEditSection/index.tsx
@@ -18,6 +18,7 @@ export const ClubInfoSidebarEditSection = () => {
     recruitEnd: string | null;
     regularMeetingInfo: string;
     applicationNotice: string;
+    instagramUrl: string;
   }>();
 
   const formValues = getValues();
@@ -38,7 +39,7 @@ export const ClubInfoSidebarEditSection = () => {
             {...register('presidentPhoneNumber', {
               pattern: {
                 value: /^\d{3}-\d{4}-\d{4}$/,
-                message: '’ - ’를 포함한 형식으로 입력해주세요.',
+                message: "'-'를 포함한 형식으로 입력해주세요.",
               },
               validate: (value) =>
                 !value ||
@@ -47,6 +48,18 @@ export const ClubInfoSidebarEditSection = () => {
             })}
             invalid={!!errors.presidentPhoneNumber}
             message={errors.presidentPhoneNumber?.message}
+          />
+        </S.InputWrapper>
+      </S.InfoItem>
+
+      <S.InfoItem>
+        <S.Label>인스타그램 링크</S.Label>
+        <S.InputWrapper>
+          <UnderlineInputField
+            {...register('instagramUrl')}
+            placeholder='https://www.instagram.com/...'
+            invalid={!!errors.instagramUrl}
+            message={errors.instagramUrl?.message}
           />
         </S.InputWrapper>
       </S.InfoItem>

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -60,6 +60,7 @@ export const ClubDetailPage = () => {
           isRegistered={club.isRegistered}
           everyTimeUrl={club.everyTimeUrl}
           googleFormUrl={club.googleFormUrl}
+          instagramUrl={club.instagramUrl}
         />
       }
     />

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { Button } from '@/shared/components/Button';
 import { formatDate } from '@/shared/utils/dateUtils';
 import ApplyButton from './ApplyButton';
 import type { ClubDetail } from '@/pages/user/ClubDetail/types/clubDetail';
@@ -17,6 +18,7 @@ type ClubInfoSidebarSectionProps = Pick<
   | 'isRegistered'
   | 'everyTimeUrl'
   | 'googleFormUrl'
+  | 'instagramUrl'
 >;
 
 export const ClubInfoSidebarSection = ({
@@ -32,6 +34,7 @@ export const ClubInfoSidebarSection = ({
   isRegistered,
   everyTimeUrl,
   googleFormUrl,
+  instagramUrl,
 }: ClubInfoSidebarSectionProps) => {
   return (
     <SidebarContainer>
@@ -45,6 +48,11 @@ export const ClubInfoSidebarSection = ({
       </InfoItem>
       <InfoItem>정기 모임: {regularMeetingInfo}</InfoItem>
       <InfoItem>모집 상태: {recruitStatus}</InfoItem>
+      {instagramUrl && (
+        <Button variant='outline' onClick={() => window.open(instagramUrl, '_blank')} width='100%'>
+          공식 인스타그램 보기
+        </Button>
+      )}
       <ApplyButton
         recruitStatus={recruitStatus}
         to={`/clubs/${clubId}/apply`}

--- a/src/pages/user/ClubDetail/types/clubDetail.ts
+++ b/src/pages/user/ClubDetail/types/clubDetail.ts
@@ -23,4 +23,5 @@ export type ClubDetail = {
   isRegistered: boolean;
   everyTimeUrl: string;
   googleFormUrl: string;
+  instagramUrl: string;
 };

--- a/src/pages/user/Main/components/ClubListSection/Club.styled.ts
+++ b/src/pages/user/Main/components/ClubListSection/Club.styled.ts
@@ -1,10 +1,29 @@
 import styled from '@emotion/styled';
 import type { RecruitStatus } from '@/pages/user/Main/types/club';
 
+export const ClubNameContainer = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+});
+
 export const ClubNameText = styled.div(({ theme }) => ({
   fontSize: theme?.font?.size?.lg,
   fontWeight: theme.font.weight.bold,
   color: theme?.colors?.textPrimary,
+}));
+
+export const VerifiedBadge = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '3px',
+  color: theme.colors.primary,
+}));
+
+export const VerifiedText = styled.span(({ theme }) => ({
+  fontSize: '10px',
+  fontWeight: theme.font.weight.medium,
+  color: theme.colors.primary,
 }));
 
 export const ClubIntroduction = styled.div(({ theme }) => ({

--- a/src/pages/user/Main/components/ClubListSection/Club.styled.ts
+++ b/src/pages/user/Main/components/ClubListSection/Club.styled.ts
@@ -24,7 +24,7 @@ export const VerifiedText = styled.span(({ theme }) => ({
   fontSize: '10px',
   fontWeight: theme.font.weight.medium,
   color: theme.colors.primary,
-}));
+})); //차후 추가 (등록뱃지 옆 문구)
 
 export const ClubIntroduction = styled.div(({ theme }) => ({
   fontSize: theme?.font?.size?.xs,

--- a/src/pages/user/Main/components/ClubListSection/index.tsx
+++ b/src/pages/user/Main/components/ClubListSection/index.tsx
@@ -32,7 +32,6 @@ export const ClubListSection = ({
   if (isLoading) return <LoadingSpinner />;
   if (error) return <div>{error.message}</div>;
 
-  // 기본 정렬: 검색이나 필터가 적용되지 않았을 때 isRegistered가 true인 동아리를 상위에 표시
   const isDefaultSort = !searchText && categoryFilter === 'ALL' && !filterStatus;
   const sortedClubs = isDefaultSort
     ? [...filteredClubs].sort((a, b) => {
@@ -54,7 +53,6 @@ export const ClubListSection = ({
               {club.isRegistered && (
                 <S.VerifiedBadge>
                   <BsFillPatchCheckFill size={14} />
-                  <S.VerifiedText>안심동아리</S.VerifiedText>
                 </S.VerifiedBadge>
               )}
             </S.ClubNameContainer>

--- a/src/pages/user/Main/components/ClubListSection/index.tsx
+++ b/src/pages/user/Main/components/ClubListSection/index.tsx
@@ -34,10 +34,7 @@ export const ClubListSection = ({
 
   const isDefaultSort = !searchText && categoryFilter === 'ALL' && !filterStatus;
   const sortedClubs = isDefaultSort
-    ? [...filteredClubs].sort((a, b) => {
-        if (a.isRegistered === b.isRegistered) return 0;
-        return a.isRegistered ? -1 : 1;
-      })
+    ? [...filteredClubs].sort((a, b) => Number(!!b.isRegistered) - Number(!!a.isRegistered))
     : filteredClubs;
 
   if (sortedClubs.length === 0)

--- a/src/pages/user/Main/components/ClubListSection/index.tsx
+++ b/src/pages/user/Main/components/ClubListSection/index.tsx
@@ -1,3 +1,4 @@
+import { BsFillPatchCheckFill } from 'react-icons/bs';
 import { useNavigate } from 'react-router-dom';
 import { useClubFiltering } from '@/pages/user/Main/hooks/useClubFiltering.ts';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner.tsx';
@@ -48,7 +49,15 @@ export const ClubListSection = ({
       <S.Grid>
         {sortedClubs.map((club: Club) => (
           <S.ClubItem onClick={() => navigate(`/clubs/${club.id}`)} key={club.id}>
-            <S.ClubNameText>{club.name}</S.ClubNameText>
+            <S.ClubNameContainer>
+              <S.ClubNameText>{club.name}</S.ClubNameText>
+              {club.isRegistered && (
+                <S.VerifiedBadge>
+                  <BsFillPatchCheckFill size={14} />
+                  <S.VerifiedText>안심동아리</S.VerifiedText>
+                </S.VerifiedBadge>
+              )}
+            </S.ClubNameContainer>
             <S.ClubIntroduction>{club.shortIntroduction}</S.ClubIntroduction>
             <S.StatusContainer>
               <S.CategoryStatusBox>

--- a/src/pages/user/Main/components/ClubListSection/index.tsx
+++ b/src/pages/user/Main/components/ClubListSection/index.tsx
@@ -31,13 +31,22 @@ export const ClubListSection = ({
   if (isLoading) return <LoadingSpinner />;
   if (error) return <div>{error.message}</div>;
 
-  if (filteredClubs.length === 0)
+  // 기본 정렬: 검색이나 필터가 적용되지 않았을 때 isRegistered가 true인 동아리를 상위에 표시
+  const isDefaultSort = !searchText && categoryFilter === 'ALL' && !filterStatus;
+  const sortedClubs = isDefaultSort
+    ? [...filteredClubs].sort((a, b) => {
+        if (a.isRegistered === b.isRegistered) return 0;
+        return a.isRegistered ? -1 : 1;
+      })
+    : filteredClubs;
+
+  if (sortedClubs.length === 0)
     return NoSearchResult(filteredClubs, searchText, categoryFilter, filterStatus);
 
   return (
     <S.ClubListContainer>
       <S.Grid>
-        {filteredClubs.map((club: Club) => (
+        {sortedClubs.map((club: Club) => (
           <S.ClubItem onClick={() => navigate(`/clubs/${club.id}`)} key={club.id}>
             <S.ClubNameText>{club.name}</S.ClubNameText>
             <S.ClubIntroduction>{club.shortIntroduction}</S.ClubIntroduction>

--- a/src/pages/user/Main/types/club.ts
+++ b/src/pages/user/Main/types/club.ts
@@ -6,6 +6,7 @@ export type Club = {
   category: ClubCategoryEng;
   shortIntroduction: string;
   recruitStatus: RecruitStatus;
+  isRegistered?: boolean;
 };
 
 export const RECRUIT_STATUS_MAP = {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호

## 📝작업 내용

등록된 동아리(isRegistered)를 사용자가 쉽게 인식하고 접근할 수 있도록 UI/UX를 개선하고, 동아리 인스타그램 링크 기능을 추가했습니다.

### 1. 등록 동아리 우선 표시 및 인증 뱃지
메인 페이지 동아리 목록에서 isRegistered: true인 동아리가 상단에 표시되도록 정렬 기능 추가
등록 동아리에 인증 뱃지 아이콘 표시 (react-icons/bs의 BsFillPatchCheckFill 사용)
인증 뱃지는 primary 컬러로 표시되어 시각적으로 구분 가능
### 2. 인스타그램 링크 기능
타입 추가: ClubDetail 타입에 instagramUrl: string 필드 추가
관리자 기능: 동아리 정보 수정 페이지에 인스타그램 링크 입력 필드 추가
위치: 연락처 입력란 아래
선택 항목 (required 아님)
사용자 기능: 동아리 상세 페이지에 "공식 인스타그램 보기" 버튼 추가
위치: 지원하기 버튼 위
스타일: outline variant
클릭 시 새 탭에서 인스타그램 페이지로 이동
인스타그램 링크가 있는 경우에만 표시 (조건부 렌더링)


___
상세
### API 연동
GET /api/clubs/{clubId}: instagramUrl 필드 포함
POST /api/clubs/{clubId}: instagramUrl 필드 포함
### 파일 변경사항
src/pages/user/Main/types/club.ts: isRegistered 필드 추가
src/pages/user/Main/components/ClubListSection/: 정렬 로직 및 인증 뱃지 UI
src/pages/user/ClubDetail/types/clubDetail.ts: instagramUrl 필드 추가
src/pages/admin/ClubDetailEdit/components/ClubInfoSidebarEditSection/: 인스타그램 링크 입력 필드
src/pages/user/ClubDetail/components/ClubInfoSidebarSection/: 인스타그램 버튼

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
