### PR TITLE
[FIX] 드롭다운 아이콘을 SVG로 교체하여 GTM Click Text 통일 (#466)

### DIFF
--- a/src/pages/user/Main/components/FiltersSection/index.styled.ts
+++ b/src/pages/user/Main/components/FiltersSection/index.styled.ts
@@ -130,7 +130,8 @@ type DropdownIconProps = {
 };
 
 export const DropdownIcon = styled.span<DropdownIconProps>(({ theme, isOpen }) => ({
-  fontSize: '10px',
+  display: 'flex',
+  alignItems: 'center',
   transition: 'transform 0.2s ease',
   transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
   color: theme.colors.gray400,

--- a/src/pages/user/Main/components/FiltersSection/index.tsx
+++ b/src/pages/user/Main/components/FiltersSection/index.tsx
@@ -64,7 +64,17 @@ export const FiltersSection = ({
         <S.DropdownWrapper>
           <S.DropdownButton onClick={() => setIsDropdownOpen(!isDropdownOpen)}>
             {selectedRecruitStatus || '전체'}
-            <S.DropdownIcon isOpen={isDropdownOpen}>▼</S.DropdownIcon>
+            <S.DropdownIcon isOpen={isDropdownOpen}>
+              <svg width='10' height='10' viewBox='0 0 10 10' fill='none' aria-hidden='true'>
+                <path
+                  d='M1 3L5 7L9 3'
+                  stroke='currentColor'
+                  strokeWidth='1.5'
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                />
+              </svg>
+            </S.DropdownIcon>
           </S.DropdownButton>
 
           {isDropdownOpen && (


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #466 

## 📝작업 내용

> GTM에서 드롭다운 클릭 이벤트를 수집할 때 아이콘 문자(▼)가 포함되어 매개변수 값이 달라지는 버그를 수정했습니다
- 모집 상태 드롭다운 버튼의 ▼ 텍스트 문자를 SVG 아이콘으로 교체
- 기존 ▼ 텍스트가 GTM Click Text에 포함되어 버튼("전체▼")과
  항목("전체") 간 매개변수 불일치 문제 수정