### PR TITLE
[REFACTOR] useSuspenseQuery를 활용한 비동기 데이터 로딩 개선 (#313)

### DIFF
--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -40,7 +40,11 @@ export const router = createBrowserRouter([
       },
       {
         path: USER.APPLICATION,
-        element: <ClubApplicationPage />,
+        element: (
+          <Suspense fallback={<LoadingSpinner />}>
+            <ClubApplicationPage />
+          </Suspense>
+        ),
       },
       {
         path: COMMON.CALLBACK,

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -80,7 +80,11 @@ export const router = createBrowserRouter([
           },
           {
             path: ADMIN.CLUB_EDIT,
-            element: <ClubDetailEditPage />,
+            element: (
+              <Suspense fallback={<LoadingSpinner />}>
+                <ClubDetailEditPage />
+              </Suspense>
+            ),
           },
           {
             path: ADMIN.APPLICATION_FORM_BUILDER,

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 import { ROUTE_PATH } from '@/app/constants/routerPath.ts';
 import { ClubGuard } from '@/app/providers/guards/ClubGuard';
@@ -9,6 +10,7 @@ import { ClubDetailPage } from '@/pages/user/ClubDetail/Page';
 import { MainPage } from '@/pages/user/Main/Page.tsx';
 import { NoticeDetailPage } from '@/pages/user/Notice/DetailPage';
 import { NoticeListPage } from '@/pages/user/Notice/Page';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { ApplicationDetailPage } from './admin/ApplicationDetail/Page';
 import { ApplicationFormBuilderPage } from './admin/ApplicationFormBuilder/Page';
 import { KakaoCallback } from './admin/Login/KakaoCallback';
@@ -26,7 +28,11 @@ export const router = createBrowserRouter([
       { path: COMMON.MAIN, element: <MainPage /> },
       {
         path: COMMON.CLUB_DETAIL,
-        element: <ClubDetailPage />,
+        element: (
+          <Suspense fallback={<LoadingSpinner />}>
+            <ClubDetailPage />
+          </Suspense>
+        ),
       },
       {
         path: COMMON.LOGIN,

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -84,7 +84,11 @@ export const router = createBrowserRouter([
           },
           {
             path: ADMIN.APPLICATION_FORM_BUILDER,
-            element: <ApplicationFormBuilderPage />,
+            element: (
+              <Suspense fallback={<LoadingSpinner />}>
+                <ApplicationFormBuilderPage />
+              </Suspense>
+            ),
           },
           {
             path: ADMIN.MEMBER_MANAGEMENT,

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -96,7 +96,11 @@ export const router = createBrowserRouter([
           },
           {
             path: ADMIN.MEMBER_MANAGEMENT,
-            element: <MemberManagementPage />,
+            element: (
+              <Suspense fallback={<LoadingSpinner />}>
+                <MemberManagementPage />
+              </Suspense>
+            ),
           },
         ],
       },

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -72,7 +72,11 @@ export const router = createBrowserRouter([
           },
           {
             path: ADMIN.APPLICATION_DETAIL,
-            element: <ApplicationDetailPage />,
+            element: (
+              <Suspense fallback={<LoadingSpinner />}>
+                <ApplicationDetailPage />
+              </Suspense>
+            ),
           },
           {
             path: ADMIN.CLUB_EDIT,

--- a/src/pages/admin/ApplicationDetail/Page.tsx
+++ b/src/pages/admin/ApplicationDetail/Page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAuth } from '@/app/providers/auth';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
@@ -12,15 +13,12 @@ export const ApplicationDetailPage = () => {
   const { clubId, applicantId } = useParams();
   const { user } = useAuth();
 
-  const {
-    data: detailApplicants,
-    isLoading,
-    error,
-    updateStatus,
-  } = useDetailApplications(Number(clubId), Number(applicantId));
+  const { data: detailApplicants, updateStatus } = useDetailApplications(
+    Number(clubId),
+    Number(applicantId),
+  );
 
-  if (isLoading || !user) return <LoadingSpinner />;
-  if (error) return <div>에러발생 : {error.message}</div>;
+  if (!user) return <LoadingSpinner />;
 
   if (user.clubId !== Number(clubId)) {
     return <div>권한이 없습니다.</div>;
@@ -30,23 +28,23 @@ export const ApplicationDetailPage = () => {
     <S.PageLayout>
       <S.MainContent>
         <ApplicantProfileSection
-          name={detailApplicants?.applicantInfo.name}
-          department={detailApplicants?.applicantInfo.department}
-          status={detailApplicants?.status}
-          rating={detailApplicants?.rating}
+          name={detailApplicants.applicantInfo.name}
+          department={detailApplicants.applicantInfo.department}
+          status={detailApplicants.status}
+          rating={detailApplicants.rating}
           updateStatus={updateStatus}
         />
         <ApplicantInfoSection
-          studentId={detailApplicants?.applicantInfo.studentId}
-          email={detailApplicants?.applicantInfo.email}
-          phoneNumber={detailApplicants?.applicantInfo.phoneNumber}
+          studentId={detailApplicants.applicantInfo.studentId}
+          email={detailApplicants.applicantInfo.email}
+          phoneNumber={detailApplicants.applicantInfo.phoneNumber}
         />
-        <ApplicantQuestionSection
-          questionsAndAnswers={detailApplicants?.questionsAndAnswers || []}
-        />
+        <ApplicantQuestionSection questionsAndAnswers={detailApplicants.questionsAndAnswers} />
       </S.MainContent>
       <S.AsideContent>
-        <CommentSection />
+        <Suspense fallback={<LoadingSpinner />}>
+          <CommentSection />
+        </Suspense>
       </S.AsideContent>
     </S.PageLayout>
   );

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/index.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/index.tsx
@@ -1,16 +1,12 @@
 import { useParams } from 'react-router-dom';
 import { useComments } from '@/pages/admin/ApplicationDetail/hooks/useComments';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { CommentForm } from './CommentForm';
 import { CommentList } from './CommentList';
 
 export const CommentSection = () => {
   const { applicantId } = useParams();
 
-  const { data, isLoading, error, createComment } = useComments(Number(applicantId));
-
-  if (isLoading) return <LoadingSpinner />;
-  if (error) return <div>에러발생 : {error.message}</div>;
+  const { data, createComment } = useComments(Number(applicantId));
 
   return (
     <>

--- a/src/pages/admin/ApplicationDetail/hooks/useComments.ts
+++ b/src/pages/admin/ApplicationDetail/hooks/useComments.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import {
   fetchComments,
   createComment,
@@ -7,21 +7,11 @@ import {
 } from '@/pages/admin/ApplicationDetail/api/comments';
 import { toast } from '@/shared/utils/toast';
 import type { Comment } from '@/pages/admin/ApplicationDetail/types/comments';
-import type { UseApiQueryResult } from '@/shared/types/useApiQueryResult';
 
-type CreateCommentPayload = Pick<Comment, 'content' | 'rating'>;
-type UpdateCommentPayload = Pick<Comment, 'commentId' | 'content' | 'rating'>;
-
-type UseCommentsResult = UseApiQueryResult<Comment[]> & {
-  createComment: (comment: CreateCommentPayload) => void;
-  deleteComment: (commentId: number) => void;
-  updateComment: (comment: UpdateCommentPayload) => void;
-};
-
-export const useComments = (applicationId: number): UseCommentsResult => {
+export const useComments = (applicationId: number) => {
   const queryClient = useQueryClient();
 
-  const { data, isLoading, error } = useQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ['comments', applicationId],
     queryFn: () => fetchComments(applicationId),
   });
@@ -83,9 +73,7 @@ export const useComments = (applicationId: number): UseCommentsResult => {
   });
 
   return {
-    data: data || [],
-    isLoading,
-    error,
+    data,
     createComment: createCommentMutation,
     deleteComment: deleteCommentMutation,
     updateComment: updateCommentMutation,

--- a/src/pages/admin/ApplicationDetail/hooks/useDetailApplication.ts
+++ b/src/pages/admin/ApplicationDetail/hooks/useDetailApplication.ts
@@ -1,25 +1,17 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import {
   fetchDetailApplication,
   updateApplicationStatus,
 } from '@/pages/admin/ApplicationDetail/api/detailApplication';
 import { toast } from '@/shared/utils/toast';
 import type { DetailApplication } from '@/pages/admin/ApplicationDetail/types/detailApplication';
-import type { UseApiQueryResult } from '@/shared/types/useApiQueryResult';
 
-type UseDetailApplicationResult = UseApiQueryResult<DetailApplication | null> & {
-  updateStatus: (status: DetailApplication['status']) => void;
-};
-
-export const useDetailApplications = (
-  clubId: number,
-  applicantId: number,
-): UseDetailApplicationResult => {
+export const useDetailApplications = (clubId: number, applicantId: number) => {
   const queryClient = useQueryClient();
 
-  const { data, isLoading, error } = useQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ['detailApplications', clubId, applicantId],
-    queryFn: () => fetchDetailApplication(clubId!, applicantId!),
+    queryFn: () => fetchDetailApplication(clubId, applicantId),
     staleTime: 1000 * 60 * 5,
   });
 
@@ -48,10 +40,5 @@ export const useDetailApplications = (
     },
   });
 
-  return {
-    data: data || null,
-    isLoading,
-    error,
-    updateStatus,
-  };
+  return { data, updateStatus };
 };

--- a/src/pages/admin/ApplicationFormBuilder/Page.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/Page.tsx
@@ -1,12 +1,11 @@
 import styled from '@emotion/styled';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import {
   useAdaptedApplicationForm,
   useAdaptedPatchApplicationForm,
 } from '@/pages/admin/ApplicationFormBuilder/hooks/useApplicationFormAdapter';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { toast } from '@/shared/utils/toast';
 import { ApplicationInfoSection } from './components/ApplicationInfoSection';
 import { ApplicationFieldsFormTableSection } from './components/FieldsFormTableSection';
@@ -16,24 +15,12 @@ import type { ApplicationFormData } from './types/fieldType';
 export const ApplicationFormBuilderPage = () => {
   const { clubId } = useParams();
   const [isEditMode, setIsEditMode] = useState(false);
-  const { data, isLoading, error } = useAdaptedApplicationForm(Number(clubId));
+  const { data } = useAdaptedApplicationForm(Number(clubId));
   const { adaptedPatchForm } = useAdaptedPatchApplicationForm(Number(clubId));
 
   const formHandler = useForm<ApplicationFormData>({
-    defaultValues: {
-      title: '',
-      description: '',
-      recruitDate: '',
-      interviewRequired: false,
-      formQuestions: [],
-    },
+    defaultValues: data,
   });
-
-  useEffect(() => {
-    if (data) {
-      formHandler.reset(data);
-    }
-  }, [data, formHandler]);
 
   const handleEdit = () => setIsEditMode(true);
   const handleCancel = () => {
@@ -85,9 +72,6 @@ export const ApplicationFormBuilderPage = () => {
       );
     }
   };
-
-  if (isLoading) return <LoadingSpinner />;
-  if (error) return <div>에러발생 : {error.message}</div>;
 
   return (
     <Layout>

--- a/src/pages/admin/ApplicationFormBuilder/hooks/useApplicationForm.ts
+++ b/src/pages/admin/ApplicationFormBuilder/hooks/useApplicationForm.ts
@@ -1,19 +1,15 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { toast } from '@/shared/utils/toast';
 import { fetchApplicationForm, patchApplicationForm, postApplicationForm } from '../api/apply-form';
 import type { ApplicationForm } from '../types/fieldType';
 
 export const useApplicationForm = (clubId: number) => {
-  const { data, isLoading, error } = useQuery({
+  const { data } = useSuspenseQuery({
     queryKey: ['apply-form', clubId],
     queryFn: () => fetchApplicationForm(clubId),
   });
 
-  return {
-    data: data || undefined,
-    isLoading,
-    error,
-  };
+  return { data };
 };
 
 export const usePostApplicationForm = (clubId: number) => {

--- a/src/pages/admin/ApplicationFormBuilder/hooks/useApplicationFormAdapter.ts
+++ b/src/pages/admin/ApplicationFormBuilder/hooks/useApplicationFormAdapter.ts
@@ -7,11 +7,9 @@ import {
 import type { ApplicationForm, ApplicationFormData } from '../types/fieldType';
 
 export const useAdaptedApplicationForm = (clubId: number) => {
-  const { data: apiData, isLoading, error } = useApplicationForm(clubId);
+  const { data: apiData } = useApplicationForm(clubId);
 
   const adaptedData = useMemo(() => {
-    if (!apiData) return undefined;
-
     return {
       ...apiData,
       formQuestions: apiData.formQuestions.map((question) => {
@@ -33,7 +31,7 @@ export const useAdaptedApplicationForm = (clubId: number) => {
     };
   }, [apiData]);
 
-  return { data: adaptedData, isLoading, error };
+  return { data: adaptedData };
 };
 
 export const useAdaptedPatchApplicationForm = (clubId: number) => {

--- a/src/pages/admin/ClubDetailEdit/Page.tsx
+++ b/src/pages/admin/ClubDetailEdit/Page.tsx
@@ -1,10 +1,8 @@
 import styled from '@emotion/styled';
-import { useEffect } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Button } from '@/shared/components/Button';
 import { TwoColumnLayout } from '@/shared/components/Layout/TwoColumnLayout';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { PageHeader } from '@/shared/components/PageHeader';
 import { engToKorCategory } from '@/shared/utils/formatting';
 import { toast } from '@/shared/utils/toast';
@@ -21,21 +19,17 @@ import type { ClubCategoryEng } from '@/shared/types/club';
 
 export const ClubDetailEditPage = () => {
   const { clubId } = useParams<{ clubId: string }>();
-  const { data: club, isLoading, error } = useClubDetailEdit(clubId ?? '');
+  const club = useClubDetailEdit(clubId ?? '');
 
   const methods = useForm<ClubDetailUpdatePayload>({
     mode: 'onTouched',
+    defaultValues: club,
   });
 
   const {
     handleSubmit,
-    reset,
     formState: { errors, isSubmitting, isSubmitSuccessful },
   } = methods;
-
-  useEffect(() => {
-    if (club) reset(club);
-  }, [club, reset]);
 
   const navigate = useNavigate();
 
@@ -50,9 +44,6 @@ export const ClubDetailEditPage = () => {
         toast.error(error.message || '수정 실패!');
       });
   };
-  if (isLoading) return <LoadingSpinner />;
-  if (error) return <div>에러발생 : {error.message}</div>;
-  if (!club) return null;
 
   return (
     <FormProvider {...methods}>

--- a/src/pages/admin/ClubDetailEdit/hooks/useClubDetailEdit.ts
+++ b/src/pages/admin/ClubDetailEdit/hooks/useClubDetailEdit.ts
@@ -1,11 +1,11 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { fetchClubDetailEdit } from '@/pages/admin/ClubDetailEdit/api/clubDetailEdit';
-import type { ClubDetailEdit } from '../types/clubDetailEdit';
 
 export const useClubDetailEdit = (clubId: string | number) => {
-  return useQuery<ClubDetailEdit>({
+  const { data } = useSuspenseQuery({
     queryKey: ['clubDetailEdit', clubId],
     queryFn: () => fetchClubDetailEdit(clubId),
-    enabled: !!clubId,
   });
+
+  return data;
 };

--- a/src/pages/admin/Dashboard/Page.tsx
+++ b/src/pages/admin/Dashboard/Page.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { ApplicantListSection } from './components/ApplicantListSection';
 import { DashboardSummarySection } from './components/DashboardSummarySection';
 import { SentAcceptanceMessagesSection } from './components/SentAcceptanceMessagesSection';
@@ -13,8 +14,10 @@ export const DashboardPage = () => {
   return (
     <Layout>
       <Container>
-        <DashboardSummarySection />
-        <ApplicantListSection stage={stage} setStage={setStage} clubId={Number(clubId)} />
+        <Suspense fallback={<LoadingSpinner />}>
+          <DashboardSummarySection />
+          <ApplicantListSection stage={stage} setStage={setStage} clubId={Number(clubId)} />
+        </Suspense>
         <SentAcceptanceMessagesSection stage={stage} />
       </Container>
     </Layout>

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/List/ApplicantList/index.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useApplicants } from '@/pages/admin/Dashboard/hooks/useApplicants';
 import { STAGE_LABEL } from '@/pages/admin/Dashboard/utils/labelMap';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { ApplicantListItem } from '../ApplicantListItem';
 import * as S from './index.styled';
 import type {
@@ -24,8 +23,6 @@ export const ApplicantList = ({ filterOption, stage }: Props) => {
 
   const {
     data: applicants,
-    isLoading,
-    error,
     interviewSchedule,
     interviewRequired,
   } = useApplicants(Number(clubId), apiStage, filterOption);
@@ -43,9 +40,6 @@ export const ApplicantList = ({ filterOption, stage }: Props) => {
     },
     [clubId, navigate],
   );
-
-  if (isLoading) return <LoadingSpinner />;
-  if (error) return <div>에러발생 : {error.message}</div>;
 
   return (
     <S.Container>

--- a/src/pages/admin/Dashboard/components/DashboardSummarySection/index.tsx
+++ b/src/pages/admin/Dashboard/components/DashboardSummarySection/index.tsx
@@ -1,22 +1,13 @@
 import styled from '@emotion/styled';
 import { useParams } from 'react-router-dom';
 import { useDashboardSummary } from '@/pages/admin/Dashboard/hooks/useDashboardSummary';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { formatDateWithoutYear } from '@/shared/utils/dateUtils';
 import { SummaryCard } from './SummaryCard';
 
 export const DashboardSummarySection = () => {
   const { clubId } = useParams();
 
-  const { data: summary, isLoading, error } = useDashboardSummary(Number(clubId));
-
-  if (isLoading) return <LoadingSpinner />;
-  if (error) {
-    return <Wrapper>Error: {error.message}</Wrapper>;
-  }
-  if (!summary) {
-    return null;
-  }
+  const summary = useDashboardSummary(Number(clubId));
 
   const recruitmentPeriod =
     summary.startDay && summary.endDay

--- a/src/pages/admin/Dashboard/hooks/useApplicants.ts
+++ b/src/pages/admin/Dashboard/hooks/useApplicants.ts
@@ -1,36 +1,21 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { fetchApplicants } from '@/pages/admin/Dashboard/api/applicant';
 import type {
-  ApplicantData,
   ApplicantsApiResponse,
   ApplicationFilterOption,
-  ApplicantCounts,
-  InterviewSchedule,
 } from '@/pages/admin/Dashboard/types/dashboard';
-import type { UseApiQueryResult } from '@/shared/types/useApiQueryResult';
-
-export interface ExtendedUseApiQueryResult<T> extends UseApiQueryResult<T> {
-  counts: ApplicantCounts;
-  interviewRequired: boolean;
-  interviewSchedule: InterviewSchedule[];
-}
 
 export const useApplicants = (
   clubId: number,
   stage: 'INTERVIEW' | 'FINAL',
   status?: ApplicationFilterOption,
-): ExtendedUseApiQueryResult<ApplicantData[]> => {
-  const {
-    data: responseData,
-    isLoading,
-    error,
-  } = useQuery<ApplicantsApiResponse>({
+) => {
+  const { data: responseData } = useSuspenseQuery<ApplicantsApiResponse>({
     queryKey: ['applicants', clubId, stage],
     queryFn: () => fetchApplicants(clubId, stage),
     staleTime: 1000 * 60 * 5,
     refetchInterval: 30000,
-    enabled: !!stage,
   });
 
   const applicants = useMemo(() => responseData?.applicants || [], [responseData?.applicants]);
@@ -60,8 +45,6 @@ export const useApplicants = (
 
   return {
     data: filteredData,
-    isLoading,
-    error,
     counts,
     interviewRequired: responseData?.interviewRequired ?? false,
     interviewSchedule: responseData?.interviewSchedule || [],

--- a/src/pages/admin/Dashboard/hooks/useDashboardSummary.ts
+++ b/src/pages/admin/Dashboard/hooks/useDashboardSummary.ts
@@ -1,15 +1,13 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { fetchDashboardSummary } from '@/pages/admin/Dashboard/api/dashboard';
-import type { DashboardSummary } from '@/pages/admin/Dashboard/types/dashboard';
-import type { UseApiQueryResult } from '@/shared/types/useApiQueryResult';
 
-export const useDashboardSummary = (clubId: number): UseApiQueryResult<DashboardSummary | null> => {
-  const { data, isLoading, error } = useQuery<DashboardSummary | undefined>({
+export const useDashboardSummary = (clubId: number) => {
+  const { data } = useSuspenseQuery({
     queryKey: ['dashboardSummary', clubId],
     queryFn: () => fetchDashboardSummary(clubId),
     staleTime: 1000 * 60 * 5,
     refetchInterval: 30000,
   });
 
-  return { data: data || null, isLoading, error };
+  return data;
 };

--- a/src/pages/admin/MemberManagement/Page.tsx
+++ b/src/pages/admin/MemberManagement/Page.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAuth } from '@/app/providers/auth';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { useModal } from '@/shared/hooks/useModal';
 import { MemberHeaderSection } from './components/MemberHeaderSection';
 import { MemberTableSection } from './components/MemberTableSection';
@@ -24,7 +23,7 @@ export const MemberManagementPage = () => {
   const deleteModal = useModal();
   const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null);
 
-  const { data: members, isLoading, error } = useMembers(clubId || '');
+  const members = useMembers(clubId || '');
 
   const { searchText, sortBy, filteredMembers, setSearchText, setSortBy } =
     useMemberFilter(members);
@@ -63,9 +62,6 @@ export const MemberManagementPage = () => {
   const handleSubmitBulkUpload = (file: File) => {
     submitBulkUpload(file);
   };
-
-  if (isLoading) return <LoadingSpinner />;
-  if (error) return <div>에러 발생</div>;
 
   return (
     <>

--- a/src/pages/admin/MemberManagement/hooks/useMembers.ts
+++ b/src/pages/admin/MemberManagement/hooks/useMembers.ts
@@ -1,14 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { fetchMembers } from '../api/fetchMembers';
 import type { Member } from '../types/member';
-import type { UseApiQueryResult } from '@/shared/types/useApiQueryResult';
 
-export const useMembers = (clubId: string): UseApiQueryResult<Member[]> => {
-  const { data, isLoading, error } = useQuery<Member[]>({
+export const useMembers = (clubId: string) => {
+  const { data } = useSuspenseQuery<Member[]>({
     queryKey: ['members', clubId],
     queryFn: () => fetchMembers(clubId),
-    enabled: !!clubId,
   });
 
-  return { data: data ?? [], isLoading, error };
+  return data;
 };

--- a/src/pages/user/Apply/Page.tsx
+++ b/src/pages/user/Apply/Page.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import { useParams } from 'react-router-dom';
 import { ClubDescription } from '@/pages/user/Apply/components/ClubDescriptionSection';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { ApplicationForm } from './components/ApplicationForm';
 import { useApplicationForm } from './hooks/useApplicationForm';
 
@@ -9,8 +8,6 @@ export const ClubApplicationPage = () => {
   const { clubId } = useParams();
 
   const formData = useApplicationForm(Number(clubId));
-
-  if (!formData) return <LoadingSpinner />;
 
   return (
     <Layout>

--- a/src/pages/user/Apply/api/apply.ts
+++ b/src/pages/user/Apply/api/apply.ts
@@ -22,9 +22,11 @@ export const postApplicationForm = async (
 ) => {
   const applicationDto = toApplyRequest(formData, questionArray);
 
-  const response = await apiInstance.post(`/clubs/${clubId}/apply-submit`, applicationDto);
-
-  return response;
+  try {
+    return await apiInstance.post(`/clubs/${clubId}/apply-submit`, applicationDto);
+  } catch (error: unknown) {
+    return handleAxiosError(error, '지원서 제출에 실패했습니다.');
+  }
 };
 
 export const overwriteApplicationForm = async (
@@ -35,13 +37,10 @@ export const overwriteApplicationForm = async (
   const applicationDto = toApplyRequest(formData, questionArray);
 
   try {
-    const overwriteResponse = await apiInstance.post(
-      `/clubs/${clubId}/apply-submit`,
-      applicationDto,
-      { params: { overwrite: true } },
-    );
-    return overwriteResponse.data;
+    return await apiInstance.post(`/clubs/${clubId}/apply-submit`, applicationDto, {
+      params: { overwrite: true },
+    });
   } catch (error: unknown) {
-    return handleAxiosError(error, '지원서 제출이 실패하였습니다.');
+    return handleAxiosError(error, '지원서 제출에 실패했습니다.');
   }
 };

--- a/src/pages/user/Apply/hooks/useApplicationForm.ts
+++ b/src/pages/user/Apply/hooks/useApplicationForm.ts
@@ -1,18 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { fetchApplicationForm } from '@/pages/user/Apply/api/apply.ts';
-import type { ApplicationForm } from '../type/apply';
 
 export const useApplicationForm = (clubId: number) => {
-  const [clubApplicationForm, setClubApplicationForm] = useState<ApplicationForm | null>(null);
+  const { data } = useSuspenseQuery({
+    queryKey: ['applicationForm', clubId],
+    queryFn: () => fetchApplicationForm(clubId),
+  });
 
-  useEffect(() => {
-    if (!clubId) return;
-    const setFormStateAfterFetch = async () => {
-      const applicationForm = await fetchApplicationForm(clubId);
-      setClubApplicationForm(applicationForm);
-    };
-    setFormStateAfterFetch();
-  }, [clubId]);
-
-  return clubApplicationForm;
+  return data;
 };

--- a/src/pages/user/Apply/hooks/useApplicationSubmit.ts
+++ b/src/pages/user/Apply/hooks/useApplicationSubmit.ts
@@ -1,10 +1,9 @@
-import { isAxiosError } from 'axios';
+import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
-import { theme } from '@/app/styles/theme';
+import { toast as sonnerToast } from 'sonner';
+import { toast } from '@/shared/utils/toast';
 import { overwriteApplicationForm, postApplicationForm } from '../api/apply';
 import type { FormInputs } from '../type/apply';
-import type { ErrorResponse } from '@/pages/admin/Signup/type/error';
 
 export const useApplicationSubmit = (
   clubId: number,
@@ -14,44 +13,28 @@ export const useApplicationSubmit = (
 ) => {
   const navigate = useNavigate();
 
-  const handleOverwriteConfirm = async (data: FormInputs) => {
-    try {
-      await overwriteApplicationForm(clubId, data, questionArray);
-
-      toast.success('제출 성공!', {
-        style: {
-          backgroundColor: theme.colors.primary,
-          color: 'white',
-        },
-        duration: 1000,
-        onAutoClose: () => {
-          navigate(`/clubs/${clubId}`);
-          onSuccess?.();
-        },
+  const { mutateAsync: overwrite } = useMutation({
+    mutationFn: (data: FormInputs) => overwriteApplicationForm(clubId, data, questionArray),
+    onSuccess: () => {
+      toast.success('제출 성공!', () => {
+        navigate(`/clubs/${clubId}`);
+        onSuccess?.();
       });
-    } catch {
-      toast.error('제출 실패!', {
-        duration: 1000,
-        style: {
-          backgroundColor: 'white',
-          color: theme.colors.error,
-        },
-      });
-    }
-  };
+    },
+    onError: () => {
+      toast.error('제출 실패!');
+    },
+  });
 
-  const handleSubmit = async (data: FormInputs) => {
-    window.dataLayer?.push({ event: 'club_submit_click', clubId, clubName });
-
-    try {
-      const result = await postApplicationForm(clubId, data, questionArray);
-
+  const { mutateAsync: submit } = useMutation({
+    mutationFn: (data: FormInputs) => postApplicationForm(clubId, data, questionArray),
+    onSuccess: (result, data) => {
       if (result.status === 202) {
-        toast('이미 제출된 지원서가 있습니다.', {
+        sonnerToast('이미 제출된 지원서가 있습니다.', {
           description: '덮어쓰시겠습니까?',
           action: {
             label: '예',
-            onClick: () => handleOverwriteConfirm(data),
+            onClick: () => overwrite(data),
           },
           cancel: {
             label: '아니오',
@@ -62,36 +45,19 @@ export const useApplicationSubmit = (
         return;
       }
 
-      toast.success('제출 성공!', {
-        style: {
-          backgroundColor: theme.colors.primary,
-          color: 'white',
-        },
-        duration: 1000,
-        onAutoClose: () => {
-          navigate(`/clubs/${clubId}`);
-          onSuccess?.();
-        },
+      toast.success('제출 성공!', () => {
+        navigate(`/clubs/${clubId}`);
+        onSuccess?.();
       });
-    } catch (e: unknown) {
-      if (isAxiosError<ErrorResponse>(e)) {
-        toast.error(e.response?.data.message, {
-          duration: 1000,
-          style: {
-            backgroundColor: 'white',
-            color: theme.colors.error,
-          },
-        });
-      } else {
-        toast.error('알 수 없는 오류가 발생했습니다.', {
-          duration: 1000,
-          style: {
-            backgroundColor: 'white',
-            color: theme.colors.error,
-          },
-        });
-      }
-    }
+    },
+    onError: (error: Error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const handleSubmit = (data: FormInputs) => {
+    window.dataLayer?.push({ event: 'club_submit_click', clubId, clubName });
+    submit(data);
   };
 
   return { handleSubmit };

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -1,5 +1,7 @@
+import { Suspense } from 'react';
 import { useParams } from 'react-router-dom';
 import { TwoColumnLayout } from '@/shared/components/Layout/TwoColumnLayout';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { PageHeader } from '@/shared/components/PageHeader';
 import { engToKorCategory } from '@/shared/utils/formatting';
 import { ClubActivityPhotosSection } from './components/ClubActivityPhotosSection';
@@ -32,7 +34,9 @@ export const ClubDetailPage = () => {
             introductionActivity={club.introductionActivity}
             introductionIdeal={club.introductionIdeal}
           />
-          <ClubReviewsSection clubId={club.clubId} />
+          <Suspense fallback={<LoadingSpinner />}>
+            <ClubReviewsSection clubId={club.clubId} />
+          </Suspense>
         </>
       }
       right={<ClubInfoSidebarSection {...club} />}

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -35,24 +35,7 @@ export const ClubDetailPage = () => {
           <ClubReviewsSection clubId={club.clubId} />
         </>
       }
-      right={
-        <ClubInfoSidebarSection
-          clubName={club.clubName}
-          presidentName={club.presidentName}
-          presidentPhoneNumber={club.presidentPhoneNumber}
-          location={club.location}
-          recruitStart={club.recruitStart}
-          recruitEnd={club.recruitEnd}
-          regularMeetingInfo={club.regularMeetingInfo}
-          recruitStatus={club.recruitStatus}
-          applicationNotice={club.applicationNotice}
-          clubId={club.clubId}
-          isRegistered={club.isRegistered}
-          everyTimeUrl={club.everyTimeUrl}
-          googleFormUrl={club.googleFormUrl}
-          instagramUrl={club.instagramUrl}
-        />
-      }
+      right={<ClubInfoSidebarSection {...club} />}
     />
   );
 };

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -1,29 +1,18 @@
-import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { TwoColumnLayout } from '@/shared/components/Layout/TwoColumnLayout';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { PageHeader } from '@/shared/components/PageHeader';
 import { engToKorCategory } from '@/shared/utils/formatting';
-import { fetchClubDetail } from './api/clubDetail';
 import { ClubActivityPhotosSection } from './components/ClubActivityPhotosSection';
 import { ClubDescriptionSection } from './components/ClubDescriptionSection';
 import { ClubInfoSidebarSection } from './components/ClubInfoSidebarSection';
 import { ClubReviewsSection } from './components/ClubReviewsSection';
+import { useClubDetail } from './hooks/useClubDetail';
 
-import type { ClubDetail } from './types/clubDetail';
 import type { ClubCategoryEng } from '@/shared/types/club';
 
 export const ClubDetailPage = () => {
   const { clubId } = useParams<{ clubId: string }>();
-  const clubIdNumber = Number(clubId);
-  const [club, setClub] = useState<ClubDetail | null>(null);
-
-  useEffect(() => {
-    if (!clubIdNumber) return;
-    fetchClubDetail(clubIdNumber).then(setClub).catch(console.error);
-  }, [clubIdNumber]);
-
-  if (!club) return <LoadingSpinner />;
+  const club = useClubDetail(Number(clubId));
 
   return (
     <TwoColumnLayout

--- a/src/pages/user/ClubDetail/api/clubReviews.ts
+++ b/src/pages/user/ClubDetail/api/clubReviews.ts
@@ -1,14 +1,6 @@
 import { apiInstance } from '@/app/api/initInstance';
+import { handleAxiosError } from '@/shared/utils/handleAxiosError';
 import type { ClubReview, PostClubReviewRequest } from '@/pages/user/ClubDetail/types/review';
-
-const handleAxiosError = (error: unknown, defaultMessage: string): never => {
-  if (error && typeof error === 'object' && 'response' in error) {
-    const axiosError = error as { response?: { data?: { message?: string } } };
-    const message = axiosError.response?.data?.message || defaultMessage;
-    throw new Error(message);
-  }
-  throw new Error('알 수 없는 오류가 발생했습니다.');
-};
 
 export const fetchClubReviews = async (clubId: number): Promise<ClubReview[]> => {
   return apiInstance

--- a/src/pages/user/ClubDetail/components/ClubReviewsSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubReviewsSection/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { useClubReviews } from '@/pages/user/ClubDetail/hooks/useClubReviews';
 import { Button } from '@/shared/components/Button';
 import { OutlineInputField } from '@/shared/components/Form/InputField/OutlineInputField';
@@ -7,32 +7,23 @@ import { SectionHeading } from '@/shared/components/SectionHeading';
 import { Text } from '@/shared/components/Text';
 import * as S from './index.styled';
 
+type ReviewFormValues = {
+  studentId: string;
+  content: string;
+};
+
 export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
   const { reviews, apiError, addReview } = useClubReviews(clubId);
-  const [studentId, setStudentId] = useState('');
-  const [content, setContent] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitted, setSubmitted] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ReviewFormValues>();
 
-  const isStudentIdInvalid = submitted && !studentId.trim();
-  const isContentInvalid = submitted && !content.trim();
-
-  const handleSubmit = async () => {
-    if (isSubmitting) return;
-    setSubmitted(true);
-    if (!studentId.trim() || !content.trim()) return;
-
-    setIsSubmitting(true);
-    try {
-      const success = await addReview(studentId, content);
-      if (success) {
-        setContent('');
-        setStudentId('');
-        setSubmitted(false);
-      }
-    } finally {
-      setIsSubmitting(false);
-    }
+  const onSubmit = async ({ studentId, content }: ReviewFormValues) => {
+    const success = await addReview(studentId, content);
+    if (success) reset();
   };
 
   return (
@@ -52,7 +43,7 @@ export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
         </S.ReviewItem>
       ))}
 
-      <S.ReviewForm>
+      <S.ReviewForm onSubmit={handleSubmit(onSubmit)}>
         <SectionHeading>
           후기 작성 <S.FormNote>* 수정 및 삭제가 불가능하니, 신중히 작성해 주세요!</S.FormNote>
         </SectionHeading>
@@ -64,22 +55,19 @@ export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
         )}
         <OutlineInputField
           placeholder='학번 입력 (학번은 노출되지 않습니다.)'
-          value={studentId}
-          invalid={isStudentIdInvalid}
-          message={isStudentIdInvalid ? '학번을 입력해 주세요.' : undefined}
-          onChange={(e) => setStudentId(e.target.value)}
+          invalid={!!errors.studentId}
+          message={errors.studentId?.message}
+          {...register('studentId', { required: '학번을 입력해 주세요.' })}
         />
-
         <OutlineTextareaField
           placeholder='후기를 입력하세요'
           rows={4}
-          value={content}
-          invalid={isContentInvalid}
-          message={isContentInvalid ? '후기를 입력해 주세요.' : undefined}
-          onChange={(e) => setContent(e.target.value)}
+          invalid={!!errors.content}
+          message={errors.content?.message}
+          {...register('content', { required: '후기를 입력해 주세요.' })}
         />
         <S.ButtonWrapper>
-          <Button variant='outline' width='10rem' onClick={handleSubmit} disabled={isSubmitting}>
+          <Button variant='outline' width='10rem' type='submit' disabled={isSubmitting}>
             {isSubmitting ? '등록 중...' : '후기 등록'}
           </Button>
         </S.ButtonWrapper>

--- a/src/pages/user/ClubDetail/components/ClubReviewsSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubReviewsSection/index.tsx
@@ -4,7 +4,6 @@ import { Button } from '@/shared/components/Button';
 import { OutlineInputField } from '@/shared/components/Form/InputField/OutlineInputField';
 import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/OutlineTextareaField';
 import { SectionHeading } from '@/shared/components/SectionHeading';
-import { Text } from '@/shared/components/Text';
 import * as S from './index.styled';
 
 type ReviewFormValues = {
@@ -13,7 +12,7 @@ type ReviewFormValues = {
 };
 
 export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
-  const { reviews, apiError, addReview } = useClubReviews(clubId);
+  const { reviews, addReview } = useClubReviews(clubId);
   const {
     register,
     handleSubmit,
@@ -48,11 +47,6 @@ export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
           후기 작성 <S.FormNote>* 수정 및 삭제가 불가능하니, 신중히 작성해 주세요!</S.FormNote>
         </SectionHeading>
 
-        {apiError && (
-          <Text size='xs' color={'red'}>
-            {apiError}
-          </Text>
-        )}
         <OutlineInputField
           placeholder='학번 입력 (학번은 노출되지 않습니다.)'
           invalid={!!errors.studentId}

--- a/src/pages/user/ClubDetail/components/ClubReviewsSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubReviewsSection/index.tsx
@@ -3,27 +3,32 @@ import { useClubReviews } from '@/pages/user/ClubDetail/hooks/useClubReviews';
 import { Button } from '@/shared/components/Button';
 import { OutlineInputField } from '@/shared/components/Form/InputField/OutlineInputField';
 import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/OutlineTextareaField';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { SectionHeading } from '@/shared/components/SectionHeading';
 import { Text } from '@/shared/components/Text';
 import * as S from './index.styled';
 
 export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
-  const { reviews, loading, error, addReview } = useClubReviews(clubId);
+  const { reviews, apiError, addReview } = useClubReviews(clubId);
   const [studentId, setStudentId] = useState('');
   const [content, setContent] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const isStudentIdInvalid = submitted && !studentId.trim();
+  const isContentInvalid = submitted && !content.trim();
 
   const handleSubmit = async () => {
     if (isSubmitting) return;
-    setIsSubmitting(true);
+    setSubmitted(true);
+    if (!studentId.trim() || !content.trim()) return;
 
+    setIsSubmitting(true);
     try {
       const success = await addReview(studentId, content);
-
       if (success) {
         setContent('');
         setStudentId('');
+        setSubmitted(false);
       }
     } finally {
       setIsSubmitting(false);
@@ -34,8 +39,6 @@ export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
     <S.ReviewsContainer>
       <S.Divider />
       <SectionHeading>동아리 후기</SectionHeading>
-
-      {loading && <LoadingSpinner />}
 
       {reviews.map((review) => (
         <S.ReviewItem key={review.id}>
@@ -54,14 +57,16 @@ export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
           후기 작성 <S.FormNote>* 수정 및 삭제가 불가능하니, 신중히 작성해 주세요!</S.FormNote>
         </SectionHeading>
 
-        {error && (
+        {apiError && (
           <Text size='xs' color={'red'}>
-            {error}
+            {apiError}
           </Text>
         )}
         <OutlineInputField
           placeholder='학번 입력 (학번은 노출되지 않습니다.)'
           value={studentId}
+          invalid={isStudentIdInvalid}
+          message={isStudentIdInvalid ? '학번을 입력해 주세요.' : undefined}
           onChange={(e) => setStudentId(e.target.value)}
         />
 
@@ -69,6 +74,8 @@ export const ClubReviewsSection = ({ clubId }: { clubId: number }) => {
           placeholder='후기를 입력하세요'
           rows={4}
           value={content}
+          invalid={isContentInvalid}
+          message={isContentInvalid ? '후기를 입력해 주세요.' : undefined}
           onChange={(e) => setContent(e.target.value)}
         />
         <S.ButtonWrapper>

--- a/src/pages/user/ClubDetail/hooks/useClubDetail.ts
+++ b/src/pages/user/ClubDetail/hooks/useClubDetail.ts
@@ -2,10 +2,10 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { fetchClubDetail } from '../api/clubDetail';
 
 export const useClubDetail = (clubId: number) => {
-  const { data } = useSuspenseQuery({
+  const { data: club } = useSuspenseQuery({
     queryKey: ['clubDetail', clubId],
     queryFn: () => fetchClubDetail(clubId),
   });
 
-  return data;
+  return club;
 };

--- a/src/pages/user/ClubDetail/hooks/useClubDetail.ts
+++ b/src/pages/user/ClubDetail/hooks/useClubDetail.ts
@@ -1,0 +1,11 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { fetchClubDetail } from '../api/clubDetail';
+
+export const useClubDetail = (clubId: number) => {
+  const { data } = useSuspenseQuery({
+    queryKey: ['clubDetail', clubId],
+    queryFn: () => fetchClubDetail(clubId),
+  });
+
+  return data;
+};

--- a/src/pages/user/ClubDetail/hooks/useClubReviews.ts
+++ b/src/pages/user/ClubDetail/hooks/useClubReviews.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { toast } from '@/shared/utils/toast';
 import { fetchClubReviews, postClubReview } from '../api/clubReviews';
 
 export const useClubReviews = (clubId: number) => {
@@ -9,10 +10,13 @@ export const useClubReviews = (clubId: number) => {
     queryFn: () => fetchClubReviews(clubId),
   });
 
-  const { mutateAsync, error: mutationError } = useMutation({
+  const { mutateAsync } = useMutation({
     mutationFn: (body: { studentId: string; content: string }) => postClubReview(clubId, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['clubReviews', clubId] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message);
     },
   });
 
@@ -25,9 +29,5 @@ export const useClubReviews = (clubId: number) => {
     }
   };
 
-  return {
-    reviews,
-    addReview,
-    apiError: mutationError?.message ?? null,
-  };
+  return { reviews, addReview };
 };

--- a/src/pages/user/ClubDetail/hooks/useClubReviews.ts
+++ b/src/pages/user/ClubDetail/hooks/useClubReviews.ts
@@ -1,54 +1,33 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { fetchClubReviews, postClubReview } from '../api/clubReviews';
-import type { ClubReview } from '@/pages/user/ClubDetail/types/review';
 
 export const useClubReviews = (clubId: number) => {
-  const [reviews, setReviews] = useState<ClubReview[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
-  const loadReviews = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-      const data = await fetchClubReviews(clubId);
-      setReviews(data);
-    } catch {
-      setError('후기를 불러오지 못했습니다.');
-    } finally {
-      setLoading(false);
-    }
-  }, [clubId]);
+  const { data: reviews } = useSuspenseQuery({
+    queryKey: ['clubReviews', clubId],
+    queryFn: () => fetchClubReviews(clubId),
+  });
 
-  const addReview = useCallback(
-    async (studentId: string, content: string) => {
-      if (!studentId.trim() || !content.trim()) {
-        setError('학번과 내용을 입력해 주세요.');
-        return false;
-      }
-
-      try {
-        setError(null);
-        const newReview = await postClubReview(clubId, { studentId, content });
-        setReviews((prev) => [newReview, ...prev]);
-        return true;
-      } catch {
-        setError('학번이 일치하지 않습니다.');
-        return false;
-      }
+  const { mutateAsync, error: mutationError } = useMutation({
+    mutationFn: (body: { studentId: string; content: string }) => postClubReview(clubId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['clubReviews', clubId] });
     },
-    [clubId],
-  );
+  });
 
-  useEffect(() => {
-    loadReviews();
-  }, [loadReviews]);
+  const addReview = async (studentId: string, content: string): Promise<boolean> => {
+    try {
+      await mutateAsync({ studentId, content });
+      return true;
+    } catch {
+      return false;
+    }
+  };
 
   return {
     reviews,
-    loading,
-    error,
     addReview,
-    reload: loadReviews,
+    apiError: mutationError?.message ?? null,
   };
 };

--- a/src/pages/user/Main/Page.tsx
+++ b/src/pages/user/Main/Page.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
-import { useCallback, useState } from 'react';
+import { Suspense, useCallback, useState } from 'react';
 import { BannerSection } from '@/pages/user/Main/components/BannerSection';
 import { ClubListSection } from '@/pages/user/Main/components/ClubListSection';
 import { FiltersSection } from '@/pages/user/Main/components/FiltersSection';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import type { RecruitStatus } from './types/club';
 import type { ClubCategoryEng } from '@/shared/types/club';
 
@@ -28,11 +29,13 @@ export const MainPage = () => {
         onSelectCategory={handleCategoryFilter}
         onSelectStatus={handleRecruitStatusFilter}
       />
-      <ClubListSection
-        categoryFilter={categoryFilter}
-        searchText={searchText}
-        recruitStatus={recruitStatus}
-      />
+      <Suspense fallback={<LoadingSpinner />}>
+        <ClubListSection
+          categoryFilter={categoryFilter}
+          searchText={searchText}
+          recruitStatus={recruitStatus}
+        />
+      </Suspense>
     </Container>
   );
 };

--- a/src/pages/user/Main/components/ClubListSection/index.tsx
+++ b/src/pages/user/Main/components/ClubListSection/index.tsx
@@ -1,7 +1,6 @@
 import { BsFillPatchCheckFill } from 'react-icons/bs';
 import { useNavigate } from 'react-router-dom';
 import { useClubFiltering } from '@/pages/user/Main/hooks/useClubFiltering.ts';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner.tsx';
 import { engToKorCategory } from '@/shared/utils/formatting.ts';
 import * as S from './Club.styled.ts';
 import NoSearchResult from './NoSearchResult.tsx';
@@ -22,15 +21,7 @@ export const ClubListSection = ({
   const navigate = useNavigate();
 
   const filterStatus = recruitStatus === '전체' ? undefined : recruitStatus;
-
-  const {
-    data: filteredClubs,
-    isLoading,
-    error,
-  } = useClubFiltering(categoryFilter, searchText, filterStatus);
-
-  if (isLoading) return <LoadingSpinner />;
-  if (error) return <div>{error.message}</div>;
+  const filteredClubs = useClubFiltering(categoryFilter, searchText, filterStatus);
 
   const isDefaultSort = !searchText && categoryFilter === 'ALL' && !filterStatus;
   const sortedClubs = isDefaultSort

--- a/src/pages/user/Main/hooks/useClubFiltering.ts
+++ b/src/pages/user/Main/hooks/useClubFiltering.ts
@@ -1,16 +1,15 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { type ClubResponse, getClubsByCategory } from '@/pages/user/Main/api/club.ts';
 import { searchClubs } from '../utils/searchClubs';
 import type { Club, RecruitStatus } from '@/pages/user/Main/types/club';
 import type { ClubCategoryEng } from '@/shared/types/club';
-import type { UseApiQueryResult } from '@/shared/types/useApiQueryResult';
 
 export const useClubFiltering = (
   filter: ClubCategoryEng,
   searchText: string,
   recruitStatus: RecruitStatus | undefined,
-): UseApiQueryResult<Club[]> => {
-  const { data, isLoading, error } = useQuery<ClubResponse>({
+): Club[] => {
+  const { data } = useSuspenseQuery<ClubResponse>({
     queryKey: ['clubData', filter],
     queryFn: () => getClubsByCategory(filter),
   });
@@ -22,9 +21,5 @@ export const useClubFiltering = (
     filteredClubs = filteredClubs.filter((club) => club.recruitStatus === recruitStatus);
   }
 
-  return {
-    data: filteredClubs,
-    isLoading,
-    error,
-  };
+  return filteredClubs;
 };

--- a/src/pages/user/Notice/DetailPage.tsx
+++ b/src/pages/user/Notice/DetailPage.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
+import { Suspense } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { NoticeDetailCardSection } from './components/NoticeDetailCardSection';
 
 export const NoticeDetailPage = () => {
@@ -18,7 +20,9 @@ export const NoticeDetailPage = () => {
 
   return (
     <Wrapper>
-      <NoticeDetailCardSection noticeId={noticeId} onBack={() => navigate(-1)} />
+      <Suspense fallback={<LoadingSpinner />}>
+        <NoticeDetailCardSection noticeId={noticeId} onBack={() => navigate(-1)} />
+      </Suspense>
     </Wrapper>
   );
 };

--- a/src/pages/user/Notice/Page.tsx
+++ b/src/pages/user/Notice/Page.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
+import { Suspense } from 'react';
 import { CONTACT_EMAIL } from '@/app/constants/email';
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { Text } from '@/shared/components/Text';
 import { NoticeListCardSection } from './components/NoticeListCardSection';
 
@@ -9,7 +11,9 @@ export const NoticeListPage = () => {
       <Text size='xl' weight='bold' color='#000000'>
         공지사항
       </Text>
-      <NoticeListCardSection />
+      <Suspense fallback={<LoadingSpinner />}>
+        <NoticeListCardSection />
+      </Suspense>
       <ContactInfo>개발진과 연락하기 : {CONTACT_EMAIL}</ContactInfo>
     </Wrapper>
   );

--- a/src/pages/user/Notice/api/notices.ts
+++ b/src/pages/user/Notice/api/notices.ts
@@ -1,27 +1,23 @@
 import { apiInstance } from '@/app/api/initInstance';
+import { handleAxiosError } from '@/shared/utils/handleAxiosError';
 import type { Notice, NoticeDetail } from '@/pages/user/Notice/types/notice';
-
-const handleAxiosError = (error: unknown, defaultMessage: string): never => {
-  if (error && typeof error === 'object' && 'response' in error) {
-    const axiosError = error as { response?: { data?: { message?: string } } };
-    const message = axiosError.response?.data?.message || defaultMessage;
-    throw new Error(message);
-  }
-  throw new Error('알 수 없는 오류가 발생했습니다.');
-};
 
 export const fetchNotices = async (
   page: number,
 ): Promise<{ content: Notice[]; pageInfo: { totalPages: number } }> => {
-  return apiInstance
-    .get(`/notices?page=${page}`)
-    .then((res) => res.data)
-    .catch((error) => handleAxiosError(error, '공지사항을 불러오는데 실패했습니다.'));
+  try {
+    const response = await apiInstance.get(`/notices?page=${page}`);
+    return response.data;
+  } catch (error: unknown) {
+    return handleAxiosError(error, '공지사항을 불러오는데 실패했습니다.');
+  }
 };
 
 export const fetchNoticeDetail = async (noticeId: number): Promise<NoticeDetail> => {
-  return apiInstance
-    .get(`/notices/${noticeId}`)
-    .then((res) => res.data)
-    .catch((error) => handleAxiosError(error, '공지사항 상세 정보를 불러오는데 실패했습니다.'));
+  try {
+    const response = await apiInstance.get(`/notices/${noticeId}`);
+    return response.data;
+  } catch (error: unknown) {
+    return handleAxiosError(error, '공지사항 상세 정보를 불러오는데 실패했습니다.');
+  }
 };

--- a/src/pages/user/Notice/components/NoticeDetailCardSection/index.tsx
+++ b/src/pages/user/Notice/components/NoticeDetailCardSection/index.tsx
@@ -1,8 +1,5 @@
-import { useEffect, useState } from 'react';
-import { fetchNoticeDetail } from '@/pages/user/Notice/api/notices';
-import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { useNoticeDetail } from '@/pages/user/Notice/hooks/useNoticeDetail';
 import * as S from './index.styled';
-import type { NoticeDetail } from '@/pages/user/Notice/types/notice';
 
 type NoticeDetailCardSectionProps = {
   noticeId: number;
@@ -10,35 +7,7 @@ type NoticeDetailCardSectionProps = {
 };
 
 export const NoticeDetailCardSection = ({ noticeId, onBack }: NoticeDetailCardSectionProps) => {
-  const [data, setData] = useState<NoticeDetail | null>(null);
-  const [error, setError] = useState(false);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const res = await fetchNoticeDetail(noticeId);
-        setData(res);
-      } catch (err) {
-        console.error('Failed to fetch notice detail:', err);
-        setError(true);
-      }
-    };
-    fetchData();
-  }, [noticeId]);
-
-  if (error)
-    return (
-      <S.Container>
-        <S.ErrorBox>
-          공지사항 정보를 불러올 수 없습니다.
-          <br />
-          잠시 후 다시 시도해주세요.
-        </S.ErrorBox>
-        <S.Button onClick={onBack}>목록</S.Button>
-      </S.Container>
-    );
-
-  if (!data) return <LoadingSpinner />;
+  const data = useNoticeDetail(noticeId);
 
   return (
     <S.Container>

--- a/src/pages/user/Notice/components/NoticeListCardSection/index.tsx
+++ b/src/pages/user/Notice/components/NoticeListCardSection/index.tsx
@@ -1,25 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ROUTE_PATH } from '@/app/constants/routerPath';
-import { fetchNotices } from '@/pages/user/Notice/api/notices';
+import { useNotices } from '@/pages/user/Notice/hooks/useNotices';
 import * as S from './index.styled';
-import type { Notice } from '@/pages/user/Notice/types/notice';
 
 export const NoticeListCardSection = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [notices, setNotices] = useState<Notice[]>([]);
-  const [totalPages, setTotalPages] = useState(1);
   const [currentPage, setCurrentPage] = useState(Number(searchParams.get('page')) || 1);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      const res = await fetchNotices(currentPage);
-      setNotices(res.content);
-      setTotalPages(res.pageInfo.totalPages);
-    };
-    fetchData();
-  }, [currentPage]);
+  const { content: notices, pageInfo } = useNotices(currentPage);
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -48,7 +38,7 @@ export const NoticeListCardSection = () => {
       </S.Container>
 
       <S.PaginationWrapper>
-        {Array.from({ length: totalPages }, (_, i) => (
+        {Array.from({ length: pageInfo.totalPages }, (_, i) => (
           <S.PageButton
             key={i}
             onClick={() => handlePageChange(i + 1)}

--- a/src/pages/user/Notice/hooks/useNoticeDetail.ts
+++ b/src/pages/user/Notice/hooks/useNoticeDetail.ts
@@ -1,0 +1,11 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { fetchNoticeDetail } from '../api/notices';
+
+export const useNoticeDetail = (noticeId: number) => {
+  const { data } = useSuspenseQuery({
+    queryKey: ['noticeDetail', noticeId],
+    queryFn: () => fetchNoticeDetail(noticeId),
+  });
+
+  return data;
+};

--- a/src/pages/user/Notice/hooks/useNotices.ts
+++ b/src/pages/user/Notice/hooks/useNotices.ts
@@ -1,0 +1,11 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { fetchNotices } from '../api/notices';
+
+export const useNotices = (page: number) => {
+  const { data } = useSuspenseQuery({
+    queryKey: ['notices', page],
+    queryFn: () => fetchNotices(page),
+  });
+
+  return data;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #313 

## 📝작업 내용

> `useQuery` + 수동 로딩/에러 상태 관리 패턴을 `useSuspenseQuery` + React Suspense 패턴으로 리팩토링했습니다.

### 변경 이유
기존 코드는 각 컴포넌트마다 아래 패턴이 반복되었습니다.
- `if (isLoading) return <LoadingSpinner />`
- `if (error) return <div>에러발생: {error.message}</div>`
- `if (!data) return null`

이를 Suspense로 통합해 관심사를 분리하고 코드량을 줄였습니다.

### 공통 패턴
- `useQuery` → `useSuspenseQuery`로 교체
- 각 훅에서 `isLoading`, `error` 반환 제거
- 컴포넌트에서 loading/error 조건부 렌더링 제거
- `useEffect` + `reset(data)` 제거 → `defaultValues: data`로 직접 전달 (react-hook-form)
- `enabled: !!id` 옵션 제거 (Suspense가 렌더링 자체를 막아줌)
- `UseApiQueryResult` 등 불필요해진 타입 제거
### 변경된 페이지 및 훅

| 페이지 | 훅 |
|---|---|
| user/Main | useClubFiltering |
| user/ClubDetail | useClubDetail, useClubReviews |
| user/Apply | useApplicationForm, useApplicationSubmit |
| user/Notice | useNotices, useNoticeDetail |
| admin/Dashboard | useDashboardSummary, useApplicants |
| admin/ApplicationDetail | useDetailApplications, useComments |
| admin/ApplicationFormBuilder | useApplicationForm |
| admin/ClubDetailEdit | useClubDetailEdit |
| admin/MemberManagement | useMembers |

### Suspense 경계 배치 전략
- **Routes 레벨**: 페이지 전체를 로딩하는 경우
- **컴포넌트 레벨**: 페이지 일부만 독립적으로 로딩하는 경우
  - ex) ClubDetailPage: 클럽 기본 정보 표시 후 리뷰 섹션을 별도 로딩
  - ex) ApplicationDetailPage: 지원서 정보 표시 후 댓글 섹션을 별도 로딩

## 💬리뷰 요구사항(선택)

> 이후 API 호출 시 Suspense를 사용해 주세요!