### PR TITLE
[FEAT] 지원폼 관리 페이지 상단에 지원폼 링크 복사 기능 추가 (#496)

### DIFF
--- a/src/pages/admin/ApplicationFormBuilder/Page.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/Page.tsx
@@ -11,6 +11,7 @@ import { useOnboardingPopup } from '@/shared/hooks/useOnboardingPopup';
 import { toast } from '@/shared/utils/toast';
 import { ApplicationInfoSection } from './components/ApplicationInfoSection';
 import { ApplicationFieldsFormTableSection } from './components/FieldsFormTableSection';
+import { ApplicationFormLinkCopySection } from './components/FormLinkCopySection';
 import { ApplicationFormBuilderHeaderSection } from './components/HeaderSection';
 import type { ApplicationFormData } from './types/fieldType';
 
@@ -90,6 +91,7 @@ export const ApplicationFormBuilderPage = () => {
       />
 
       <ContentContainer>
+        <ApplicationFormLinkCopySection clubId={Number(clubId)} />
         <ApplicationFormBuilderHeaderSection
           isEditMode={isEditMode}
           onEdit={handleEdit}

--- a/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.styled.ts
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div(({ theme }) => ({
+  width: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '0.75rem',
+  marginTop: '2.5rem',
+  padding: '0.75rem 0.75rem 0.75rem 1rem',
+  borderRadius: theme.radius.md,
+  backgroundColor: theme.colors.bgGreen,
+  border: `1px solid ${theme.colors.border}`,
+  boxSizing: 'border-box',
+}));
+
+export const LinkInfo = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.125rem',
+  minWidth: 0,
+  textAlign: 'left',
+});
+
+export const LinkLabel = styled.span(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.25rem',
+  fontSize: theme.font.size.xs,
+  color: theme.colors.gray500,
+}));
+
+export const LinkText = styled.span(({ theme }) => ({
+  fontSize: theme.font.size.base,
+  fontWeight: theme.font.weight.bold,
+  color: theme.colors.gray900,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}));
+
+export const CopyButton = styled.button(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.25rem',
+  padding: '0.5rem 0.875rem',
+  border: 'none',
+  borderRadius: theme.radius.sm,
+  backgroundColor: theme.colors.primary,
+  color: theme.colors.bg,
+  fontSize: theme.font.size.sm,
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+
+  ':hover': {
+    backgroundColor: theme.colors.primary700,
+  },
+}));

--- a/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.styled.ts
@@ -1,6 +1,28 @@
 import styled from '@emotion/styled';
 
