### PR TITLE
[FEAT] 지원폼 관리 페이지 상시 편집 구조로 개선 및 하단 취소/저장 버튼 배치 (#498)

### DIFF
--- a/src/pages/admin/ApplicationFormBuilder/Page.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/Page.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import {
@@ -11,13 +10,13 @@ import { useOnboardingPopup } from '@/shared/hooks/useOnboardingPopup';
 import { toast } from '@/shared/utils/toast';
 import { ApplicationInfoSection } from './components/ApplicationInfoSection';
 import { ApplicationFieldsFormTableSection } from './components/FieldsFormTableSection';
+import { ApplicationFormActionsSection } from './components/FormActionsSection';
 import { ApplicationFormLinkCopySection } from './components/FormLinkCopySection';
 import { ApplicationFormBuilderHeaderSection } from './components/HeaderSection';
 import type { ApplicationFormData } from './types/fieldType';
 
 export const ApplicationFormBuilderPage = () => {
   const { clubId } = useParams();
-  const [isEditMode, setIsEditMode] = useState(false);
   const {
     isOpen: isFormPopupOpen,
     confirm: confirmFormPopup,
@@ -30,9 +29,7 @@ export const ApplicationFormBuilderPage = () => {
     defaultValues: data,
   });
 
-  const handleEdit = () => setIsEditMode(true);
   const handleCancel = () => {
-    setIsEditMode(false);
     if (data) {
       formHandler.reset(data);
     }
@@ -41,7 +38,7 @@ export const ApplicationFormBuilderPage = () => {
   const handleSave = formHandler.handleSubmit((formData) => {
     adaptedPatchForm(formData, {
       onSuccess: () => {
-        setIsEditMode(false);
+        toast.success('지원폼이 저장되었습니다.');
       },
       onError: (error) => {
         toast.error(error.message || '지원서 저장에 실패했습니다.');
@@ -93,17 +90,15 @@ export const ApplicationFormBuilderPage = () => {
       <ContentContainer>
         <ApplicationFormLinkCopySection clubId={Number(clubId)} />
         <ApplicationFormBuilderHeaderSection
-          isEditMode={isEditMode}
-          onEdit={handleEdit}
-          onSave={handleSave}
-          onCancel={handleCancel}
           isInterviewMode={isInterviewMode}
           onInterviewChange={handleInterviewChange}
           onOpenGuide={reopenFormPopup}
         />
-        <ApplicationInfoSection formHandler={formHandler} isEditMode={isEditMode} />
+        <ApplicationInfoSection formHandler={formHandler} />
 
-        <ApplicationFieldsFormTableSection formHandler={formHandler} isEditMode={isEditMode} />
+        <ApplicationFieldsFormTableSection formHandler={formHandler} />
+
+        <ApplicationFormActionsSection onCancel={handleCancel} onSave={handleSave} />
       </ContentContainer>
     </Layout>
   );

--- a/src/pages/admin/ApplicationFormBuilder/Page.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/Page.tsx
@@ -11,6 +11,7 @@ import { useOnboardingPopup } from '@/shared/hooks/useOnboardingPopup';
 import { toast } from '@/shared/utils/toast';
 import { ApplicationInfoSection } from './components/ApplicationInfoSection';
 import { ApplicationFieldsFormTableSection } from './components/FieldsFormTableSection';
+import { ApplicationFormLinkCopySection } from './components/FormLinkCopySection';
 import { ApplicationFormBuilderHeaderSection } from './components/HeaderSection';
 import type { ApplicationFormData } from './types/fieldType';
 
@@ -90,6 +91,7 @@ export const ApplicationFormBuilderPage = () => {
       />
 
       <ContentContainer>
+        <ApplicationFormLinkCopySection clubId={Number(clubId)} />
         <ApplicationFormBuilderHeaderSection
           isEditMode={isEditMode}
           onEdit={handleEdit}

--- a/src/pages/admin/ApplicationFormBuilder/components/ApplicationInfoSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/ApplicationInfoSection/index.tsx
@@ -13,7 +13,6 @@ import type { ApplicationFormData } from '@/pages/admin/ApplicationFormBuilder/t
 
 type Props = {
   formHandler: UseFormReturn<ApplicationFormData>;
-  isEditMode: boolean;
 };
 
 const CustomInput = ({ value, onClick }: CustomInputProps) => (
@@ -24,7 +23,7 @@ const CustomInput = ({ value, onClick }: CustomInputProps) => (
   </S.CustomInputWrapper>
 );
 
-export const ApplicationInfoSection = ({ formHandler, isEditMode }: Props) => {
+export const ApplicationInfoSection = ({ formHandler }: Props) => {
   const {
     register,
     watch,
@@ -42,7 +41,7 @@ export const ApplicationInfoSection = ({ formHandler, isEditMode }: Props) => {
   return (
     <>
       <Global styles={datePickerStyles} />
-      <Layout isEditMode={isEditMode}>
+      <Layout>
         <Wrapper>
           <UnderlineInputField
             placeholder='ex. 동아리명 10기 신입부원 모집'
@@ -55,7 +54,6 @@ export const ApplicationInfoSection = ({ formHandler, isEditMode }: Props) => {
             })}
             invalid={!!errors.title}
             message={errors.title?.message}
-            disabled={!isEditMode}
           />
           <S.DatePickerWrapper>
             <DatePicker
@@ -68,7 +66,6 @@ export const ApplicationInfoSection = ({ formHandler, isEditMode }: Props) => {
               selectsRange
               customInput={<CustomInput value={formatDateRange()} />}
               popperPlacement='bottom'
-              disabled={!isEditMode}
             />
             <input
               type='hidden'
@@ -86,19 +83,18 @@ export const ApplicationInfoSection = ({ formHandler, isEditMode }: Props) => {
           })}
           invalid={!!errors.description}
           message={errors.description?.message}
-          disabled={!isEditMode}
         />
       </Layout>
     </>
   );
 };
 
-const Layout = styled.div<{ isEditMode: boolean }>(({ theme, isEditMode }) => ({
+const Layout = styled.div(({ theme }) => ({
   width: '100%',
   border: `1px solid ${theme.colors.gray200}`,
   borderRadius: theme.radius.sm,
   padding: '1.5rem',
-  backgroundColor: isEditMode ? theme.colors.bg : theme.colors.gray00,
+  backgroundColor: theme.colors.bg,
   display: 'flex',
   flexDirection: 'column',
   gap: '2.5rem',

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/DeleteQuestionModal/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/DeleteQuestionModal/index.tsx
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+import { Button } from '@/shared/components/Button';
+import { Modal } from '@/shared/components/Modal';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+export const DeleteQuestionModal = ({ isOpen, onClose, onConfirm }: Props) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title='질문 삭제' size='md'>
+      <Content>
+        <Message>작성 중인 질문을 삭제하시겠습니까?</Message>
+        <Warning>삭제된 질문의 내용은 복구할 수 없습니다.</Warning>
+
+        <ButtonWrapper>
+          <Button onClick={onConfirm}>삭제하기</Button>
+        </ButtonWrapper>
+      </Content>
+    </Modal>
+  );
+};
+
+const Content = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+  padding: '1rem 0',
+});
+
+const Message = styled.p(({ theme }) => ({
+  fontSize: theme.font.size.base,
+  fontWeight: theme.font.weight.medium,
+  color: theme.colors.gray900,
+  textAlign: 'center',
+  margin: 0,
+}));
+
+const Warning = styled.p(({ theme }) => ({
+  fontSize: theme.font.size.sm,
+  color: theme.colors.gray600,
+  textAlign: 'center',
+  margin: 0,
+}));
+
+const ButtonWrapper = styled.div({
+  display: 'flex',
+  justifyContent: 'center',
+});

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/Builders/CheckboxOptionsBuilder.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/Builders/CheckboxOptionsBuilder.tsx
@@ -11,10 +11,9 @@ import type { ApplicationFormData } from '@/pages/admin/ApplicationFormBuilder/t
 type Props = {
   formHandler: UseFormReturn<ApplicationFormData>;
   questionIndex: number;
-  isEditMode: boolean;
 };
 
-export const CheckboxOptionsBuilder = ({ formHandler, questionIndex, isEditMode }: Props) => {
+export const CheckboxOptionsBuilder = ({ formHandler, questionIndex }: Props) => {
   const {
     register,
     control,
@@ -45,21 +44,18 @@ export const CheckboxOptionsBuilder = ({ formHandler, questionIndex, isEditMode 
             message={
               errors.formQuestions?.[questionIndex]?.optionList?.[optionIndex]?.value?.message
             }
-            disabled={!isEditMode}
           />
           <AiOutlineCloseCircle
             size={'1.5rem'}
             color='#757575'
-            onClick={isEditMode ? () => remove(optionIndex) : undefined}
+            onClick={() => remove(optionIndex)}
           />
         </OptionFieldWrapper>
       ))}
 
-      {isEditMode && (
-        <AddOptionButton onClick={handleAddOption}>
-          <FiPlus /> <Text size='sm'>옵션 추가</Text>
-        </AddOptionButton>
-      )}
+      <AddOptionButton onClick={handleAddOption}>
+        <FiPlus /> <Text size='sm'>옵션 추가</Text>
+      </AddOptionButton>
     </Layout>
   );
 };

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/Builders/RadioOptionsBuilder.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/Builders/RadioOptionsBuilder.tsx
@@ -11,10 +11,9 @@ import type { ApplicationFormData } from '@/pages/admin/ApplicationFormBuilder/t
 type Props = {
   formHandler: UseFormReturn<ApplicationFormData>;
   questionIndex: number;
-  isEditMode: boolean;
 };
 
-export const RadioOptionsBuilder = ({ formHandler, questionIndex, isEditMode }: Props) => {
+export const RadioOptionsBuilder = ({ formHandler, questionIndex }: Props) => {
   const {
     register,
     control,
@@ -45,21 +44,18 @@ export const RadioOptionsBuilder = ({ formHandler, questionIndex, isEditMode }: 
             message={
               errors.formQuestions?.[questionIndex]?.optionList?.[optionIndex]?.value?.message
             }
-            disabled={!isEditMode}
           />
           <AiOutlineCloseCircle
             size={'1.5rem'}
             color='#757575'
-            onClick={isEditMode ? () => remove(optionIndex) : undefined}
+            onClick={() => remove(optionIndex)}
           />
         </OptionFieldWrapper>
       ))}
 
-      {isEditMode && (
-        <AddOptionButton onClick={handleAddOption}>
-          <FiPlus /> <Text size='sm'>옵션 추가</Text>
-        </AddOptionButton>
-      )}
+      <AddOptionButton onClick={handleAddOption}>
+        <FiPlus /> <Text size='sm'>옵션 추가</Text>
+      </AddOptionButton>
     </Layout>
   );
 };

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/Builders/TextOptionsBuilder.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/Builders/TextOptionsBuilder.tsx
@@ -1,10 +1,5 @@
 import { OutlineTextareaField } from '@/shared/components/Form/TextAreaField/OutlineTextareaField';
 
 export const TextOptionsBuilder = () => {
-  return (
-    <OutlineTextareaField
-      placeholder='지원자가 작성할 텍스트 창입니다. 작성하지 마세요.'
-      disabled={true}
-    />
-  );
+  return <OutlineTextareaField placeholder='지원자가 작성할 텍스트 창' disabled={true} />;
 };

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/Builders/TimeslotFieldBuilder.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/Builders/TimeslotFieldBuilder.tsx
@@ -17,7 +17,6 @@ import type { ApplicationFormData } from '@/pages/admin/ApplicationFormBuilder/t
 type Props = {
   formHandler: UseFormReturn<ApplicationFormData>;
   questionIndex: number;
-  isEditMode: boolean;
 };
 
 const times = generateTimes();
@@ -28,7 +27,7 @@ const CustomInput = ({ value, onClick }: CustomInputProps) => (
   </S.CustomInputWrapper>
 );
 
-export const TimeslotFieldBuilder = ({ formHandler, questionIndex, isEditMode }: Props) => {
+export const TimeslotFieldBuilder = ({ formHandler, questionIndex }: Props) => {
   const {
     register,
     setValue,
@@ -75,7 +74,6 @@ export const TimeslotFieldBuilder = ({ formHandler, questionIndex, isEditMode }:
           })}
           invalid={!!errors.formQuestions?.[questionIndex]?.question}
           message={errors.formQuestions?.[questionIndex]?.question?.message}
-          disabled={!isEditMode}
         />
       </S.HeaderWrapper>
       <S.Container>
@@ -90,7 +88,6 @@ export const TimeslotFieldBuilder = ({ formHandler, questionIndex, isEditMode }:
             selectsRange
             customInput={<CustomInput value={formatDateRange()} />}
             popperPlacement='bottom'
-            disabled={!isEditMode}
           />
           <input
             type='hidden'
@@ -108,21 +105,11 @@ export const TimeslotFieldBuilder = ({ formHandler, questionIndex, isEditMode }:
         <S.TimeSelectContainer>
           <S.TimeSelectWrapper>
             <Text color='#6E6E6E'>시작시간</Text>
-            <Dropdown
-              value={currentStartTime}
-              onSelect={handleStartTimeSelect}
-              options={times}
-              disabled={!isEditMode}
-            />
+            <Dropdown value={currentStartTime} onSelect={handleStartTimeSelect} options={times} />
           </S.TimeSelectWrapper>
           <S.TimeSelectWrapper>
             <Text color='#6E6E6E'>마감시간</Text>
-            <Dropdown
-              value={currentEndTime}
-              onSelect={handleEndTimeSelect}
-              options={times}
-              disabled={!isEditMode}
-            />
+            <Dropdown value={currentEndTime} onSelect={handleEndTimeSelect} options={times} />
           </S.TimeSelectWrapper>
         </S.TimeSelectContainer>
       </S.Container>

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
@@ -21,7 +21,7 @@ type Props = {
   index: number;
   onRemove?: () => void;
 };
-const fieldTypes: QuestionType[] = ['텍스트', '라디오', '체크박스'];
+const fieldTypes: QuestionType[] = ['텍스트', '라디오 (1개선택)', '체크박스 (복수선택)'];
 
 export const FormFieldItem = ({ formHandler, index, onRemove }: Props) => {
   const {
@@ -55,9 +55,9 @@ export const FormFieldItem = ({ formHandler, index, onRemove }: Props) => {
     switch (currentDisplayType) {
       case '텍스트':
         return <TextOptionsBuilder />;
-      case '라디오':
+      case '라디오 (1개선택)':
         return <RadioOptionsBuilder formHandler={formHandler} questionIndex={index} />;
-      case '체크박스':
+      case '체크박스 (복수선택)':
         return <CheckboxOptionsBuilder formHandler={formHandler} questionIndex={index} />;
 
       default:

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
@@ -20,11 +20,10 @@ type Props = {
   formHandler: UseFormReturn<ApplicationFormData>;
   index: number;
   onRemove?: () => void;
-  isEditMode: boolean;
 };
 const fieldTypes: QuestionType[] = ['텍스트', '라디오', '체크박스'];
 
-export const FormFieldItem = ({ formHandler, index, onRemove, isEditMode }: Props) => {
+export const FormFieldItem = ({ formHandler, index, onRemove }: Props) => {
   const {
     watch,
     setValue,
@@ -57,21 +56,9 @@ export const FormFieldItem = ({ formHandler, index, onRemove, isEditMode }: Prop
       case '텍스트':
         return <TextOptionsBuilder />;
       case '라디오':
-        return (
-          <RadioOptionsBuilder
-            formHandler={formHandler}
-            questionIndex={index}
-            isEditMode={isEditMode}
-          />
-        );
+        return <RadioOptionsBuilder formHandler={formHandler} questionIndex={index} />;
       case '체크박스':
-        return (
-          <CheckboxOptionsBuilder
-            formHandler={formHandler}
-            questionIndex={index}
-            isEditMode={isEditMode}
-          />
-        );
+        return <CheckboxOptionsBuilder formHandler={formHandler} questionIndex={index} />;
 
       default:
         return null;
@@ -92,14 +79,12 @@ export const FormFieldItem = ({ formHandler, index, onRemove, isEditMode }: Prop
       <input type='hidden' {...register(`formQuestions.${index}.displayOrder`)} />
       <CommonHeader>
         <Wrapper>
-          {isEditMode && (
-            <IoCloseOutline
-              size={'2rem'}
-              color='#757575'
-              onClick={onRemove}
-              style={{ cursor: 'pointer' }}
-            />
-          )}
+          <IoCloseOutline
+            size={'2rem'}
+            color='#757575'
+            onClick={onRemove}
+            style={{ cursor: 'pointer' }}
+          />
         </Wrapper>
         <Wrapper>
           <OutlineInputField
@@ -110,14 +95,8 @@ export const FormFieldItem = ({ formHandler, index, onRemove, isEditMode }: Prop
             })}
             invalid={!!errors.formQuestions?.[index]?.question}
             message={errors.formQuestions?.[index]?.question?.message}
-            disabled={!isEditMode}
           />
-          <Dropdown
-            value={currentDisplayType}
-            onSelect={handleTypeSelect}
-            options={fieldTypes}
-            disabled={!isEditMode}
-          />
+          <Dropdown value={currentDisplayType} onSelect={handleTypeSelect} options={fieldTypes} />
         </Wrapper>
       </CommonHeader>
 

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
@@ -21,7 +21,14 @@ type Props = {
   index: number;
   onRemove?: () => void;
 };
-const fieldTypes: QuestionType[] = ['텍스트', '라디오 (1개선택)', '체크박스 (복수선택)'];
+const fieldTypes: QuestionType[] = ['텍스트', '라디오', '체크박스'];
+
+// 옵션 목록에서만 선택 방식 안내를 붙여서 보여준다(선택된 값 표시는 짧게 유지).
+const fieldTypeLabels: Record<QuestionType, string> = {
+  텍스트: '텍스트',
+  라디오: '라디오 (1개선택)',
+  체크박스: '체크박스 (복수선택)',
+};
 
 export const FormFieldItem = ({ formHandler, index, onRemove }: Props) => {
   const {
@@ -55,9 +62,9 @@ export const FormFieldItem = ({ formHandler, index, onRemove }: Props) => {
     switch (currentDisplayType) {
       case '텍스트':
         return <TextOptionsBuilder />;
-      case '라디오 (1개선택)':
+      case '라디오':
         return <RadioOptionsBuilder formHandler={formHandler} questionIndex={index} />;
-      case '체크박스 (복수선택)':
+      case '체크박스':
         return <CheckboxOptionsBuilder formHandler={formHandler} questionIndex={index} />;
 
       default:
@@ -96,7 +103,12 @@ export const FormFieldItem = ({ formHandler, index, onRemove }: Props) => {
             invalid={!!errors.formQuestions?.[index]?.question}
             message={errors.formQuestions?.[index]?.question?.message}
           />
-          <Dropdown value={currentDisplayType} onSelect={handleTypeSelect} options={fieldTypes} />
+          <Dropdown
+            value={currentDisplayType}
+            onSelect={handleTypeSelect}
+            options={fieldTypes}
+            getOptionLabel={(option) => fieldTypeLabels[option]}
+          />
         </Wrapper>
       </CommonHeader>
 

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/FormFieldItem/index.tsx
@@ -21,14 +21,7 @@ type Props = {
   index: number;
   onRemove?: () => void;
 };
-const fieldTypes: QuestionType[] = ['텍스트', '라디오', '체크박스'];
-
-// 옵션 목록에서만 선택 방식 안내를 붙여서 보여준다(선택된 값 표시는 짧게 유지).
-const fieldTypeLabels: Record<QuestionType, string> = {
-  텍스트: '텍스트',
-  라디오: '라디오 (1개선택)',
-  체크박스: '체크박스 (복수선택)',
-};
+const fieldTypes: QuestionType[] = ['서술형', '1개 선택', '복수 선택'];
 
 export const FormFieldItem = ({ formHandler, index, onRemove }: Props) => {
   const {
@@ -53,18 +46,18 @@ export const FormFieldItem = ({ formHandler, index, onRemove }: Props) => {
         return reverseTypeMapping[qType];
       case 'TIME_SLOT':
       default:
-        return '텍스트';
+        return '서술형';
     }
   };
   const currentDisplayType = getDisplayType(questionType);
 
   const renderOptionsBuilder = () => {
     switch (currentDisplayType) {
-      case '텍스트':
+      case '서술형':
         return <TextOptionsBuilder />;
-      case '라디오':
+      case '1개 선택':
         return <RadioOptionsBuilder formHandler={formHandler} questionIndex={index} />;
-      case '체크박스':
+      case '복수 선택':
         return <CheckboxOptionsBuilder formHandler={formHandler} questionIndex={index} />;
 
       default:
@@ -103,12 +96,7 @@ export const FormFieldItem = ({ formHandler, index, onRemove }: Props) => {
             invalid={!!errors.formQuestions?.[index]?.question}
             message={errors.formQuestions?.[index]?.question?.message}
           />
-          <Dropdown
-            value={currentDisplayType}
-            onSelect={handleTypeSelect}
-            options={fieldTypes}
-            getOptionLabel={(option) => fieldTypeLabels[option]}
-          />
+          <Dropdown value={currentDisplayType} onSelect={handleTypeSelect} options={fieldTypes} />
         </Wrapper>
       </CommonHeader>
 

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/index.tsx
@@ -8,10 +8,9 @@ import type { ApplicationFormData } from '@/pages/admin/ApplicationFormBuilder/t
 
 type Props = {
   formHandler: UseFormReturn<ApplicationFormData>;
-  isEditMode: boolean;
 };
 
-export const ApplicationFieldsFormTableSection = ({ formHandler, isEditMode }: Props) => {
+export const ApplicationFieldsFormTableSection = ({ formHandler }: Props) => {
   const { control } = formHandler;
 
   const { fields, append, remove } = useFieldArray({
@@ -37,22 +36,13 @@ export const ApplicationFieldsFormTableSection = ({ formHandler, isEditMode }: P
         <div key={data.id}>
           {index !== 0 && <Divider />}
           {data.fieldType === 'TIME_SLOT' ? (
-            <TimeslotFieldBuilder
-              formHandler={formHandler}
-              questionIndex={index}
-              isEditMode={isEditMode}
-            />
+            <TimeslotFieldBuilder formHandler={formHandler} questionIndex={index} />
           ) : (
-            <FormFieldItem
-              index={index}
-              formHandler={formHandler}
-              onRemove={() => remove(index)}
-              isEditMode={isEditMode}
-            />
+            <FormFieldItem index={index} formHandler={formHandler} onRemove={() => remove(index)} />
           )}
         </div>
       ))}
-      {isEditMode && <AddFieldButton onClick={handleAddFormField} />}
+      <AddFieldButton onClick={handleAddFormField} />
     </>
   );
 };

--- a/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FieldsFormTableSection/index.tsx
@@ -1,7 +1,9 @@
 import type { UseFormReturn } from 'react-hook-form';
 import styled from '@emotion/styled';
+import { useState } from 'react';
 import { useFieldArray } from 'react-hook-form';
 import { AddFieldButton } from './AddFieldButton';
+import { DeleteQuestionModal } from './DeleteQuestionModal';
 import { FormFieldItem } from './FormFieldItem';
 import { TimeslotFieldBuilder } from './FormFieldItem/Builders/TimeslotFieldBuilder';
 import type { ApplicationFormData } from '@/pages/admin/ApplicationFormBuilder/types/fieldType';
@@ -11,12 +13,34 @@ type Props = {
 };
 
 export const ApplicationFieldsFormTableSection = ({ formHandler }: Props) => {
-  const { control } = formHandler;
+  const { control, getValues } = formHandler;
+  const [deleteTargetIndex, setDeleteTargetIndex] = useState<number | null>(null);
 
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'formQuestions',
   });
+
+  // 작성된 내용이 없는 질문은 확인 없이 바로 삭제한다.
+  const isEmptyQuestion = (index: number) => {
+    const question = getValues(`formQuestions.${index}`);
+    return !question.question && (question.optionList ?? []).every((option) => !option.value);
+  };
+
+  const handleRemoveRequest = (index: number) => {
+    if (isEmptyQuestion(index)) {
+      remove(index);
+      return;
+    }
+    setDeleteTargetIndex(index);
+  };
+
+  const handleConfirmRemove = () => {
+    if (deleteTargetIndex !== null) {
+      remove(deleteTargetIndex);
+    }
+    setDeleteTargetIndex(null);
+  };
 
   const handleAddFormField = () => {
     append({
@@ -38,11 +62,21 @@ export const ApplicationFieldsFormTableSection = ({ formHandler }: Props) => {
           {data.fieldType === 'TIME_SLOT' ? (
             <TimeslotFieldBuilder formHandler={formHandler} questionIndex={index} />
           ) : (
-            <FormFieldItem index={index} formHandler={formHandler} onRemove={() => remove(index)} />
+            <FormFieldItem
+              index={index}
+              formHandler={formHandler}
+              onRemove={() => handleRemoveRequest(index)}
+            />
           )}
         </div>
       ))}
       <AddFieldButton onClick={handleAddFormField} />
+
+      <DeleteQuestionModal
+        isOpen={deleteTargetIndex !== null}
+        onClose={() => setDeleteTargetIndex(null)}
+        onConfirm={handleConfirmRemove}
+      />
     </>
   );
 };

--- a/src/pages/admin/ApplicationFormBuilder/components/FormActionsSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormActionsSection/index.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import { Button } from '@/shared/components/Button';
+
+type Props = {
+  onCancel: () => void;
+  onSave: () => void;
+};
+
+export const ApplicationFormActionsSection = ({ onCancel, onSave }: Props) => {
+  return (
+    <Layout>
+      <Button variant='outline' width='4rem' onClick={onCancel}>
+        취소
+      </Button>
+      <Button width='6rem' onClick={onSave}>
+        저장하기
+      </Button>
+    </Layout>
+  );
+};
+
+const Layout = styled.div(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '0.5rem',
+  width: '100%',
+  marginTop: '1rem',
+
+  [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    marginTop: '0.5rem',
+  },
+}));

--- a/src/pages/admin/ApplicationFormBuilder/components/FormActionsSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormActionsSection/index.tsx
@@ -9,24 +9,27 @@ type Props = {
 export const ApplicationFormActionsSection = ({ onCancel, onSave }: Props) => {
   return (
     <Layout>
-      <Button variant='outline' width='4rem' onClick={onCancel}>
+      <Button variant='outline' onClick={onCancel}>
         취소
       </Button>
-      <Button width='6rem' onClick={onSave}>
-        저장하기
-      </Button>
+      <Button onClick={onSave}>저장하기</Button>
     </Layout>
   );
 };
 
 const Layout = styled.div(({ theme }) => ({
   display: 'flex',
-  justifyContent: 'flex-end',
-  gap: '0.5rem',
+  gap: '1.5rem',
   width: '100%',
   marginTop: '1rem',
 
+  '& > *': {
+    width: 'auto',
+    flex: '1 1 0',
+  },
+
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {
+    gap: '1rem',
     marginTop: '0.5rem',
   },
 }));

--- a/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.styled.ts
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div(({ theme }) => ({
+  width: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '0.75rem',
+  marginTop: '2.5rem',
+  padding: '0.75rem 0.75rem 0.75rem 1rem',
+  borderRadius: theme.radius.md,
+  backgroundColor: theme.colors.bgGreen,
+  border: `1px solid ${theme.colors.border}`,
+  boxSizing: 'border-box',
+}));
+
+export const LinkInfo = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.125rem',
+  minWidth: 0,
+  textAlign: 'left',
+});
+
+export const LinkLabel = styled.span(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.25rem',
+  fontSize: theme.font.size.xs,
+  color: theme.colors.gray500,
+}));
+
+export const LinkText = styled.span(({ theme }) => ({
+  fontSize: theme.font.size.base,
+  fontWeight: theme.font.weight.bold,
+  color: theme.colors.gray900,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}));
+
+export const CopyButton = styled.button(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.25rem',
+  padding: '0.5rem 0.875rem',
+  border: 'none',
+  borderRadius: theme.radius.sm,
+  backgroundColor: theme.colors.primary,
+  color: theme.colors.bg,
+  fontSize: theme.font.size.sm,
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+
+  ':hover': {
+    backgroundColor: theme.colors.primary700,
+  },
+}));

--- a/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.styled.ts
@@ -1,6 +1,28 @@
 import styled from '@emotion/styled';
 
+export const Tooltip = styled.span(({ theme }) => ({
+  position: 'absolute',
+  top: 'calc(100% + 0.5rem)',
+  right: 0,
+  width: 'max-content',
+  maxWidth: '100%',
+  padding: '0.5rem 0.75rem',
+  borderRadius: theme.radius.sm,
+  backgroundColor: theme.colors.gray800,
+  color: theme.colors.bg,
+  fontSize: theme.font.size.xs,
+  lineHeight: 1.5,
+  boxShadow: theme.shadow.sm,
+  opacity: 0,
+  visibility: 'hidden',
+  transition: 'opacity 0.15s ease',
+  pointerEvents: 'none',
+  zIndex: 1,
+  boxSizing: 'border-box',
+}));
+
 export const Container = styled.div(({ theme }) => ({
+  position: 'relative',
   width: '100%',
   display: 'flex',
   alignItems: 'center',
@@ -12,6 +34,11 @@ export const Container = styled.div(({ theme }) => ({
   backgroundColor: theme.colors.bgGreen,
   border: `1px solid ${theme.colors.border}`,
   boxSizing: 'border-box',
+
+  [`&:hover ${Tooltip}, &:focus-within ${Tooltip}`]: {
+    opacity: 1,
+    visibility: 'visible',
+  },
 }));
 
 export const LinkInfo = styled.div({

--- a/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.styled.ts
@@ -6,7 +6,7 @@ export const Container = styled.div(({ theme }) => ({
   alignItems: 'center',
   justifyContent: 'space-between',
   gap: '0.75rem',
-  marginTop: '2.5rem',
+  margin: '2.5rem 0 0.5rem 0',
   padding: '0.75rem 0.75rem 0.75rem 1rem',
   borderRadius: theme.radius.md,
   backgroundColor: theme.colors.bgGreen,

--- a/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.tsx
@@ -1,4 +1,5 @@
 import { FiCopy, FiLink } from 'react-icons/fi';
+import { copyToClipboard } from '@/shared/utils/copyToClipboard';
 import { toast } from '@/shared/utils/toast';
 import * as S from './index.styled';
 
@@ -7,13 +8,15 @@ type Props = {
 };
 
 export const ApplicationFormLinkCopySection = ({ clubId }: Props) => {
+  if (Number.isNaN(clubId)) return null;
+
   const formLink = `${window.location.origin}/clubs/${clubId}/apply`;
 
   const handleCopyLink = async () => {
-    try {
-      await navigator.clipboard.writeText(formLink);
+    const copied = await copyToClipboard(formLink);
+    if (copied) {
       toast.success('지원폼 링크가 복사되었습니다.');
-    } catch {
+    } else {
       toast.error('지원폼 링크 복사에 실패했습니다.');
     }
   };

--- a/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.tsx
@@ -1,0 +1,36 @@
+import { FiCopy, FiLink } from 'react-icons/fi';
+import { toast } from '@/shared/utils/toast';
+import * as S from './index.styled';
+
+type Props = {
+  clubId: number;
+};
+
+export const ApplicationFormLinkCopySection = ({ clubId }: Props) => {
+  const formLink = `${window.location.origin}/clubs/${clubId}/apply`;
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(formLink);
+      toast.success('지원폼 링크가 복사되었습니다.');
+    } catch {
+      toast.error('지원폼 링크 복사에 실패했습니다.');
+    }
+  };
+
+  return (
+    <S.Container>
+      <S.LinkInfo>
+        <S.LinkLabel>
+          <FiLink aria-hidden />
+          지원폼 공유 링크
+        </S.LinkLabel>
+        <S.LinkText>{formLink}</S.LinkText>
+      </S.LinkInfo>
+      <S.CopyButton type='button' onClick={handleCopyLink} aria-label='지원폼 링크 복사'>
+        <FiCopy />
+        복사
+      </S.CopyButton>
+    </S.Container>
+  );
+};

--- a/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/FormLinkCopySection/index.tsx
@@ -31,6 +31,9 @@ export const ApplicationFormLinkCopySection = ({ clubId }: Props) => {
         <FiCopy />
         복사
       </S.CopyButton>
+      <S.Tooltip role='tooltip'>
+        복사하지 않아도 동아리움에서는 지원 시기에 맞게 지원하기 버튼이 활성화 돼요!
+      </S.Tooltip>
     </S.Container>
   );
 };

--- a/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.styled.ts
@@ -5,7 +5,6 @@ export const Container = styled.div(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   gap: '2rem',
-  padding: '2.5rem 0 0 0',
   boxSizing: 'border-box',
 
   [`@media (max-width: ${theme.breakpoints.mobile})`]: {

--- a/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.styled.ts
+++ b/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.styled.ts
@@ -18,11 +18,6 @@ export const HeaderWrapper = styled.div({
   alignItems: 'center',
 });
 
-export const ButtonWrapper = styled.div({
-  display: 'flex',
-  gap: '0.5rem',
-});
-
 export const Title = styled.h1(({ theme }) => ({
   fontSize: '2.5rem',
   fontWeight: theme.font.weight.medium,

--- a/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.tsx
+++ b/src/pages/admin/ApplicationFormBuilder/components/HeaderSection/index.tsx
@@ -1,23 +1,14 @@
-import { Button } from '@/shared/components/Button';
 import { GuideIconButton } from '@/shared/components/GuideIconButton';
 import { Text } from '@/shared/components/Text';
 import * as S from './index.styled';
 
 type Props = {
-  isEditMode: boolean;
-  onEdit: () => void;
-  onSave: () => void;
-  onCancel: () => void;
   isInterviewMode: boolean;
   onInterviewChange: (checked: boolean) => void;
   onOpenGuide?: () => void;
 };
 
 export const ApplicationFormBuilderHeaderSection = ({
-  isEditMode,
-  onEdit,
-  onSave,
-  onCancel,
   isInterviewMode,
   onInterviewChange,
   onOpenGuide,
@@ -29,38 +20,16 @@ export const ApplicationFormBuilderHeaderSection = ({
           <S.Title>지원폼 생성</S.Title>
           {onOpenGuide && <GuideIconButton onClick={onOpenGuide} />}
         </S.TitleWrapper>
-        {isEditMode ? (
-          <S.ButtonWrapper>
-            <Button variant='outline' width='4rem' onClick={onCancel}>
-              취소
-            </Button>
-            <Button width='6rem' onClick={onSave}>
-              저장하기
-            </Button>
-          </S.ButtonWrapper>
-        ) : (
-          <Button variant='outline' width='6rem' onClick={onEdit}>
-            수정하기
-          </Button>
-        )}
       </S.HeaderWrapper>
       <S.CheckboxWrapper>
-        {isEditMode ? (
-          <>
-            <S.CustomCheckbox
-              type='checkbox'
-              checked={isInterviewMode}
-              onChange={(e) => onInterviewChange(e.target.checked)}
-            />
-            <Text size='sm' weight='bold' color='#339356'>
-              면접 전형을 진행하시면 체크박스를 눌러주세요!
-            </Text>
-          </>
-        ) : (
-          <Text size='sm' weight='bold' color='#339356'>
-            면접날짜는 타임 슬롯을 이용해서 안내할 수 있어요!
-          </Text>
-        )}
+        <S.CustomCheckbox
+          type='checkbox'
+          checked={isInterviewMode}
+          onChange={(e) => onInterviewChange(e.target.checked)}
+        />
+        <Text size='sm' weight='bold' color='#339356'>
+          면접 전형을 진행하시면 체크박스를 눌러주세요!
+        </Text>
       </S.CheckboxWrapper>
     </S.Container>
   );

--- a/src/pages/admin/ApplicationFormBuilder/types/fieldType.ts
+++ b/src/pages/admin/ApplicationFormBuilder/types/fieldType.ts
@@ -1,4 +1,4 @@
-export type QuestionType = '텍스트' | '라디오' | '체크박스';
+export type QuestionType = '텍스트' | '라디오 (1개선택)' | '체크박스 (복수선택)';
 
 type TimeSlotOption = {
   date: string;

--- a/src/pages/admin/ApplicationFormBuilder/types/fieldType.ts
+++ b/src/pages/admin/ApplicationFormBuilder/types/fieldType.ts
@@ -1,4 +1,4 @@
-export type QuestionType = '텍스트' | '라디오 (1개선택)' | '체크박스 (복수선택)';
+export type QuestionType = '텍스트' | '라디오' | '체크박스';
 
 type TimeSlotOption = {
   date: string;

--- a/src/pages/admin/ApplicationFormBuilder/types/fieldType.ts
+++ b/src/pages/admin/ApplicationFormBuilder/types/fieldType.ts
@@ -1,4 +1,4 @@
-export type QuestionType = '텍스트' | '라디오' | '체크박스';
+export type QuestionType = '서술형' | '1개 선택' | '복수 선택';
 
 type TimeSlotOption = {
   date: string;

--- a/src/pages/admin/ApplicationFormBuilder/utils/typeMapping.ts
+++ b/src/pages/admin/ApplicationFormBuilder/utils/typeMapping.ts
@@ -2,12 +2,12 @@ import type { QuestionType } from '../types/fieldType';
 
 export const typeMapping: Record<QuestionType, 'TEXT' | 'RADIO' | 'CHECKBOX'> = {
   텍스트: 'TEXT',
-  라디오: 'RADIO',
-  체크박스: 'CHECKBOX',
+  '라디오 (1개선택)': 'RADIO',
+  '체크박스 (복수선택)': 'CHECKBOX',
 };
 
 export const reverseTypeMapping: Record<'TEXT' | 'RADIO' | 'CHECKBOX', QuestionType> = {
   TEXT: '텍스트',
-  RADIO: '라디오',
-  CHECKBOX: '체크박스',
+  RADIO: '라디오 (1개선택)',
+  CHECKBOX: '체크박스 (복수선택)',
 };

--- a/src/pages/admin/ApplicationFormBuilder/utils/typeMapping.ts
+++ b/src/pages/admin/ApplicationFormBuilder/utils/typeMapping.ts
@@ -2,12 +2,12 @@ import type { QuestionType } from '../types/fieldType';
 
 export const typeMapping: Record<QuestionType, 'TEXT' | 'RADIO' | 'CHECKBOX'> = {
   텍스트: 'TEXT',
-  '라디오 (1개선택)': 'RADIO',
-  '체크박스 (복수선택)': 'CHECKBOX',
+  라디오: 'RADIO',
+  체크박스: 'CHECKBOX',
 };
 
 export const reverseTypeMapping: Record<'TEXT' | 'RADIO' | 'CHECKBOX', QuestionType> = {
   TEXT: '텍스트',
-  RADIO: '라디오 (1개선택)',
-  CHECKBOX: '체크박스 (복수선택)',
+  RADIO: '라디오',
+  CHECKBOX: '체크박스',
 };

--- a/src/pages/admin/ApplicationFormBuilder/utils/typeMapping.ts
+++ b/src/pages/admin/ApplicationFormBuilder/utils/typeMapping.ts
@@ -1,13 +1,13 @@
 import type { QuestionType } from '../types/fieldType';
 
 export const typeMapping: Record<QuestionType, 'TEXT' | 'RADIO' | 'CHECKBOX'> = {
-  텍스트: 'TEXT',
-  라디오: 'RADIO',
-  체크박스: 'CHECKBOX',
+  서술형: 'TEXT',
+  '1개 선택': 'RADIO',
+  '복수 선택': 'CHECKBOX',
 };
 
 export const reverseTypeMapping: Record<'TEXT' | 'RADIO' | 'CHECKBOX', QuestionType> = {
-  TEXT: '텍스트',
-  RADIO: '라디오',
-  CHECKBOX: '체크박스',
+  TEXT: '서술형',
+  RADIO: '1개 선택',
+  CHECKBOX: '복수 선택',
 };

--- a/src/shared/components/Dropdown/index.styled.ts
+++ b/src/shared/components/Dropdown/index.styled.ts
@@ -20,6 +20,8 @@ export const SelectBox = styled.div<{ disabled: boolean }>(({ theme, disabled })
   border: `1px solid ${theme.colors.gray200}`,
   minWidth: '9rem',
   boxSizing: 'border-box',
+  // 선택된 라벨이 길어도 줄바꿈 없이 박스가 내용 폭만큼 늘어나도록 한다.
+  whiteSpace: 'nowrap',
 
   '&::before': {
     content: '"⌵"',
@@ -44,7 +46,10 @@ export const SelectOptions = styled.ul(({ theme }) => ({
   maxHeight: '12.5rem',
   overflowY: 'auto',
   zIndex: 100,
-  width: '90%',
+  // 가장 긴 옵션 기준으로 넓어지되 최소한 셀렉트 박스 폭은 유지한다.
+  width: 'max-content',
+  minWidth: '100%',
+  boxSizing: 'border-box',
   border: `1px solid ${theme.colors.gray200}`,
   borderRadius: theme.radius.md,
   backgroundColor: `${theme.colors.bg}`,

--- a/src/shared/components/Dropdown/index.styled.ts
+++ b/src/shared/components/Dropdown/index.styled.ts
@@ -12,7 +12,8 @@ export const SelectBox = styled.div<{ disabled: boolean }>(({ theme, disabled })
   position: 'relative',
   width: '100%',
   height: '2.65rem',
-  padding: '10px',
+  // 오른쪽은 ::before 화살표(⌵) 영역과 겹치지 않도록 여유를 둔다.
+  padding: '10px 2.2rem 10px 10px',
   borderRadius: theme.radius.md,
   backgroundColor: disabled ? theme.colors.gray00 : theme.colors.bg,
   alignSelf: 'center',

--- a/src/shared/components/Dropdown/index.tsx
+++ b/src/shared/components/Dropdown/index.tsx
@@ -8,8 +8,6 @@ type Props<T extends string> = {
   placeholder?: string;
   onSelect: (value: T) => void;
   disabled?: boolean;
-  // 옵션 목록에 표시할 라벨을 값과 다르게 지정할 때 사용한다(선택된 값 표시는 value 그대로).
-  getOptionLabel?: (option: T) => string;
 };
 
 export const Dropdown = <T extends string>({
@@ -18,7 +16,6 @@ export const Dropdown = <T extends string>({
   placeholder,
   onSelect,
   disabled = false,
-  getOptionLabel,
 }: Props<T>) => {
   const [isShowOptions, setIsShowOptions] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -62,7 +59,7 @@ export const Dropdown = <T extends string>({
                 onClick={() => handleSelectOption(option)}
                 selected={value === option}
               >
-                {getOptionLabel ? getOptionLabel(option) : option}
+                {option}
               </S.Option>
             ))}
           </S.SelectOptions>

--- a/src/shared/components/Dropdown/index.tsx
+++ b/src/shared/components/Dropdown/index.tsx
@@ -8,6 +8,8 @@ type Props<T extends string> = {
   placeholder?: string;
   onSelect: (value: T) => void;
   disabled?: boolean;
+  // 옵션 목록에 표시할 라벨을 값과 다르게 지정할 때 사용한다(선택된 값 표시는 value 그대로).
+  getOptionLabel?: (option: T) => string;
 };
 
 export const Dropdown = <T extends string>({
@@ -16,6 +18,7 @@ export const Dropdown = <T extends string>({
   placeholder,
   onSelect,
   disabled = false,
+  getOptionLabel,
 }: Props<T>) => {
   const [isShowOptions, setIsShowOptions] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -59,7 +62,7 @@ export const Dropdown = <T extends string>({
                 onClick={() => handleSelectOption(option)}
                 selected={value === option}
               >
-                {option}
+                {getOptionLabel ? getOptionLabel(option) : option}
               </S.Option>
             ))}
           </S.SelectOptions>

--- a/src/shared/components/Footer/index.tsx
+++ b/src/shared/components/Footer/index.tsx
@@ -6,6 +6,7 @@ import { ROUTE_PATH } from '@/app/constants/routerPath';
 import { SPONSOR_ACCOUNT } from '@/app/constants/sponsor';
 import { Modal } from '@/shared/components/Modal';
 import { useModal } from '@/shared/hooks/useModal';
+import { copyToClipboard } from '@/shared/utils/copyToClipboard';
 import { toast } from '@/shared/utils/toast';
 import * as S from './index.styled';
 
@@ -18,10 +19,10 @@ const Footer = () => {
     matchPath(`/${ROUTE_PATH.USER.APPLICATION}`, pathname) !== null;
 
   const handleCopyAccount = async () => {
-    try {
-      await navigator.clipboard.writeText(SPONSOR_ACCOUNT.number);
+    const copied = await copyToClipboard(SPONSOR_ACCOUNT.number);
+    if (copied) {
       toast.success('계좌번호가 복사되었습니다.');
-    } catch {
+    } else {
       toast.error('계좌번호 복사에 실패했습니다.');
     }
   };

--- a/src/shared/utils/copyToClipboard.ts
+++ b/src/shared/utils/copyToClipboard.ts
@@ -1,10 +1,30 @@
+// HTTPS가 아니거나 구형 브라우저라 navigator.clipboard를 쓸 수 없을 때의 fallback.
+const copyWithExecCommand = (text: string): boolean => {
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.style.position = 'absolute';
+  textArea.style.opacity = '0';
+  document.body.appendChild(textArea);
+  textArea.select();
+
+  try {
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textArea);
+  }
+};
+
 export const copyToClipboard = async (text: string): Promise<boolean> => {
-  if (!navigator.clipboard) return false;
+  if (!navigator.clipboard || !window.isSecureContext) {
+    return copyWithExecCommand(text);
+  }
 
   try {
     await navigator.clipboard.writeText(text);
     return true;
   } catch {
-    return false;
+    return copyWithExecCommand(text);
   }
 };

--- a/src/shared/utils/copyToClipboard.ts
+++ b/src/shared/utils/copyToClipboard.ts
@@ -1,0 +1,10 @@
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  if (!navigator.clipboard) return false;
+
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #498

## 📝작업 내용

지원폼 관리 페이지의 `수정하기` 버튼 기반 편집 모드 전환 구조를 제거하고, 페이지 진입 시 바로 모든 항목을 수정할 수 있도록 변경했습니다. 액션 버튼은 페이지 최하단으로 이동했습니다.

- `isEditMode` 상태 및 전 섹션(정보/필드/빌더)에 전파되던 prop 제거 — 모든 입력·드롭다운·옵션 추가/삭제가 항상 활성화
- 상단 헤더의 수정하기/취소/저장하기 버튼 제거, 면접 전형 체크박스는 항상 노출
- 최하단에 `FormActionsSection` 추가 — 공유 `Button` 컴포넌트(`variant='outline'` 취소 / 기본 저장하기)를 기존 헤더 버튼과 동일한 스펙으로 사용
- 취소 시 서버 데이터 기준으로 폼 리셋, 저장 성공 시 토스트 피드백 추가 (편집 모드 종료라는 시각적 피드백이 사라진 것을 대체)

## 💬리뷰 요구사항(선택)

> 이 브랜치는 #497 (지원폼 링크 복사) 위에 쌓여 있습니다. **#497을 먼저 머지한 뒤** 이 PR을 머지해주세요.
> 안정성 점검: `tsc`·ESLint·프로덕션 빌드 통과 확인, vitest 실패 3건은 develop에서도 동일하게 실패하는 기존 auth 테스트로 이번 변경과 무관합니다.