### PR TITLE
[FEAT] 푸터에 후원계좌 복사 기능 추가 (#490)

### DIFF
--- a/src/app/constants/sponsor.ts
+++ b/src/app/constants/sponsor.ts
@@ -1,0 +1,5 @@
+export const SPONSOR_ACCOUNT = {
+  bank: '카카오뱅크',
+  number: '3333150462491',
+  holder: '정*진',
+} as const;

--- a/src/shared/components/Footer/index.styled.ts
+++ b/src/shared/components/Footer/index.styled.ts
@@ -1,4 +1,14 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
+
+const ENVELOPE_WIDTH = 240;
+const ENVELOPE_HEIGHT = 150;
+const FLAP_HEIGHT = 78;
+
+const hintBob = keyframes({
+  '0%, 100%': { transform: 'translateY(0)' },
+  '50%': { transform: 'translateY(-6px)' },
+});
 
 export const Container = styled.div(({ theme }) => ({
   backgroundColor: theme.colors.gray100,
@@ -26,5 +36,145 @@ export const Email = styled.a(({ theme }) => ({
   ':hover': {
     textDecoration: 'underline',
     color: theme.colors.gray700,
+  },
+}));
+
+export const Sponsor = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  marginTop: 24,
+  perspective: 1000,
+});
+
+// 봉투 전체(클릭하면 모달이 뜨는 트리거). hover 시 뚜껑이 살짝 열려 클릭을 유도한다.
+export const Envelope = styled.div<{ isOpen: boolean }>(({ isOpen }) => ({
+  position: 'relative',
+  width: ENVELOPE_WIDTH,
+  height: ENVELOPE_HEIGHT,
+  cursor: 'pointer',
+  transformStyle: 'preserve-3d',
+  animation: isOpen ? 'none' : `${hintBob} 2.4s ease-in-out infinite`,
+}));
+
+// 봉투 뒷면(가장 안쪽). 앞면/뚜껑이 clip-path·삼각형이라 코너가 직각이므로 radius 없이 맞춘다.
+export const EnvelopeBack = styled.div(({ theme }) => ({
+  position: 'absolute',
+  inset: 0,
+  backgroundColor: theme.colors.primary900,
+}));
+
+// 봉투 앞면
+export const EnvelopeFront = styled.div(({ theme }) => ({
+  position: 'absolute',
+  inset: 0,
+  zIndex: 4,
+  backgroundColor: theme.colors.primary700,
+  // 아래쪽 접힘선(V) 표현
+  clipPath: 'polygon(0 0, 100% 0, 100% 100%, 50% 42%, 0 100%)',
+}));
+
+// 봉투 옆/아래 접힘선 음영
+export const EnvelopeFrontShade = styled.div(({ theme }) => ({
+  position: 'absolute',
+  inset: 0,
+  zIndex: 4,
+  backgroundColor: theme.colors.primary600,
+  clipPath: 'polygon(0 100%, 50% 42%, 100% 100%)',
+}));
+
+// 윗뚜껑. 닫힘: 아래를 덮음 / 열림: 뒤로 젖혀짐.
+export const Flap = styled.div<{ isOpen: boolean }>(({ theme, isOpen }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: 0,
+  height: 0,
+  borderLeft: `${ENVELOPE_WIDTH / 2}px solid transparent`,
+  borderRight: `${ENVELOPE_WIDTH / 2}px solid transparent`,
+  borderTop: `${FLAP_HEIGHT}px solid ${theme.colors.primary800}`,
+  transformOrigin: 'top center',
+  transformStyle: 'preserve-3d',
+  transform: isOpen ? 'rotateX(180deg)' : 'rotateX(0deg)',
+  zIndex: isOpen ? 1 : 5,
+  transition: 'transform 0.45s ease, z-index 0s linear 0.22s',
+}));
+
+// 봉투에서 빠져나온 듯한 모달 안내 아이콘
+export const SponsorHeartIcon = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  margin: '0 auto 12px',
+  width: 48,
+  height: 48,
+  borderRadius: '50%',
+  backgroundColor: theme.colors.bgGreen,
+  color: theme.colors.primary,
+  fontSize: 24,
+}));
+
+export const SponsorTitle = styled.p(({ theme }) => ({
+  margin: 0,
+  textAlign: 'center',
+  fontSize: theme.font.size.base,
+  fontWeight: theme.font.weight.bold,
+  lineHeight: 1.5,
+  color: theme.colors.gray900,
+}));
+
+export const SponsorSubText = styled.p(({ theme }) => ({
+  margin: '8px 0 0',
+  textAlign: 'center',
+  fontSize: theme.font.size.sm,
+  lineHeight: 1.5,
+  color: theme.colors.gray500,
+}));
+
+export const AccountRow = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 12,
+  marginTop: 20,
+  padding: '12px 12px 12px 16px',
+  borderRadius: theme.radius.md,
+  backgroundColor: theme.colors.bgGreen,
+  border: `1px solid ${theme.colors.border}`,
+}));
+
+export const AccountInfo = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
+  textAlign: 'left',
+});
+
+export const AccountBank = styled.span(({ theme }) => ({
+  fontSize: theme.font.size.xs,
+  color: theme.colors.gray500,
+}));
+
+export const AccountNumber = styled.span(({ theme }) => ({
+  fontSize: theme.font.size.base,
+  fontWeight: theme.font.weight.bold,
+  color: theme.colors.gray900,
+}));
+
+export const CopyButton = styled.button(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+  padding: '8px 14px',
+  border: 'none',
+  borderRadius: theme.radius.sm,
+  backgroundColor: theme.colors.primary,
+  color: theme.colors.bg,
+  fontSize: theme.font.size.sm,
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+
+  ':hover': {
+    backgroundColor: theme.colors.primary700,
   },
 }));

