### PR TITLE
[FIX] 모바일 키보드 노출 시 지원하기 버튼 숨김 처리 (#475)

### DIFF
--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 import { TwoColumnLayout } from '@/shared/components/Layout/TwoColumnLayout';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { PageHeader } from '@/shared/components/PageHeader';
+import { useKeyboardVisible } from '@/shared/hooks/useKeyboardVisible';
 import { engToKorCategory } from '@/shared/utils/formatting';
 import { ClubActivityPhotosSection } from './components/ClubActivityPhotosSection';
 import { ClubDescriptionSection } from './components/ClubDescriptionSection';
@@ -18,6 +19,7 @@ import type { ClubCategoryEng } from '@/shared/types/club';
 export const ClubDetailPage = () => {
   const { clubId } = useParams<{ clubId: string }>();
   const club = useClubDetail(Number(clubId));
+  const isKeyboardVisible = useKeyboardVisible();
 
   return (
     <>
@@ -50,18 +52,20 @@ export const ClubDetailPage = () => {
         }
         right={<ClubInfoSidebarSection {...club} />}
       />
-      <FixedBottomBar>
-        <ApplyButton
-          clubId={club.clubId}
-          clubName={club.clubName}
-          recruitStatus={club.recruitStatus}
-          to={`/clubs/${club.clubId}/apply`}
-          width='100%'
-          isRegistered={club.isRegistered}
-          everyTimeUrl={club.everyTimeUrl}
-          googleFormUrl={club.googleFormUrl}
-        />
-      </FixedBottomBar>
+      {!isKeyboardVisible && (
+        <FixedBottomBar>
+          <ApplyButton
+            clubId={club.clubId}
+            clubName={club.clubName}
+            recruitStatus={club.recruitStatus}
+            to={`/clubs/${club.clubId}/apply`}
+            width='100%'
+            isRegistered={club.isRegistered}
+            everyTimeUrl={club.everyTimeUrl}
+            googleFormUrl={club.googleFormUrl}
+          />
+        </FixedBottomBar>
+      )}
     </>
   );
 };

--- a/src/shared/hooks/useKeyboardVisible.ts
+++ b/src/shared/hooks/useKeyboardVisible.ts
@@ -1,14 +1,15 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 export const useKeyboardVisible = () => {
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
+  const initialHeightRef = useRef(window.innerHeight);
 
   useEffect(() => {
     const viewport = window.visualViewport;
     if (!viewport) return;
 
     const handleResize = () => {
-      setIsKeyboardVisible(viewport.height < window.innerHeight * 0.75);
+      setIsKeyboardVisible(viewport.height < initialHeightRef.current * 0.75);
     };
 
     viewport.addEventListener('resize', handleResize);

--- a/src/shared/hooks/useKeyboardVisible.ts
+++ b/src/shared/hooks/useKeyboardVisible.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+export const useKeyboardVisible = () => {
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
+
+  useEffect(() => {
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+
+    const handleResize = () => {
+      setIsKeyboardVisible(viewport.height < window.innerHeight * 0.75);
+    };
+
+    viewport.addEventListener('resize', handleResize);
+    return () => viewport.removeEventListener('resize', handleResize);
+  }, []);
+
+  return isKeyboardVisible;
+};

--- a/src/shared/hooks/useKeyboardVisible.ts
+++ b/src/shared/hooks/useKeyboardVisible.ts
@@ -13,6 +13,7 @@ export const useKeyboardVisible = () => {
     };
 
     viewport.addEventListener('resize', handleResize);
+    handleResize();
     return () => viewport.removeEventListener('resize', handleResize);
   }, []);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #475 

## 📝작업 내용
모바일 환경에서 입력 폼 작성 시, 하단 고정 버튼이 키보드와 겹쳐 화면을 가리거나 사용자 입력을 방해하는 현상을 해결했습니다. visualViewport API를 활용하여 키보드 활성화 여부를 감지하고, 입력 중에는 버튼을 숨김을 적용했습니다.


### useKeyboardVisible 커스텀 훅 추가
- visualViewport API를 사용하여 뷰포트의 높이 변화를 실시간으로 감지
- 뷰포트 높이가 전체 창 높이의 75% 미만으로 줄어들 경우 키보드가 노출된 것으로 판단

- **판단 로직** : `visualViewport.height < window.innerHeight * 0.75`
> 일반적인 모바일 브라우저 하단 바 크기보다 더 큰 높이 변화가 생길 때만 키보드로 간주하여 오작동 방지했습니다.


### ClubDetailPage 내 조건부 렌더링 적용
- 상세 페이지 하단의 '지원하기' 버튼 섹션에 훅 연결
- 키보드가 활성화된 상태(isKeyboardVisible === true)일 때는 숨겨서 입력창의 가시성 확보


