### PR TITLE
[FIX] 단일 체크박스 선택 시 문자열 반환에 따른 유효성 검사 오류 수정 (#460)

### DIFF
--- a/src/pages/user/Apply/components/ApplicationForm/index.tsx
+++ b/src/pages/user/Apply/components/ApplicationForm/index.tsx
@@ -173,10 +173,7 @@ export const ApplicationForm = ({ questions }: Props) => {
                         value={option}
                         {...methods.register(`answers.${field.originalIndex}`, {
                           validate: (value) => {
-                            const checked = value as unknown as string | string[];
-                            const hasValue = Array.isArray(checked)
-                              ? checked.length > 0
-                              : Boolean(checked);
+                            const hasValue = Array.isArray(value) ? value.length > 0 : !!value;
                             return hasValue || '하나 이상 선택해야 합니다.';
                           },
                         })}

--- a/src/pages/user/Apply/components/ApplicationForm/index.tsx
+++ b/src/pages/user/Apply/components/ApplicationForm/index.tsx
@@ -173,10 +173,11 @@ export const ApplicationForm = ({ questions }: Props) => {
                         value={option}
                         {...methods.register(`answers.${field.originalIndex}`, {
                           validate: (value) => {
-                            if (Array.isArray(value) && value.length > 0) {
-                              return true;
-                            }
-                            return '하나 이상 선택해야 합니다.';
+                            const checked = value as unknown as string | string[];
+                            const hasValue = Array.isArray(checked)
+                              ? checked.length > 0
+                              : Boolean(checked);
+                            return hasValue || '하나 이상 선택해야 합니다.';
                           },
                         })}
                       />


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #460 

## 📝작업 내용

> 단일 옵션 체크박스 선택 시 react-hook-form이 값을 문자열로 반환하여 발생하는 유효성 검사 오류를 해결했습니다. 

### 유효성 검사로직 개선
기존: `Array.isArray(value) && value.length > 0` 검사만 수행하여 단일 문자열 값일 때 실패함.
변경: 값이 배열인 경우와 문자열인 경우를 모두 체크하도록 수정.

### 타입 일관성 유지
`Array.isArray` 검사를 통과하지 못하더라도 값이 존재하면 유효한 것으로 처리


