### PR TITLE
[STYLE] 푸터 후원 봉투(편지) 인터랙션 크기 축소 (#494)

### DIFF
--- a/src/shared/components/Footer/index.styled.ts
+++ b/src/shared/components/Footer/index.styled.ts
@@ -1,9 +1,9 @@
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
-const ENVELOPE_WIDTH = 240;
-const ENVELOPE_HEIGHT = 150;
-const FLAP_HEIGHT = 78;
+const ENVELOPE_WIDTH = 96;
+const ENVELOPE_HEIGHT = 60;
+const FLAP_HEIGHT = 31;
 
 const hintBob = keyframes({
   '0%, 100%': { transform: 'translateY(0)' },


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #494

## 📝작업 내용

푸터 하단의 후원 봉투(편지) 인터랙션 크기를 기존의 2/5로 축소했습니다.

| 상수 | 기존 | 변경 |
|------|------|------|
| `ENVELOPE_WIDTH` | 240 | 96 |
| `ENVELOPE_HEIGHT` | 150 | 60 |
| `FLAP_HEIGHT` | 78 | 31 |

봉투 앞면/뚜껑은 상수 기반(clip-path·border)으로 그려져 있어 상수만 줄여도 비율이 그대로 유지됩니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 호버 유도 애니메이션(`hintBob`)의 이동 폭(-6px)은 그대로 두었습니다. 축소된 크기 대비 과하게 느껴지면 말씀해주세요.