+export const Tooltip = styled.span(({ theme }) => ({
+  position: 'absolute',
+  top: 'calc(100% + 0.5rem)',
+  right: 0,
+  width: 'max-content',
+  maxWidth: '100%',
+  padding: '0.5rem 0.75rem',
+  borderRadius: theme.radius.sm,
+  backgroundColor: theme.colors.gray800,
+  color: theme.colors.bg,
+  fontSize: theme.font.size.xs,
+  lineHeight: 1.5,
+  boxShadow: theme.shadow.sm,
+  opacity: 0,
+  visibility: 'hidden',
+  transition: 'opacity 0.15s ease',
+  pointerEvents: 'none',
+  zIndex: 1,
+  boxSizing: 'border-box',
+}));
+
 export const Container = styled.div(({ theme }) => ({
+  position: 'relative',
   width: '100%',
   display: 'flex',
   alignItems: 'center',
@@ -12,6 +34,11 @@ export const Container = styled.div(({ theme }) => ({
   backgroundColor: theme.colors.bgGreen,
   border: `1px solid ${theme.colors.border}`,
   boxSizing: 'border-box',
+
+  [`&:hover ${Tooltip}, &:focus-within ${Tooltip}`]: {
+    opacity: 1,
+    visibility: 'visible',
+  },
 }));
 
 export const LinkInfo = styled.div({

--- a/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.styled.ts
@@ -6,7 +6,7 @@ export const Container = styled.div(({ theme }) => ({
   alignItems: 'center',
   justifyContent: 'space-between',
   gap: '0.75rem',
-  marginTop: '2.5rem',
+  margin: '2.5rem 0 0.5rem 0',
   padding: '0.75rem 0.75rem 0.75rem 1rem',
   borderRadius: theme.radius.md,
   backgroundColor: theme.colors.bgGreen,

--- a/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.tsx
@@ -1,4 +1,5 @@
 import { FiCopy, FiLink } from 'react-icons/fi';
+import { copyToClipboard } from '@/shared/utils/copyToClipboard';
 import { toast } from '@/shared/utils/toast';
 import * as S from './index.styled';
 
@@ -7,13 +8,15 @@ type Props = {
 };
 
 export const ApplicationFormLinkCopySection = ({ clubId }: Props) => {
+  if (Number.isNaN(clubId)) return null;
+
   const formLink = `${window.location.origin}/clubs/${clubId}/apply`;
 
   const handleCopyLink = async () => {
-    try {
-      await navigator.clipboard.writeText(formLink);
+    const copied = await copyToClipboard(formLink);
+    if (copied) {
       toast.success('지원폼 링크가 복사되었습니다.');
-    } catch {
+    } else {
       toast.error('지원폼 링크 복사에 실패했습니다.');
     }
   };

--- a/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.tsx
@@ -1,0 +1,36 @@
+import { FiCopy, FiLink } from 'react-icons/fi';
+import { toast } from '@/shared/utils/toast';
+import * as S from './index.styled';
+
+type Props = {
+  clubId: number;
+};
+
+export const ApplicationFormLinkCopySection = ({ clubId }: Props) => {
+  const formLink = `${window.location.origin}/clubs/${clubId}/apply`;
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(formLink);
+      toast.success('지원폼 링크가 복사되었습니다.');
+    } catch {
+      toast.error('지원폼 링크 복사에 실패했습니다.');
+    }
+  };
+
+  return (
+    <S.Container>
+      <S.LinkInfo>
+        <S.LinkLabel>
+          <FiLink aria-hidden />
+          지원폼 공유 링크
+        </S.LinkLabel>
+        <S.LinkText>{formLink}</S.LinkText>
+      </S.LinkInfo>
+      <S.CopyButton type='button' onClick={handleCopyLink} aria-label='지원폼 링크 복사'>
+        <FiCopy />
+        복사
+      </S.CopyButton>
+    </S.Container>
+  );
+};

--- a/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.tsx
@@ -31,6 +31,9 @@ export const ApplicationFormLinkCopySection = ({ clubId }: Props) => {
         <FiCopy />
         복사
       </S.CopyButton>
+      <S.Tooltip role='tooltip'>
+        복사하지 않아도 동아리움에서는 지원 시기에 맞게 지원하기 버튼이 활성화 돼요!
+      </S.Tooltip>
     </S.Container>
   );
 };

--- a/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.styled.ts
@@ -5,7 +5,6 @@ export const Container = styled.div(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: '2rem',
-  padding: '2.5rem 0 0 0',
   boxSizing: 'border-box',
 
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {

--- a/src/shared/components/Footer/index.tsx
+++ b/src/shared/components/Footer/index.tsx
@@ -6,6 +6,7 @@ import { ROUTE_PATH } from '@/app/constants/routerPath';
 import { SPONSOR_ACCOUNT } from '@/app/constants/sponsor';
 import { Modal } from '@/shared/components/Modal';
 import { useModal } from '@/shared/hooks/useModal';
+import { copyToClipboard } from '@/shared/utils/copyToClipboard';
 import { toast } from '@/shared/utils/toast';
 import * as S from './index.styled';
 
@@ -18,10 +19,10 @@ const Footer = () => {
     matchPath(`/${ROUTE_PATH.USER.APPLICATION}`, pathname) !== null;
 
   const handleCopyAccount = async () => {
-    try {
-      await navigator.clipboard.writeText(SPONSOR_ACCOUNT.number);
+    const copied = await copyToClipboard(SPONSOR_ACCOUNT.number);
+    if (copied) {
       toast.success('계좌번호가 복사되었습니다.');
-    } catch {
+    } else {
       toast.error('계좌번호 복사에 실패했습니다.');
     }
   };

--- a/src/shared/utils/copyToClipboard.ts
+++ b/src/shared/utils/copyToClipboard.ts
@@ -1,10 +1,30 @@
+// HTTPS가 아니거나 구형 브라우저라 navigator.clipboard를 쓸 수 없을 때의 fallback.
+const copyWithExecCommand = (text: string): boolean => {
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.style.position = 'absolute';
+  textArea.style.opacity = '0';
+  document.body.appendChild(textArea);
+  textArea.select();
+
+  try {
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textArea);
+  }
+};
+
 export const copyToClipboard = async (text: string): Promise<boolean> => {
-  if (!navigator.clipboard) return false;
+  if (!navigator.clipboard || !window.isSecureContext) {
+    return copyWithExecCommand(text);
+  }
 
   try {
     await navigator.clipboard.writeText(text);
     return true;
   } catch {
-    return false;
+    return copyWithExecCommand(text);
   }
 };

--- a/src/shared/utils/copyToClipboard.ts
+++ b/src/shared/utils/copyToClipboard.ts
@@ -1,0 +1,10 @@
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  if (!navigator.clipboard) return false;
+
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #496

## 📝작업 내용

관리자 지원폼 관리(생성/수정) 페이지 최상단에 해당 동아리의 공개 지원폼 링크(`/clubs/:clubId/apply`)를 확인·복사할 수 있는 섹션을 추가했습니다.

- `FormLinkCopySection` 컴포넌트 신규 추가 (기존 섹션 컴포넌트 구조와 동일하게 `components/FormLinkCopySection/index.tsx` + `index.styled.ts`)
- 복사 버튼 클릭 시 `navigator.clipboard`로 링크 복사, 성공/실패 토스트 피드백 (푸터 후원계좌 복사와 동일한 인터랙션 패턴)
- 디자인 토큰(`bgGreen`, `border`, `radius.md/sm`, `primary`, `gray`)만 사용해 기존 UI에 자연스럽게 녹아들도록 구성
- 긴 링크는 말줄임표 처리, 복사 버튼에 `aria-label` 적용
- 기존 HeaderSection이 갖고 있던 페이지 상단 여백(2.5rem)을 새 섹션으로 이동 (섹션 간 간격은 기존 `ContentContainer` gap 그대로 사용)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 링크 문구("지원폼 공유 링크")와 배치(헤더 타이틀 위)가 어색하지 않은지 봐주세요.