### PR TITLE
[FIX] 토큰 만료·로그아웃 처리 시 리다이렉트 URI 누락으로 404 페이지 노출 문제 수정 (#492)

### DIFF
--- a/src/app/api/initInstance.ts
+++ b/src/app/api/initInstance.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { ROUTE_PATH } from '@/app/constants/routerPath';
 import {
   AUTH_ERRORS,
   getAccessToken,
@@ -34,7 +35,7 @@ apiInstance.interceptors.request.use((config) => {
 
 const handleLogout = (errorMessage: string) => {
   removeAccessToken();
-  window.location.href = LOGOUT_REDIRECT_URI_REISSUE;
+  window.location.href = LOGOUT_REDIRECT_URI_REISSUE || ROUTE_PATH.COMMON.MAIN;
   throw new Error(errorMessage);
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #492

## 📝작업 내용

세션 만료·토큰 재발급 실패로 로그아웃 처리될 때 `/undefined` 경로로 이동해 404 페이지가 노출되던 문제를 수정했습니다.

| 원인 | 해결 |
|------|------|
| `VITE_LOGOUT_REDIRECT_URI_REISSUE` 환경변수가 정의되어 있지 않아 `window.location.href`에 `undefined`가 할당되어 `/undefined`로 이동 | `initInstance.ts`: `LOGOUT_REDIRECT_URI_REISSUE \|\| ROUTE_PATH.COMMON.MAIN` 폴백 추가하여 값 누락 시 메인 페이지로 이동 |

## 💬리뷰 요구사항(선택)

> 로그아웃 리다이렉트의 의도가 별도 URL이라면 배포 환경에 `VITE_LOGOUT_REDIRECT_URI_REISSUE` 값을 설정해야 합니다. 현재는 값이 없어 메인(`/`)으로 폴백됩니다.
