### PR TITLE
[REFACTOR] 지원서 상세 페이지 불필요 리렌더링 최적화 (#485)

### DIFF
--- a/src/pages/admin/ApplicationDetail/components/ApplicantInfoSection/index.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicantInfoSection/index.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { memo } from 'react';
 import { Text } from '@/shared/components/Text';
 
 type Props = {
@@ -6,7 +7,7 @@ type Props = {
   email?: string;
   phoneNumber?: string;
 };
-export const ApplicantInfoSection = ({ studentId, email, phoneNumber }: Props) => {
+export const ApplicantInfoSection = memo(({ studentId, email, phoneNumber }: Props) => {
   return (
     <Layout>
       <Title>
@@ -30,7 +31,8 @@ export const ApplicantInfoSection = ({ studentId, email, phoneNumber }: Props) =
       </InfoContainer>
     </Layout>
   );
-};
+});
+ApplicantInfoSection.displayName = 'ApplicantInfoSection';
 
 const Layout = styled.div(({ theme }) => ({
   border: `1px solid ${theme.colors.gray200}`,

--- a/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStarRating.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStarRating.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 
 const getFillPercentage = (rating: number, index: number) => {
   if (rating >= index) return 100;
@@ -9,7 +9,7 @@ const getFillPercentage = (rating: number, index: number) => {
 
 const STAR_INDICES = [1, 2, 3, 4, 5];
 
-export const ApplicantStarRating = ({ rating = 0 }: { rating?: number }) => {
+export const ApplicantStarRating = memo(({ rating = 0 }: { rating?: number }) => {
   const stars = useMemo(() => {
     return STAR_INDICES.map((i) => {
       const fillPercentage = getFillPercentage(rating, i);
@@ -24,7 +24,8 @@ export const ApplicantStarRating = ({ rating = 0 }: { rating?: number }) => {
   }, [rating]);
 
   return <StarContainer>{stars}</StarContainer>;
-};
+});
+ApplicantStarRating.displayName = 'ApplicantStarRating';
 
 const StarContainer = styled.div({
   display: 'flex',

--- a/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStatusButton.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStatusButton.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { memo } from 'react';
 import type { StatusLabel, ApplicationStatus } from '@/pages/admin/Dashboard/types/dashboard';
 
 type Props = {
@@ -8,13 +9,14 @@ type Props = {
   onClick: (status: ApplicationStatus) => void;
 };
 
-export const ApplicantStatusButton = ({ label, value, selected, onClick }: Props) => {
+export const ApplicantStatusButton = memo(({ label, value, selected, onClick }: Props) => {
   return (
     <Wrapper label={label} selected={selected} onClick={() => onClick(value)}>
       {label}
     </Wrapper>
   );
-};
+});
+ApplicantStatusButton.displayName = 'ApplicantStatusButton';
 
 const Wrapper = styled.button<Pick<Props, 'selected' | 'label'>>(({ theme, selected, label }) => {
   const statusStyles = {

--- a/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStatusToggle.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/ApplicantStatusToggle.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { ApplicantStatusButton } from './ApplicantStatusButton';
 import type { ApplicationStatus } from '@/pages/admin/Dashboard/types/dashboard';
 
@@ -8,13 +8,16 @@ type Props = {
   updateStatus: (status: ApplicationStatus) => void;
 };
 
-export const ApplicantStatusToggle = ({ status, updateStatus }: Props) => {
+export const ApplicantStatusToggle = memo(({ status, updateStatus }: Props) => {
   const [statusOption, setStatusOption] = useState(status);
 
-  const handleClick = (newStatus: ApplicationStatus) => {
-    setStatusOption(newStatus);
-    updateStatus(newStatus);
-  };
+  const handleClick = useCallback(
+    (newStatus: ApplicationStatus) => {
+      setStatusOption(newStatus);
+      updateStatus(newStatus);
+    },
+    [updateStatus],
+  );
 
   return (
     <Container>
@@ -38,7 +41,8 @@ export const ApplicantStatusToggle = ({ status, updateStatus }: Props) => {
       />
     </Container>
   );
-};
+});
+ApplicantStatusToggle.displayName = 'ApplicantStatusToggle';
 
 const Container = styled.div(() => ({
   display: 'flex',

--- a/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/index.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicantProfileSection/index.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { memo } from 'react';
 import { Text } from '@/shared/components/Text';
 import { ApplicantStarRating } from './ApplicantStarRating';
 import { ApplicantStatusToggle } from './ApplicantStatusToggle';
@@ -12,28 +13,25 @@ type Props = {
   updateStatus: (status: ApplicationStatus) => void;
 };
 
-export const ApplicantProfileSection = ({
-  name,
-  department,
-  status,
-  rating,
-  updateStatus,
-}: Props) => {
-  return (
-    <Container>
-      <LeftSection>
-        <ProfileWrapper>
-          <Text size='xl'>{name}</Text>
-          <Text color='#616677'>{department}</Text>
-        </ProfileWrapper>
-        <ApplicantStarRating rating={rating} />
-      </LeftSection>
-      <RightSection>
-        <ApplicantStatusToggle status={status} updateStatus={updateStatus} />
-      </RightSection>
-    </Container>
-  );
-};
+export const ApplicantProfileSection = memo(
+  ({ name, department, status, rating, updateStatus }: Props) => {
+    return (
+      <Container>
+        <LeftSection>
+          <ProfileWrapper>
+            <Text size='xl'>{name}</Text>
+            <Text color='#616677'>{department}</Text>
+          </ProfileWrapper>
+          <ApplicantStarRating rating={rating} />
+        </LeftSection>
+        <RightSection>
+          <ApplicantStatusToggle status={status} updateStatus={updateStatus} />
+        </RightSection>
+      </Container>
+    );
+  },
+);
+ApplicantProfileSection.displayName = 'ApplicantProfileSection';
 
 const Container = styled.div(() => ({
   display: 'flex',

--- a/src/pages/admin/ApplicationDetail/components/ApplicationQuestionSection/index.tsx
+++ b/src/pages/admin/ApplicationDetail/components/ApplicationQuestionSection/index.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { memo } from 'react';
 import { Text } from '@/shared/components/Text';
 
 type Props = {
@@ -8,7 +9,7 @@ type Props = {
   }[];
 };
 
-export const ApplicantQuestionSection = ({ questionsAndAnswers }: Props) => {
+export const ApplicantQuestionSection = memo(({ questionsAndAnswers }: Props) => {
   return (
     <Wrapper>
       {questionsAndAnswers.map((item, index) => {
@@ -25,7 +26,8 @@ export const ApplicantQuestionSection = ({ questionsAndAnswers }: Props) => {
       })}
     </Wrapper>
   );
-};
+});
+ApplicantQuestionSection.displayName = 'ApplicantQuestionSection';
 
 const Wrapper = styled.div(({ theme }) => ({
   border: `1px solid ${theme.colors.gray200}`,

--- a/src/pages/admin/ApplicationDetail/components/CommentSection/index.tsx
+++ b/src/pages/admin/ApplicationDetail/components/CommentSection/index.tsx
@@ -1,9 +1,10 @@
+import { memo } from 'react';
 import { useParams } from 'react-router-dom';
 import { useComments } from '@/pages/admin/ApplicationDetail/hooks/useComments';
 import { CommentForm } from './CommentForm';
 import { CommentList } from './CommentList';
 
-export const CommentSection = () => {
+export const CommentSection = memo(() => {
   const { applicantId } = useParams();
 
   const { data, createComment } = useComments(Number(applicantId));
@@ -14,4 +15,5 @@ export const CommentSection = () => {
       <CommentList comments={data} />
     </>
   );
-};
+});
+CommentSection.displayName = 'CommentSection';


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #485 

## 📝 작업 내용
관리자 지원서 상세 페이지에서 합격/불합격/미정 버튼 클릭 시 상태 변경과 무관한 컴포넌트까지 전체 리렌더링되는 문제를 발견하여 개선했습니다.

### 문제 원인

버튼 클릭 시 아래 흐름으로 리렌더가 전파됩니다.

버튼 클릭
→ useMutation 실행 → ApplicationDetailPage 1차 리렌더
→ onSuccess: queryClient.setQueryData 호출 → React Query 캐시 갱신
→ useSuspenseQuery 감지 → ApplicationDetailPage 2차 리렌더
→ React.memo 없는 모든 자식 컴포넌트에 리렌더 전파 

### 컴포넌트별 불필요 리렌더 원인

| 컴포넌트 | 원인 | 실제 변화 |
|---|---|---|
| `ApplicantInfoSection` | 부모 리렌더 전파 | 없음 (학번/이메일/전화번호 불변) |
| `ApplicantQuestionSection` | 부모 리렌더 전파 | 없음 (`setQueryData` 스프레드로 동일 참조 유지) |
| `ApplicantStarRating` | 부모 리렌더 전파 | 없음 (rating 불변) |
| `ApplicantStatusButton` × 2 | `handleClick` 매 렌더마다 새 참조 생성 | 없음 (selected 값 불변) |
| `CommentSection` | 부모 리렌더 전파 | 없음 (props 자체가 없음) |

### `ApplicantStatusButton`의 추가 문제

`handleClick`이 `useCallback` 없이 선언되어 `ApplicantStatusToggle`이 리렌더될 때마다 새 함수 참조가 생성됩니다. 
이 경우 `React.memo`를 적용해도 onClick prop이 매번 달라진 것으로 판단해 3개 버튼 모두 리렌더됩니다.

```ts
// 기존: 매 렌더마다 새 함수 참조 생성
const handleClick = (newStatus: ApplicationStatus) => { ... };

// 개선: 참조 안정화
const handleClick = useCallback((newStatus: ApplicationStatus) => { ... }, [updateStatus]);
```
----

### React.memo 적용
부모 리렌더 시 props가 실제로 바뀐 경우에만 리렌더되도록 하도록 수정했습니다.

- `ApplicantInfoSection` — `props`(학번/이메일/전화번호)가 상태 변경과 무관
- `ApplicantQuestionSection` — `questionsAndAnswers` 배열이 동일 참조 유지
- `ApplicantProfileSection` — `status` 변경 시에만 리렌더되도록 격리
- `ApplicantStarRating` — `rating`이 상태 변경과 무관
- `ApplicantStatusButton` — `useCallback`과 결합하여 `selected` 바뀐 버튼만 리렌더
- `CommentSection` — `props` 없음, 부모 리렌더로부터 완전 격리
### useCallback 적용
- `ApplicantStatusToggle.handleClick `— 참조 안정화로 `ApplicantStatusButton`의 `React.memo`가 실제로 동작하도록 함

----

### 최적화 전/후 비교 (버튼 클릭 1회 기준)

| 컴포넌트 | 최적화 전 | 최적화 후 |
|---|---|---|
| `ApplicantInfoSection` | 2회 | 0회 |
| `ApplicantQuestionSection` | 2회 | 0회 |
| `ApplicantStarRating` | 2회 | 0회 |
| `ApplicantStatusButton` | 9회 (3개×3) | 2회 (변경된 2개만) |
| `CommentSection` | 2회 | 0회 |
| `ApplicantProfileSection` | 2회 | 0회 |

### 측정 방법
각 컴포넌트에 `console.count` 삽입 후 버튼 클릭 전후 렌더 횟수 비교


### 스크린샷 (선택)

- **개선 전**

<img width="2838" height="1816" alt="화면 기록 2026-05-05 오전 3 56 37" src="https://github.com/user-attachments/assets/ba9ae59d-3108-4f34-be16-ecaf3e592c7e" />

----

- **개선 후**

<img width="2838" height="1816" alt="화면 기록 2026-05-05 오전 3 50 34" src="https://github.com/user-attachments/assets/4c8d29e4-a58b-4b0b-b518-07841a10704d" />
