### PR TITLE
[FEAT] 페이지별 가이드 다시보기 기능 추가 (#482)

### DIFF
--- a/src/pages/admin/ApplicationFormBuilder/Page.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/Page.tsx
@@ -17,9 +17,11 @@ import type { ApplicationFormData } from './types/fieldType';
 export const ApplicationFormBuilderPage = () => {
   const { clubId } = useParams();
   const [isEditMode, setIsEditMode] = useState(false);
-  const { isOpen: isFormPopupOpen, confirm: confirmFormPopup } = useOnboardingPopup('form', {
-    triggerMode: 'pageVisit',
-  });
+  const {
+    isOpen: isFormPopupOpen,
+    confirm: confirmFormPopup,
+    reopen: reopenFormPopup,
+  } = useOnboardingPopup('form', { triggerMode: 'pageVisit' });
   const { data } = useAdaptedApplicationForm(Number(clubId));
   const { adaptedPatchForm } = useAdaptedPatchApplicationForm(Number(clubId));
 
@@ -86,6 +88,7 @@ export const ApplicationFormBuilderPage = () => {
         imageAlt='지원폼 관리 가이드'
         onConfirm={confirmFormPopup}
       />
+
       <ContentContainer>
         <ApplicationFormBuilderHeaderSection
           isEditMode={isEditMode}
@@ -94,6 +97,7 @@ export const ApplicationFormBuilderPage = () => {
           onCancel={handleCancel}
           isInterviewMode={isInterviewMode}
           onInterviewChange={handleInterviewChange}
+          onOpenGuide={reopenFormPopup}
         />
         <ApplicationInfoSection formHandler={formHandler} isEditMode={isEditMode} />
 

--- a/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.styled.ts
@@ -45,6 +45,12 @@ export const CheckboxWrapper = styled.div(({ theme }) => ({
   },
 }));
 
+export const TitleWrapper = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+});
+
 export const CustomCheckbox = styled.input(({ theme }) => ({
   width: '1.15rem',
   height: '1.15rem',

--- a/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/shared/components/Button';
+import { GuideIconButton } from '@/shared/components/GuideIconButton';
 import { Text } from '@/shared/components/Text';
 import * as S from './index.styled';
 
@@ -9,6 +10,7 @@ type Props = {
   onCancel: () => void;
   isInterviewMode: boolean;
   onInterviewChange: (checked: boolean) => void;
+  onOpenGuide?: () => void;
 };
 
 export const ApplicationFormBuilderHeaderSection = ({
@@ -18,11 +20,15 @@ export const ApplicationFormBuilderHeaderSection = ({
   onCancel,
   isInterviewMode,
   onInterviewChange,
+  onOpenGuide,
 }: Props) => {
   return (
     <S.Container>
       <S.HeaderWrapper>
-        <S.Title>지원폼 생성</S.Title>
+        <S.TitleWrapper>
+          <S.Title>지원폼 생성</S.Title>
+          {onOpenGuide && <GuideIconButton onClick={onOpenGuide} />}
+        </S.TitleWrapper>
         {isEditMode ? (
           <S.ButtonWrapper>
             <Button variant='outline' width='4rem' onClick={onCancel}>

--- a/src/pages/admin/ClubDetailEdit/Page.tsx
+++ b/src/pages/admin/ClubDetailEdit/Page.tsx
@@ -21,10 +21,11 @@ import type { ClubCategoryEng } from '@/shared/types/club';
 
 export const ClubDetailEditPage = () => {
   const { clubId } = useParams<{ clubId: string }>();
-  const { isOpen: isClubPagePopupOpen, confirm: confirmClubPagePopup } = useOnboardingPopup(
-    'club-page',
-    { triggerMode: 'pageVisit' },
-  );
+  const {
+    isOpen: isClubPagePopupOpen,
+    confirm: confirmClubPagePopup,
+    reopen: reopenClubPagePopup,
+  } = useOnboardingPopup('club-page', { triggerMode: 'pageVisit' });
   const club = useClubDetailEdit(clubId ?? '');
 
   const methods = useForm<ClubDetailUpdatePayload>({
@@ -69,6 +70,7 @@ export const ClubDetailEditPage = () => {
                   category={
                     club.category in engToKorCategory ? (club.category as ClubCategoryEng) : 'ALL'
                   }
+                  onOpenGuide={reopenClubPagePopup}
                 />
                 <ClubShortIntroductionEditSection />
                 <ClubActivityPhotosEditSection

--- a/src/pages/admin/Dashboard/Page.tsx
+++ b/src/pages/admin/Dashboard/Page.tsx
@@ -16,7 +16,7 @@ export const DashboardPage = () => {
     isOpen: isDashboardPopupOpen,
     confirm: confirmDashboardPopup,
     reopen: reopenDashboardPopup,
-  } = useOnboardingPopup('dashboard', { triggerMode: 'pageVisit' });
+  } = useOnboardingPopup('dashboard', { triggerMode: 'login' });
 
   return (
     <Layout>

--- a/src/pages/admin/Dashboard/Page.tsx
+++ b/src/pages/admin/Dashboard/Page.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 import { Suspense, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { OnboardingPopup } from '@/shared/components/OnboardingPopup';
+import { useOnboardingPopup } from '@/shared/hooks/useOnboardingPopup';
 import { ApplicantListSection } from './components/ApplicantListSection';
 import { DashboardSummarySection } from './components/DashboardSummarySection';
 import { SentAcceptanceMessagesSection } from './components/SentAcceptanceMessagesSection';
@@ -10,13 +12,29 @@ import type { ApplicationStage } from '@/pages/admin/Dashboard/types/dashboard';
 export const DashboardPage = () => {
   const { clubId } = useParams();
   const [stage, setStage] = useState<ApplicationStage>('서류');
+  const {
+    isOpen: isDashboardPopupOpen,
+    confirm: confirmDashboardPopup,
+    reopen: reopenDashboardPopup,
+  } = useOnboardingPopup('dashboard', { triggerMode: 'pageVisit' });
 
   return (
     <Layout>
+      <OnboardingPopup
+        isOpen={isDashboardPopupOpen}
+        images={[1, 2, 3, 4, 5, 6].map((n) => `/assets/onboarding/dashboard/${n}.webp`)}
+        imageAlt='지원자 관리 가이드'
+        onConfirm={confirmDashboardPopup}
+      />
       <Container>
         <Suspense fallback={<LoadingSpinner />}>
           <DashboardSummarySection />
-          <ApplicantListSection stage={stage} setStage={setStage} clubId={Number(clubId)} />
+          <ApplicantListSection
+            stage={stage}
+            setStage={setStage}
+            clubId={Number(clubId)}
+            onOpenGuide={reopenDashboardPopup}
+          />
         </Suspense>
         <SentAcceptanceMessagesSection stage={stage} />
       </Container>

--- a/src/pages/admin/Dashboard/components/ApplicantListSection/index.tsx
+++ b/src/pages/admin/Dashboard/components/ApplicantListSection/index.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useApplicants } from '@/pages/admin/Dashboard/hooks/useApplicants';
+import { GuideIconButton } from '@/shared/components/GuideIconButton';
 import { Text } from '@/shared/components/Text';
 import { ApplicationStatusFilter } from './Filter/ApplicationFilter';
 import { ApplicantList } from './List/ApplicantList';
@@ -15,9 +16,15 @@ type ApplicantListSectionProps = {
   stage: ApplicationStage;
   setStage: React.Dispatch<React.SetStateAction<ApplicationStage>>;
   clubId: number;
+  onOpenGuide?: () => void;
 };
 
-export const ApplicantListSection = ({ stage, setStage, clubId }: ApplicantListSectionProps) => {
+export const ApplicantListSection = ({
+  stage,
+  setStage,
+  clubId,
+  onOpenGuide,
+}: ApplicantListSectionProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const optionType = 'ALL' as ApplicationFilterOption;
 
@@ -38,9 +45,12 @@ export const ApplicantListSection = ({ stage, setStage, clubId }: ApplicantListS
     <>
       <ApplicantFilterTopBarWrapper>
         <LeftSection>
-          <Text size='xl' weight='medium'>
-            지원자 목록
-          </Text>
+          <TitleWrapper>
+            <Text size='xl' weight='medium'>
+              지원자 목록
+            </Text>
+            {onOpenGuide && <GuideIconButton onClick={onOpenGuide} />}
+          </TitleWrapper>
           {interviewRequired && <StageToggle value={stage} onChange={setStage} />}
         </LeftSection>
         <ApplicationStatusFilter
@@ -81,6 +91,12 @@ const LeftSection = styled.div`
     justify-content: space-between;
   }
 `;
+
+const TitleWrapper = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+});
 
 const ListWrapper = styled.main(({ theme }) => ({
   minHeight: 'auto',

--- a/src/pages/admin/MemberManagement/Page.tsx
+++ b/src/pages/admin/MemberManagement/Page.tsx
@@ -25,10 +25,11 @@ export const MemberManagementPage = () => {
   const deleteModal = useModal();
   const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null);
 
-  const { isOpen: isMembersPopupOpen, confirm: confirmMembersPopup } = useOnboardingPopup(
-    'members',
-    { triggerMode: 'pageVisit' },
-  );
+  const {
+    isOpen: isMembersPopupOpen,
+    confirm: confirmMembersPopup,
+    reopen: reopenMembersPopup,
+  } = useOnboardingPopup('members', { triggerMode: 'pageVisit' });
 
   const members = useMembers(clubId || '');
 
@@ -88,6 +89,7 @@ export const MemberManagementPage = () => {
             onSortChange={setSortBy}
             onAddMember={handleAddMember}
             onBulkUpload={handleBulkUpload}
+            onOpenGuide={reopenMembersPopup}
           />
 
           <MemberTableSection

--- a/src/pages/admin/MemberManagement/components/MemberHeaderSection/index.tsx
+++ b/src/pages/admin/MemberManagement/components/MemberHeaderSection/index.tsx
@@ -1,5 +1,6 @@
 import { FiSearch, FiPlus } from 'react-icons/fi';
 import { Dropdown } from '@/shared/components/Dropdown';
+import { GuideIconButton } from '@/shared/components/GuideIconButton';
 import { Text } from '@/shared/components/Text';
 import * as S from './index.styled';
 import type { SortOption } from '../../types/member';
@@ -12,6 +13,7 @@ type Props = {
   onSortChange: (sort: SortOption) => void;
   onAddMember: () => void;
   onBulkUpload: () => void;
+  onOpenGuide?: () => void;
 };
 
 const SORT_OPTIONS: SortOption[] = ['이름순', '등록순'];
@@ -24,6 +26,7 @@ export const MemberHeaderSection = ({
   onSortChange,
   onAddMember,
   onBulkUpload,
+  onOpenGuide,
 }: Props) => {
   return (
     <S.Header>
@@ -31,6 +34,7 @@ export const MemberHeaderSection = ({
         <Text size='xl' weight='medium'>
           {clubName} 동아리원 명단
         </Text>
+        {onOpenGuide && <GuideIconButton onClick={onOpenGuide} />}
         <S.AddButton onClick={onAddMember}>동아리원 추가</S.AddButton>
         <S.AddButton onClick={onBulkUpload}>엑셀로 일괄 등록</S.AddButton>
         <S.AddIconButton onClick={onAddMember}>

--- a/src/shared/components/GuideIconButton.tsx
+++ b/src/shared/components/GuideIconButton.tsx
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+import { HiOutlineQuestionMarkCircle } from 'react-icons/hi';
+
+type Props = {
+  onClick: () => void;
+};
+
+export const GuideIconButton = ({ onClick }: Props) => (
+  <Button type='button' onClick={onClick}>
+    <HiOutlineQuestionMarkCircle size={20} />
+  </Button>
+);
+
+const Button = styled.button(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  color: theme.colors.textSecondary,
+  padding: '0.25rem',
+  borderRadius: '50%',
+  flexShrink: 0,
+  transition: 'color 0.15s',
+  '&:hover': { color: theme.colors.primary },
+}));

--- a/src/shared/components/PageHeader/index.styled.ts
+++ b/src/shared/components/PageHeader/index.styled.ts
@@ -22,7 +22,7 @@ export const TextWrapper = styled.div({
 export const Title = styled.h1(({ theme }) => ({
   fontSize: '2.5rem',
   fontWeight: theme.font.weight.medium,
-  margin: '1rem 0 0 0.5rem',
+  margin: '0 0 0 0.5rem',
 }));
 
 export const Category = styled.span(({ theme }) => ({
@@ -30,6 +30,13 @@ export const Category = styled.span(({ theme }) => ({
   color: theme.colors.textSecondary,
   margin: '0.5rem 0 0 0.5rem',
 }));
+
+export const TitleGroup = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  marginTop: '1rem',
+});
 
 export const InstagramLink = styled.a(({ theme }) => ({
   display: 'none',

--- a/src/shared/components/PageHeader/index.tsx
+++ b/src/shared/components/PageHeader/index.tsx
@@ -1,4 +1,5 @@
 import { FaInstagram } from 'react-icons/fa';
+import { GuideIconButton } from '@/shared/components/GuideIconButton';
 import { engToKorCategory } from '@/shared/utils/formatting';
 import * as S from './index.styled';
 import type { ClubCategoryEng } from '@/shared/types/club';
@@ -8,15 +9,19 @@ type Props = {
   category?: ClubCategoryEng;
   instagramUrl?: string;
   clubId?: number;
+  onOpenGuide?: () => void;
 };
 
-export const PageHeader = ({ clubName, category, instagramUrl, clubId }: Props) => {
+export const PageHeader = ({ clubName, category, instagramUrl, clubId, onOpenGuide }: Props) => {
   const korCategory = category && engToKorCategory[category];
 
   return (
     <S.Container>
       <S.TitleRow>
-        <S.Title>{clubName}</S.Title>
+        <S.TitleGroup>
+          <S.Title>{clubName}</S.Title>
+          {onOpenGuide && <GuideIconButton onClick={onOpenGuide} />}
+        </S.TitleGroup>
         {instagramUrl && (
           <S.InstagramLink
             href={instagramUrl}

--- a/src/shared/hooks/useOnboardingPopup.ts
+++ b/src/shared/hooks/useOnboardingPopup.ts
@@ -8,6 +8,7 @@ type UseOnboardingPopupOptions = {
 type UseOnboardingPopupReturn = {
   isOpen: boolean;
   confirm: () => void;
+  reopen: () => void;
 };
 
 export const useOnboardingPopup = (
@@ -26,5 +27,7 @@ export const useOnboardingPopup = (
     setIsOpen(false);
   };
 
-  return { isOpen, confirm };
+  const reopen = () => setIsOpen(true);
+
+  return { isOpen, confirm, reopen };
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #482 

## 📝 작업 내용
운영진이 언제든 페이지별 사용법을 확인할 수 있도록 가이드 다시보기(도움말) 기능을 도입했습니다. 
> **도움말 버튼 추가**: 4개 관리 페이지(지원자, 지원폼, 동아리페이지, 동아리원 관리) 우측 상단에 가이드 재호출을 위한 도움말 아이콘 배치

### 스크린샷 (선택)
<img width="695" height="340" alt="image" src="https://github.com/user-attachments/assets/832e96b5-45c3-4551-b3b9-4295ef5d250d" />
