### PR TITLE
[FEAT] GTM dataLayer 이벤트 추가

### DIFF
--- a/src/pages/user/Apply/Page.tsx
+++ b/src/pages/user/Apply/Page.tsx
@@ -16,7 +16,7 @@ export const ClubApplicationPage = () => {
     <Layout>
       <ContentContainer>
         <ClubDescription title={formData.title} description={formData?.description ?? ''} />
-        <ApplicationForm questions={formData.formQuestions} />
+        <ApplicationForm questions={formData.formQuestions} clubName={formData.title} />
       </ContentContainer>
     </Layout>
   );

--- a/src/pages/user/Apply/components/ApplicationForm/index.tsx
+++ b/src/pages/user/Apply/components/ApplicationForm/index.tsx
@@ -14,9 +14,10 @@ import type { FormInputs, Question } from '@/pages/user/Apply/type/apply';
 
 type Props = {
   questions: Question[];
+  clubName: string;
 };
 
-export const ApplicationForm = ({ questions }: Props) => {
+export const ApplicationForm = ({ questions, clubName }: Props) => {
   const [formKey, setFormKey] = useState(0);
 
   const { clubId } = useParams<{ clubId: string }>();
@@ -57,7 +58,12 @@ export const ApplicationForm = ({ questions }: Props) => {
   }, [clubIdNumber, reset]);
 
   const questionArray = questions.map((e) => e.question);
-  const { handleSubmit } = useApplicationSubmit(clubIdNumber, questionArray, clearFormAndStorage);
+  const { handleSubmit } = useApplicationSubmit(
+    clubIdNumber,
+    clubName,
+    questionArray,
+    clearFormAndStorage,
+  );
 
   const questionsWithIndex = questions.map((q, i) => ({ ...q, originalIndex: i }));
   const timeSlotQuestions = questionsWithIndex.filter(

--- a/src/pages/user/Apply/hooks/useApplicationSubmit.ts
+++ b/src/pages/user/Apply/hooks/useApplicationSubmit.ts
@@ -8,6 +8,7 @@ import type { ErrorResponse } from '@/pages/admin/Signup/type/error';
 
 export const useApplicationSubmit = (
   clubId: number,
+  clubName: string,
   questionArray: string[],
   onSuccess?: () => void,
 ) => {
@@ -40,6 +41,12 @@ export const useApplicationSubmit = (
   };
 
   const handleSubmit = async (data: FormInputs) => {
+    window.dataLayer?.push({
+      event: 'click_submit_application',
+      club_id: clubId,
+      club_name: clubName,
+    });
+
     try {
       const result = await postApplicationForm(clubId, data, questionArray);
 

--- a/src/pages/user/Apply/hooks/useApplicationSubmit.ts
+++ b/src/pages/user/Apply/hooks/useApplicationSubmit.ts
@@ -41,11 +41,7 @@ export const useApplicationSubmit = (
   };
 
   const handleSubmit = async (data: FormInputs) => {
-    window.dataLayer?.push({
-      event: 'click_submit_application',
-      club_id: clubId,
-      club_name: clubName,
-    });
+    window.dataLayer?.push({ event: 'club_submit_click', clubId, clubName });
 
     try {
       const result = await postApplicationForm(clubId, data, questionArray);

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -48,6 +48,7 @@ export const ClubDetailPage = () => {
       }
       right={
         <ClubInfoSidebarSection
+          clubName={club.clubName}
           presidentName={club.presidentName}
           presidentPhoneNumber={club.presidentPhoneNumber}
           location={club.location}

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ApplyButton.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ApplyButton.tsx
@@ -4,6 +4,8 @@ import { toast } from '@/shared/utils/toast';
 import type { RecruitStatus } from '@/pages/user/Main/types/club';
 
 type Props = {
+  clubId: number;
+  clubName: string;
   recruitStatus: RecruitStatus;
   to: string;
   width?: string;
@@ -13,6 +15,8 @@ type Props = {
 };
 
 const ApplyButton = ({
+  clubId,
+  clubName,
   recruitStatus,
   to,
   width,
@@ -32,6 +36,8 @@ const ApplyButton = ({
 
   const handleApplyClick = () => {
     if (!isRecruiting) return;
+
+    window.dataLayer?.push({ event: 'click_apply_button', club_id: clubId, club_name: clubName });
 
     if (isRegistered) {
       navigate(to);

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ApplyButton.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ApplyButton.tsx
@@ -37,7 +37,7 @@ const ApplyButton = ({
   const handleApplyClick = () => {
     if (!isRecruiting) return;
 
-    window.dataLayer?.push({ event: 'click_apply_button', club_id: clubId, club_name: clubName });
+    window.dataLayer?.push({ event: 'club_apply_click', clubId, clubName });
 
     if (isRegistered) {
       navigate(to);

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -54,11 +54,7 @@ export const ClubInfoSidebarSection = ({
         <Button
           variant='outline'
           onClick={() => {
-            window.dataLayer?.push({
-              event: 'click_instagram_button',
-              club_id: clubId,
-              club_name: clubName,
-            });
+            window.dataLayer?.push({ event: 'club_instagram_click', clubId, clubName });
             window.open(instagramUrl, '_blank');
           }}
           width='100%'

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -7,6 +7,7 @@ import type { ClubDetail } from '@/pages/user/ClubDetail/types/clubDetail';
 type ClubInfoSidebarSectionProps = Pick<
   ClubDetail,
   | 'clubId'
+  | 'clubName'
   | 'presidentName'
   | 'presidentPhoneNumber'
   | 'location'
@@ -23,6 +24,7 @@ type ClubInfoSidebarSectionProps = Pick<
 
 export const ClubInfoSidebarSection = ({
   clubId,
+  clubName,
   presidentName,
   presidentPhoneNumber,
   location,
@@ -49,11 +51,24 @@ export const ClubInfoSidebarSection = ({
       <InfoItem>정기 모임: {regularMeetingInfo}</InfoItem>
       <InfoItem>모집 상태: {recruitStatus}</InfoItem>
       {instagramUrl && (
-        <Button variant='outline' onClick={() => window.open(instagramUrl, '_blank')} width='100%'>
+        <Button
+          variant='outline'
+          onClick={() => {
+            window.dataLayer?.push({
+              event: 'click_instagram_button',
+              club_id: clubId,
+              club_name: clubName,
+            });
+            window.open(instagramUrl, '_blank');
+          }}
+          width='100%'
+        >
           공식 인스타그램 보기
         </Button>
       )}
       <ApplyButton
+        clubId={clubId}
+        clubName={clubName}
         recruitStatus={recruitStatus}
         to={`/clubs/${clubId}/apply`}
         width={'auto'}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface Window {
+  dataLayer?: Record<string, unknown>[];
+}


### PR DESCRIPTION

## 📝작업 내용
> 마케팅 성과 측정 및 사용자 행동 분석을 위해 주요 전환 지점에 GTM dataLayer 이벤트를 심었습니다

### 버튼 클릭 이벤트 트래킹 구현
- **동아리 지원하기**: 메인 또는 상세 페이지에서 지원하기 클릭 시 `club_apply_click` 이벤트 추적
- **인스타그램 방문**: 공식 인스타그램 버튼 클릭 시 `club_instagram_click` 이벤트 추적
- **지원서 최종 제출**: 지원서 작성을 완료하고 제출 버튼을 누를 때 `club_submit_click` 이벤트 추적

### 데이터 일관성을 위한 Prop 및 파라미터 구조 수정
- `ApplyButton.tsx`: `clubId`, `clubName`을 `prop`으로 받아 클릭 시 데이터 레이어에 푸시
- `ClubInfoSidebarSection`: 인스타그램 버튼 이벤트 추가 및 하위 버튼으로 클럽 정보 전달
- `useApplicationSubmit.ts`: 제출 훅 내부에 `clubName` 파라미터를 추가하여 성공 시 이벤트 발생
- `Apply/Page.tsx` 및 `ApplicationForm`: 클럽 정보가 필요한 모든 레이어에 데이터 전달