--- a/src/shared/components/Footer/index.tsx
+++ b/src/shared/components/Footer/index.tsx
@@ -1,11 +1,93 @@
+import { FiCopy } from 'react-icons/fi';
+import { HiOutlineHeart } from 'react-icons/hi2';
+import { matchPath, useLocation } from 'react-router-dom';
 import { CONTACT_EMAIL } from '@/app/constants/email';
+import { ROUTE_PATH } from '@/app/constants/routerPath';
+import { SPONSOR_ACCOUNT } from '@/app/constants/sponsor';
+import { Modal } from '@/shared/components/Modal';
+import { useModal } from '@/shared/hooks/useModal';
+import { toast } from '@/shared/utils/toast';
 import * as S from './index.styled';
 
 const Footer = () => {
+  const { isOpen, openModal, closeModal } = useModal();
+  const { pathname } = useLocation();
+  // admin 페이지(/admin 하위)와 지원 폼 페이지에서는 후원 봉투를 노출하지 않는다.
+  const hideSponsor =
+    pathname.startsWith('/admin') ||
+    matchPath(`/${ROUTE_PATH.USER.APPLICATION}`, pathname) !== null;
+
+  const handleCopyAccount = async () => {
+    try {
+      await navigator.clipboard.writeText(SPONSOR_ACCOUNT.number);
+      toast.success('계좌번호가 복사되었습니다.');
+    } catch {
+      toast.error('계좌번호 복사에 실패했습니다.');
+    }
+  };
+
   return (
     <S.Container>
       <S.Email href={`mailto:${CONTACT_EMAIL}`}>Contact : {CONTACT_EMAIL}</S.Email>
       <S.Copyright>© {new Date().getFullYear()} Dongarium. All rights reserved.</S.Copyright>
+
+      {!hideSponsor && (
+        <>
+          <S.Sponsor>
+            <S.Envelope
+              isOpen={isOpen}
+              role='button'
+              tabIndex={0}
+              aria-haspopup='dialog'
+              aria-expanded={isOpen}
+              aria-label='후원 안내 열기'
+              onClick={openModal}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  openModal();
+                }
+              }}
+            >
+              <S.EnvelopeBack aria-hidden />
+              <S.EnvelopeFrontShade aria-hidden />
+              <S.EnvelopeFront aria-hidden />
+              <S.Flap isOpen={isOpen} aria-hidden />
+            </S.Envelope>
+          </S.Sponsor>
+
+          <Modal isOpen={isOpen} onClose={closeModal} size='md'>
+            <S.SponsorHeartIcon aria-hidden>
+              <HiOutlineHeart />
+            </S.SponsorHeartIcon>
+            <S.SponsorTitle>
+              도움이 되셨다면,
+              <br />
+              후원으로 동아리움 운영을 지속하게 도와주세요!
+            </S.SponsorTitle>
+            <S.SponsorSubText>
+              이 콘텐츠가 계속 무료로 유지되는 건 후원자 덕분입니다. 함께해 주세요.
+            </S.SponsorSubText>
+
+            <S.AccountRow>
+              <S.AccountInfo>
+                <S.AccountBank>
+                  {SPONSOR_ACCOUNT.bank} · {SPONSOR_ACCOUNT.holder}
+                </S.AccountBank>
+                <S.AccountNumber>{SPONSOR_ACCOUNT.number}</S.AccountNumber>
+              </S.AccountInfo>
+              <S.CopyButton
+                type='button'
+                onClick={handleCopyAccount}
+                aria-label='후원 계좌번호 복사'
+              >
+                <FiCopy />
+                복사
+              </S.CopyButton>
+            </S.AccountRow>
+          </Modal>
+        </>
+      )}
     </S.Container>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

close #490 

  ## 작업 내용

  - 푸터 하단에 후원 봉투 추가 (클릭 시 후원 안내 모달 오픈)
  - CSS 3D 트랜스폼으로 봉투 뚜껑이 젖혀지는 인터랙션 구현
  - 공유 `Modal` 컴포넌트로 후원 계좌 안내 모달 구성
  - 계좌번호 복사 버튼 + 복사 완료 토스트
  - admin 페이지 / 지원 폼 페이지에서는 미노출

  ## 참고

  - 후원 계좌 정보는 `src/app/constants/sponsor.ts`에서 관리

