### PR TITLE
[FEAT] 모바일 지원하기 버튼 하단 고정 및 핵심 정보 상단 재배치 (#472)

### DIFF
--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -35,6 +35,8 @@ export const ClubDetailPage = () => {
             category={
               club.category in engToKorCategory ? (club.category as ClubCategoryEng) : 'ALL'
             }
+            instagramUrl={club.instagramUrl}
+            clubId={club.clubId}
           />
           <NarrowOnly>
             <ClubInfoSidebarSection
@@ -51,7 +53,6 @@ export const ClubDetailPage = () => {
               isRegistered={club.isRegistered}
               everyTimeUrl={club.everyTimeUrl}
               googleFormUrl={club.googleFormUrl}
-              instagramUrl={club.instagramUrl}
             />
           </NarrowOnly>
           {club.introductionImages.length > 0 && (

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -101,6 +101,6 @@ const FixedBottomBar = styled.div(({ theme }) => ({
     right: 0,
     padding: '0.75rem 1.3rem',
     zIndex: 100,
-    animation: `${slideUp} 1s cubic-bezier(0.16, 1, 0.3, 1) 0.8s both`,
+    animation: `${slideUp} 1s cubic-bezier(0.16, 1, 0.3, 1) 0.2s both`,
   },
 }));

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -43,7 +43,9 @@ export const ClubDetailPage = () => {
               introductionActivity={club.introductionActivity}
               introductionIdeal={club.introductionIdeal}
             />
-            <ClubReviewsSection clubId={club.clubId} />
+            <Suspense fallback={<LoadingSpinner />}>
+              <ClubReviewsSection clubId={club.clubId} />
+            </Suspense>
           </>
         }
         right={<ClubInfoSidebarSection {...club} />}

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -42,22 +42,7 @@ export const ClubDetailPage = () => {
               clubId={club.clubId}
             />
             <NarrowOnly>
-              <ClubInfoSidebarSection
-                clubName={club.clubName}
-                presidentName={club.presidentName}
-                presidentPhoneNumber={club.presidentPhoneNumber}
-                location={club.location}
-                recruitStart={club.recruitStart}
-                recruitEnd={club.recruitEnd}
-                regularMeetingInfo={club.regularMeetingInfo}
-                recruitStatus={club.recruitStatus}
-                applicationNotice={club.applicationNotice}
-                clubId={club.clubId}
-                isRegistered={club.isRegistered}
-                everyTimeUrl={club.everyTimeUrl}
-                googleFormUrl={club.googleFormUrl}
-                showApplyButton={false}
-              />
+              <ClubInfoSidebarSection {...club} instagramUrl={undefined} showApplyButton={false} />
             </NarrowOnly>
             {club.introductionImages.length > 0 && (
               <ClubActivityPhotosSection images={club.introductionImages} />
@@ -70,24 +55,7 @@ export const ClubDetailPage = () => {
             <ClubReviewsSection clubId={club.clubId} />
           </>
         }
-        right={
-          <ClubInfoSidebarSection
-            clubName={club.clubName}
-            presidentName={club.presidentName}
-            presidentPhoneNumber={club.presidentPhoneNumber}
-            location={club.location}
-            recruitStart={club.recruitStart}
-            recruitEnd={club.recruitEnd}
-            regularMeetingInfo={club.regularMeetingInfo}
-            recruitStatus={club.recruitStatus}
-            applicationNotice={club.applicationNotice}
-            clubId={club.clubId}
-            isRegistered={club.isRegistered}
-            everyTimeUrl={club.everyTimeUrl}
-            googleFormUrl={club.googleFormUrl}
-            instagramUrl={club.instagramUrl}
-          />
-        }
+        right={<ClubInfoSidebarSection {...club} />}
       />
       <FixedBottomBar>
         <ApplyButton

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { TwoColumnLayout } from '@/shared/components/Layout/TwoColumnLayout';
@@ -35,6 +36,24 @@ export const ClubDetailPage = () => {
               club.category in engToKorCategory ? (club.category as ClubCategoryEng) : 'ALL'
             }
           />
+          <NarrowOnly>
+            <ClubInfoSidebarSection
+              clubName={club.clubName}
+              presidentName={club.presidentName}
+              presidentPhoneNumber={club.presidentPhoneNumber}
+              location={club.location}
+              recruitStart={club.recruitStart}
+              recruitEnd={club.recruitEnd}
+              regularMeetingInfo={club.regularMeetingInfo}
+              recruitStatus={club.recruitStatus}
+              applicationNotice={club.applicationNotice}
+              clubId={club.clubId}
+              isRegistered={club.isRegistered}
+              everyTimeUrl={club.everyTimeUrl}
+              googleFormUrl={club.googleFormUrl}
+              instagramUrl={club.instagramUrl}
+            />
+          </NarrowOnly>
           {club.introductionImages.length > 0 && (
             <ClubActivityPhotosSection images={club.introductionImages} />
           )}
@@ -67,3 +86,10 @@ export const ClubDetailPage = () => {
     />
   );
 };
+
+const NarrowOnly = styled.div(({ theme }) => ({
+  display: 'none',
+  [`@media (max-width: ${theme.breakpoints.web})`]: {
+    display: 'block',
+  },
+}));

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -1,3 +1,4 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -111,6 +112,17 @@ const NarrowOnly = styled.div(({ theme }) => ({
   },
 }));
 
+const slideUp = keyframes`
+  from {
+    transform: translateY(1.5rem);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+`;
+
 const FixedBottomBar = styled.div(({ theme }) => ({
   display: 'none',
   [`@media (max-width: ${theme.breakpoints.web})`]: {
@@ -121,5 +133,6 @@ const FixedBottomBar = styled.div(({ theme }) => ({
     right: 0,
     padding: '0.75rem 1.3rem',
     zIndex: 100,
+    animation: `${slideUp} 1s cubic-bezier(0.16, 1, 0.3, 1) 0.8s both`,
   },
 }));

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -9,6 +9,7 @@ import { fetchClubDetail } from './api/clubDetail';
 import { ClubActivityPhotosSection } from './components/ClubActivityPhotosSection';
 import { ClubDescriptionSection } from './components/ClubDescriptionSection';
 import { ClubInfoSidebarSection } from './components/ClubInfoSidebarSection';
+import ApplyButton from './components/ClubInfoSidebarSection/ApplyButton';
 import { ClubReviewsSection } from './components/ClubReviewsSection';
 
 import type { ClubDetail } from './types/clubDetail';
@@ -27,64 +28,79 @@ export const ClubDetailPage = () => {
   if (!club) return <LoadingSpinner />;
 
   return (
-    <TwoColumnLayout
-      left={
-        <>
-          <PageHeader
-            clubName={club.clubName}
-            category={
-              club.category in engToKorCategory ? (club.category as ClubCategoryEng) : 'ALL'
-            }
-            instagramUrl={club.instagramUrl}
-            clubId={club.clubId}
-          />
-          <NarrowOnly>
-            <ClubInfoSidebarSection
+    <>
+      <TwoColumnLayout
+        left={
+          <>
+            <PageHeader
               clubName={club.clubName}
-              presidentName={club.presidentName}
-              presidentPhoneNumber={club.presidentPhoneNumber}
-              location={club.location}
-              recruitStart={club.recruitStart}
-              recruitEnd={club.recruitEnd}
-              regularMeetingInfo={club.regularMeetingInfo}
-              recruitStatus={club.recruitStatus}
-              applicationNotice={club.applicationNotice}
+              category={
+                club.category in engToKorCategory ? (club.category as ClubCategoryEng) : 'ALL'
+              }
+              instagramUrl={club.instagramUrl}
               clubId={club.clubId}
-              isRegistered={club.isRegistered}
-              everyTimeUrl={club.everyTimeUrl}
-              googleFormUrl={club.googleFormUrl}
             />
-          </NarrowOnly>
-          {club.introductionImages.length > 0 && (
-            <ClubActivityPhotosSection images={club.introductionImages} />
-          )}
-          <ClubDescriptionSection
-            introductionOverview={club.introductionOverview}
-            introductionActivity={club.introductionActivity}
-            introductionIdeal={club.introductionIdeal}
+            <NarrowOnly>
+              <ClubInfoSidebarSection
+                clubName={club.clubName}
+                presidentName={club.presidentName}
+                presidentPhoneNumber={club.presidentPhoneNumber}
+                location={club.location}
+                recruitStart={club.recruitStart}
+                recruitEnd={club.recruitEnd}
+                regularMeetingInfo={club.regularMeetingInfo}
+                recruitStatus={club.recruitStatus}
+                applicationNotice={club.applicationNotice}
+                clubId={club.clubId}
+                isRegistered={club.isRegistered}
+                everyTimeUrl={club.everyTimeUrl}
+                googleFormUrl={club.googleFormUrl}
+                showApplyButton={false}
+              />
+            </NarrowOnly>
+            {club.introductionImages.length > 0 && (
+              <ClubActivityPhotosSection images={club.introductionImages} />
+            )}
+            <ClubDescriptionSection
+              introductionOverview={club.introductionOverview}
+              introductionActivity={club.introductionActivity}
+              introductionIdeal={club.introductionIdeal}
+            />
+            <ClubReviewsSection clubId={club.clubId} />
+          </>
+        }
+        right={
+          <ClubInfoSidebarSection
+            clubName={club.clubName}
+            presidentName={club.presidentName}
+            presidentPhoneNumber={club.presidentPhoneNumber}
+            location={club.location}
+            recruitStart={club.recruitStart}
+            recruitEnd={club.recruitEnd}
+            regularMeetingInfo={club.regularMeetingInfo}
+            recruitStatus={club.recruitStatus}
+            applicationNotice={club.applicationNotice}
+            clubId={club.clubId}
+            isRegistered={club.isRegistered}
+            everyTimeUrl={club.everyTimeUrl}
+            googleFormUrl={club.googleFormUrl}
+            instagramUrl={club.instagramUrl}
           />
-          <ClubReviewsSection clubId={club.clubId} />
-        </>
-      }
-      right={
-        <ClubInfoSidebarSection
-          clubName={club.clubName}
-          presidentName={club.presidentName}
-          presidentPhoneNumber={club.presidentPhoneNumber}
-          location={club.location}
-          recruitStart={club.recruitStart}
-          recruitEnd={club.recruitEnd}
-          regularMeetingInfo={club.regularMeetingInfo}
-          recruitStatus={club.recruitStatus}
-          applicationNotice={club.applicationNotice}
+        }
+      />
+      <FixedBottomBar>
+        <ApplyButton
           clubId={club.clubId}
+          clubName={club.clubName}
+          recruitStatus={club.recruitStatus}
+          to={`/clubs/${club.clubId}/apply`}
+          width='100%'
           isRegistered={club.isRegistered}
           everyTimeUrl={club.everyTimeUrl}
           googleFormUrl={club.googleFormUrl}
-          instagramUrl={club.instagramUrl}
         />
-      }
-    />
+      </FixedBottomBar>
+    </>
   );
 };
 
@@ -92,5 +108,18 @@ const NarrowOnly = styled.div(({ theme }) => ({
   display: 'none',
   [`@media (max-width: ${theme.breakpoints.web})`]: {
     display: 'block',
+  },
+}));
+
+const FixedBottomBar = styled.div(({ theme }) => ({
+  display: 'none',
+  [`@media (max-width: ${theme.breakpoints.web})`]: {
+    display: 'block',
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    padding: '0.75rem 1.3rem',
+    zIndex: 100,
   },
 }));

--- a/src/pages/user/ClubDetail/components/ClubDescriptionSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubDescriptionSection/index.tsx
@@ -42,4 +42,5 @@ const DescriptionText = styled.p(({ theme }) => ({
   paddingBottom: '1.5rem',
   color: theme.colors.textPrimary,
   margin: 0,
+  overflowWrap: 'break-word',
 }));

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ClubInfoRow.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ClubInfoRow.tsx
@@ -38,6 +38,7 @@ const LabelCell = styled.span({
 
 const ValueCell = styled.span({
   flex: 1,
+  lineHeight: '1.2rem',
 });
 
 const Icon = styled.span(({ theme }) => ({

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ClubInfoRow.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ClubInfoRow.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react';
+import styled from '@emotion/styled';
+import { Text } from '@/shared/components/Text';
+
+type Props = {
+  icon: ReactNode;
+  label: string;
+  value: ReactNode;
+};
+
+export const ClubInfoRow = ({ icon, label, value }: Props) => {
+  return (
+    <Row>
+      <Icon>{icon}</Icon>
+      <Text size='sm' color='#757575'>
+        {label}
+      </Text>
+      {value}
+    </Row>
+  );
+};
+
+const Row = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.4rem',
+  fontSize: theme.font.size.sm,
+  color: theme.colors.textPrimary,
+}));
+
+const Icon = styled.span(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  color: theme.colors.textSecondary,
+  flexShrink: 0,
+  fontSize: '1.2rem',
+}));

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ClubInfoRow.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/ClubInfoRow.tsx
@@ -12,10 +12,12 @@ export const ClubInfoRow = ({ icon, label, value }: Props) => {
   return (
     <Row>
       <Icon>{icon}</Icon>
-      <Text size='sm' color='#757575'>
-        {label}
-      </Text>
-      {value}
+      <LabelCell>
+        <Text size='sm' color='#757575'>
+          {label}
+        </Text>
+      </LabelCell>
+      <ValueCell>{value}</ValueCell>
     </Row>
   );
 };
@@ -27,6 +29,16 @@ const Row = styled.div(({ theme }) => ({
   fontSize: theme.font.size.sm,
   color: theme.colors.textPrimary,
 }));
+
+const LabelCell = styled.span({
+  width: '5rem',
+  flexShrink: 0,
+  whiteSpace: 'nowrap',
+});
+
+const ValueCell = styled.span({
+  flex: 1,
+});
 
 const Icon = styled.span(({ theme }) => ({
   display: 'flex',

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -22,7 +22,7 @@ type ClubInfoSidebarSectionProps = Pick<
   | 'isRegistered'
   | 'everyTimeUrl'
   | 'googleFormUrl'
-> & { instagramUrl?: string };
+> & { instagramUrl?: string; showApplyButton?: boolean };
 
 export const ClubInfoSidebarSection = ({
   clubId,
@@ -39,6 +39,7 @@ export const ClubInfoSidebarSection = ({
   everyTimeUrl,
   googleFormUrl,
   instagramUrl,
+  showApplyButton = true,
 }: ClubInfoSidebarSectionProps) => {
   return (
     <SidebarContainer>
@@ -67,16 +68,18 @@ export const ClubInfoSidebarSection = ({
           공식 인스타그램 보기
         </Button>
       )}
-      <ApplyButton
-        clubId={clubId}
-        clubName={clubName}
-        recruitStatus={recruitStatus}
-        to={`/clubs/${clubId}/apply`}
-        width={'auto'}
-        isRegistered={isRegistered}
-        everyTimeUrl={everyTimeUrl}
-        googleFormUrl={googleFormUrl}
-      />
+      {showApplyButton && (
+        <ApplyButton
+          clubId={clubId}
+          clubName={clubName}
+          recruitStatus={recruitStatus}
+          to={`/clubs/${clubId}/apply`}
+          width={'auto'}
+          isRegistered={isRegistered}
+          everyTimeUrl={everyTimeUrl}
+          googleFormUrl={googleFormUrl}
+        />
+      )}
       <Notice>{applicationNotice}</Notice>
     </SidebarContainer>
   );

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -2,9 +2,9 @@ import styled from '@emotion/styled';
 import { BiListUl } from 'react-icons/bi';
 import { PiCalendarDotsDuotone } from 'react-icons/pi';
 import { Button } from '@/shared/components/Button';
-import { Text } from '@/shared/components/Text';
 import { formatDate } from '@/shared/utils/dateUtils';
 import ApplyButton from './ApplyButton';
+import { ClubInfoRow } from './ClubInfoRow';
 import type { ClubDetail } from '@/pages/user/ClubDetail/types/clubDetail';
 
 type ClubInfoSidebarSectionProps = Pick<
@@ -43,62 +43,19 @@ export const ClubInfoSidebarSection = ({
 }: ClubInfoSidebarSectionProps) => {
   return (
     <SidebarContainer>
-      <InfoItem>
-        <InfoIcon>
-          <BiListUl />
-        </InfoIcon>
-        <Text size='sm' color='#757575'>
-          회장 이름
-        </Text>
-        {presidentName}
-      </InfoItem>
+      <ClubInfoRow icon={<BiListUl />} label='회장 이름' value={presidentName} />
       {!/^010-0000/.test(presidentPhoneNumber) && (
-        <InfoItem>
-          <InfoIcon>
-            <BiListUl />
-          </InfoIcon>
-          <Text size='sm' color='#757575'>
-            연락처
-          </Text>
-          {presidentPhoneNumber}
-        </InfoItem>
+        <ClubInfoRow icon={<BiListUl />} label='연락처' value={presidentPhoneNumber} />
       )}
-      <InfoItem>
-        <InfoIcon>
-          <BiListUl />
-        </InfoIcon>
-        <Text size='sm' color='#757575'>
-          동방 위치
-        </Text>
-        {location}
-      </InfoItem>
-      <InfoItem>
-        <InfoIcon>
-          <PiCalendarDotsDuotone />
-        </InfoIcon>
-        <Text size='sm' color='#757575'>
-          모집 기간
-        </Text>
-        {formatDate(recruitStart)} ~ {formatDate(recruitEnd)}
-      </InfoItem>
-      <InfoItem>
-        <InfoIcon>
-          <BiListUl />
-        </InfoIcon>
-        <Text size='sm' color='#757575'>
-          정기 모임
-        </Text>
-        {regularMeetingInfo}
-      </InfoItem>
-      <InfoItem>
-        <InfoIcon>
-          <BiListUl />
-        </InfoIcon>
-        <Text size='sm' color='#757575'>
-          모집 상태
-        </Text>
-        {recruitStatus}
-      </InfoItem>
+      <ClubInfoRow icon={<BiListUl />} label='동방 위치' value={location} />
+      <ClubInfoRow
+        icon={<PiCalendarDotsDuotone />}
+        label='모집 기간'
+        value={`${formatDate(recruitStart)} ~ ${formatDate(recruitEnd)}`}
+      />
+      {regularMeetingInfo !== '-' && (
+        <ClubInfoRow icon={<BiListUl />} label='정기 모임' value={regularMeetingInfo} />
+      )}
       {instagramUrl && (
         <Button
           variant='outline'
@@ -135,22 +92,6 @@ const SidebarContainer = styled.div(({ theme }) => ({
   flexDirection: 'column',
   gap: '1rem',
   border: '1px solid #E5E7ED',
-}));
-
-const InfoItem = styled.div(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '0.4rem',
-  fontSize: theme.font.size.sm,
-  color: theme.colors.textPrimary,
-}));
-
-const InfoIcon = styled.span(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  color: theme.colors.textSecondary,
-  flexShrink: 0,
-  fontSize: '1.2rem',
 }));
 
 const Notice = styled.div(({ theme }) => ({

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -106,6 +106,8 @@ const SidebarContainer = styled.div(({ theme }) => ({
 const Notice = styled.div(({ theme }) => ({
   fontSize: theme.font.size.xs,
   color: theme.colors.textSecondary,
+  lineHeight: '1rem',
+
   [`@media (max-width: ${theme.breakpoints.web})`]: {
     paddingBottom: '1.8rem',
     borderBottom: '0.5px solid #E5E7ED',

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -92,6 +92,13 @@ const SidebarContainer = styled.div(({ theme }) => ({
   flexDirection: 'column',
   gap: '1rem',
   border: '1px solid #E5E7ED',
+
+  [`@media (max-width: ${theme.breakpoints.web})`]: {
+    border: 'none',
+    marginTop: 0,
+    borderRadius: 0,
+    padding: '0 0.5rem',
+  },
 }));
 
 const Notice = styled.div(({ theme }) => ({

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -22,8 +22,7 @@ type ClubInfoSidebarSectionProps = Pick<
   | 'isRegistered'
   | 'everyTimeUrl'
   | 'googleFormUrl'
-  | 'instagramUrl'
->;
+> & { instagramUrl?: string };
 
 export const ClubInfoSidebarSection = ({
   clubId,

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -106,4 +106,8 @@ const SidebarContainer = styled.div(({ theme }) => ({
 const Notice = styled.div(({ theme }) => ({
   fontSize: theme.font.size.xs,
   color: theme.colors.textSecondary,
+  [`@media (max-width: ${theme.breakpoints.web})`]: {
+    paddingBottom: '1.8rem',
+    borderBottom: '0.5px solid #E5E7ED',
+  },
 }));

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -1,5 +1,8 @@
 import styled from '@emotion/styled';
+import { BiListUl } from 'react-icons/bi';
+import { PiCalendarDotsDuotone } from 'react-icons/pi';
 import { Button } from '@/shared/components/Button';
+import { Text } from '@/shared/components/Text';
 import { formatDate } from '@/shared/utils/dateUtils';
 import ApplyButton from './ApplyButton';
 import type { ClubDetail } from '@/pages/user/ClubDetail/types/clubDetail';
@@ -40,16 +43,62 @@ export const ClubInfoSidebarSection = ({
 }: ClubInfoSidebarSectionProps) => {
   return (
     <SidebarContainer>
-      <InfoItem>회장 이름: {presidentName}</InfoItem>
-      {!/^010-0000/.test(presidentPhoneNumber) && (
-        <InfoItem>연락처: {presidentPhoneNumber}</InfoItem>
-      )}
-      <InfoItem>동방 위치: {location}</InfoItem>
       <InfoItem>
-        모집 기간: {formatDate(recruitStart)} ~ {formatDate(recruitEnd)}
+        <InfoIcon>
+          <BiListUl />
+        </InfoIcon>
+        <Text size='sm' color='#757575'>
+          회장 이름
+        </Text>
+        {presidentName}
       </InfoItem>
-      <InfoItem>정기 모임: {regularMeetingInfo}</InfoItem>
-      <InfoItem>모집 상태: {recruitStatus}</InfoItem>
+      {!/^010-0000/.test(presidentPhoneNumber) && (
+        <InfoItem>
+          <InfoIcon>
+            <BiListUl />
+          </InfoIcon>
+          <Text size='sm' color='#757575'>
+            연락처
+          </Text>
+          {presidentPhoneNumber}
+        </InfoItem>
+      )}
+      <InfoItem>
+        <InfoIcon>
+          <BiListUl />
+        </InfoIcon>
+        <Text size='sm' color='#757575'>
+          동방 위치
+        </Text>
+        {location}
+      </InfoItem>
+      <InfoItem>
+        <InfoIcon>
+          <PiCalendarDotsDuotone />
+        </InfoIcon>
+        <Text size='sm' color='#757575'>
+          모집 기간
+        </Text>
+        {formatDate(recruitStart)} ~ {formatDate(recruitEnd)}
+      </InfoItem>
+      <InfoItem>
+        <InfoIcon>
+          <BiListUl />
+        </InfoIcon>
+        <Text size='sm' color='#757575'>
+          정기 모임
+        </Text>
+        {regularMeetingInfo}
+      </InfoItem>
+      <InfoItem>
+        <InfoIcon>
+          <BiListUl />
+        </InfoIcon>
+        <Text size='sm' color='#757575'>
+          모집 상태
+        </Text>
+        {recruitStatus}
+      </InfoItem>
       {instagramUrl && (
         <Button
           variant='outline'
@@ -89,8 +138,19 @@ const SidebarContainer = styled.div(({ theme }) => ({
 }));
 
 const InfoItem = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.4rem',
   fontSize: theme.font.size.sm,
   color: theme.colors.textPrimary,
+}));
+
+const InfoIcon = styled.span(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  color: theme.colors.textSecondary,
+  flexShrink: 0,
+  fontSize: '1.2rem',
 }));
 
 const Notice = styled.div(({ theme }) => ({

--- a/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
+++ b/src/pages/user/ClubDetail/components/ClubInfoSidebarSection/index.tsx
@@ -7,22 +7,7 @@ import ApplyButton from './ApplyButton';
 import { ClubInfoRow } from './ClubInfoRow';
 import type { ClubDetail } from '@/pages/user/ClubDetail/types/clubDetail';
 
-type ClubInfoSidebarSectionProps = Pick<
-  ClubDetail,
-  | 'clubId'
-  | 'clubName'
-  | 'presidentName'
-  | 'presidentPhoneNumber'
-  | 'location'
-  | 'recruitStart'
-  | 'recruitEnd'
-  | 'regularMeetingInfo'
-  | 'recruitStatus'
-  | 'applicationNotice'
-  | 'isRegistered'
-  | 'everyTimeUrl'
-  | 'googleFormUrl'
-> & { instagramUrl?: string; showApplyButton?: boolean };
+type ClubInfoSidebarSectionProps = ClubDetail & { showApplyButton?: boolean };
 
 export const ClubInfoSidebarSection = ({
   clubId,

--- a/src/pages/user/ClubDetail/types/clubDetail.ts
+++ b/src/pages/user/ClubDetail/types/clubDetail.ts
@@ -23,5 +23,5 @@ export type ClubDetail = {
   isRegistered: boolean;
   everyTimeUrl: string;
   googleFormUrl: string;
-  instagramUrl: string;
+  instagramUrl?: string;
 };

--- a/src/shared/components/Layout/TwoColumnLayout.tsx
+++ b/src/shared/components/Layout/TwoColumnLayout.tsx
@@ -69,13 +69,6 @@ const ContentRight = styled.div(({ theme }) => ({
   top: '3rem',
 
   [`@media (max-width: ${theme.breakpoints.web})`]: {
-    flex: '1 1 100%',
-    margin: '1.5rem auto 0 auto',
-  },
-  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
-    flex: 'initial',
-    maxWidth: '100%',
-    margin: '1rem 0 0 0',
-    padding: '1rem',
+    display: 'none',
   },
 }));

--- a/src/shared/components/PageHeader/index.styled.ts
+++ b/src/shared/components/PageHeader/index.styled.ts
@@ -3,6 +3,13 @@ import styled from '@emotion/styled';
 export const Container = styled.div({
   display: 'flex',
   flexDirection: 'column',
+  gap: '0.25rem',
+});
+
+export const TitleRow = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
   gap: '0.5rem',
 });
 
@@ -22,4 +29,21 @@ export const Category = styled.span(({ theme }) => ({
   fontSize: theme.font.size.base,
   color: theme.colors.textSecondary,
   margin: '0.5rem 0 0 0.5rem',
+}));
+
+export const InstagramLink = styled.a(({ theme }) => ({
+  display: 'none',
+  marginRight: '0.4rem',
+  [`@media (max-width: ${theme.breakpoints.web})`]: {
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: '2rem',
+    color: '#E1306C',
+    marginTop: '1rem',
+    flexShrink: 0,
+    transition: 'opacity 0.2s',
+    '&:hover': {
+      opacity: 0.8,
+    },
+  },
 }));

--- a/src/shared/components/PageHeader/index.tsx
+++ b/src/shared/components/PageHeader/index.tsx
@@ -1,3 +1,4 @@
+import { FaInstagram } from 'react-icons/fa';
 import { engToKorCategory } from '@/shared/utils/formatting';
 import * as S from './index.styled';
 import type { ClubCategoryEng } from '@/shared/types/club';
@@ -5,17 +6,31 @@ import type { ClubCategoryEng } from '@/shared/types/club';
 type Props = {
   clubName: string;
   category?: ClubCategoryEng;
+  instagramUrl?: string;
+  clubId?: number;
 };
 
-export const PageHeader = ({ clubName, category }: Props) => {
+export const PageHeader = ({ clubName, category, instagramUrl, clubId }: Props) => {
   const korCategory = category && engToKorCategory[category];
 
   return (
     <S.Container>
-      <S.TextWrapper>
+      <S.TitleRow>
         <S.Title>{clubName}</S.Title>
-        <S.Category>{korCategory}</S.Category>
-      </S.TextWrapper>
+        {instagramUrl && (
+          <S.InstagramLink
+            href={instagramUrl}
+            target='_blank'
+            rel='noopener noreferrer'
+            onClick={() => {
+              window.dataLayer?.push({ event: 'club_instagram_click', clubId, clubName });
+            }}
+          >
+            <FaInstagram />
+          </S.InstagramLink>
+        )}
+      </S.TitleRow>
+      <S.Category>{korCategory}</S.Category>
     </S.Container>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #472 

## 📝작업 내용
모바일 사용자가 전체의 90%를 차지하지만, 긴 페이지 구조로 인해 핵심 액션 버튼이 가려지는 문제가 확인되었습니다.

- 모바일 평균 참여 시간: 3분 (데스크탑 6분 대비 2배 빠른 이탈)
- 사용자의 약 42%만 버튼이 위치한 하단 90% 지점까지 도달

이를 해결하기 위해 핵심 정보를 상단으로 재배치하고 지원하기 버튼을 화면 하단에 상시 노출하였습니다.

### 핵심 정보 상단 재배치
- 모바일/태블릿 환경에서 모집 상태, 기간, 연락처 등 요약 정보를 활동 사진 위로 재배치
- 웹 브레이크포인트 이하에서 기존 우측 사이드바(TwoColumnLayout의 ContentRight)는 숨김 처리

### 지원하기 버튼 하단 고정
- 모바일/태블릿에서 position: fixed로 뷰포트 하단에 상시 노출
- 페이지 진입 시 슬라이드업 + 페이드인 애니메이션 적용 

### 인스타그램 버튼 개선
- 모바일/태블릿에서 사이드바 내 텍스트 버튼 → PageHeader 우측 아이콘(FaInstagram)으로 이동
- 데스크탑에서는 기존 사이드바 텍스트 버튼 유지

### 스크린샷 (선택)

<table>
  <tr>
    <th>변경 전</th>
    <th>변경 후</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/45574031-af21-4a1a-a363-604576b91b75"/></td>
    <td><img src= "https://github.com/user-attachments/assets/2bc031e4-e558-4aa2-91ec-f5a3dd238fdb"/></td>
  </tr>
</table>
