### PR TITLE
[FIX] 모집 기간이 아닌 동아리 지원폼 URL 직접 접근 시 안내 화면 표시 (#500)

### DIFF
--- a/src/pages/user/Apply/Page.tsx
+++ b/src/pages/user/Apply/Page.tsx
@@ -1,20 +1,35 @@
 import styled from '@emotion/styled';
 import { useParams } from 'react-router-dom';
 import { ClubDescription } from '@/pages/user/Apply/components/ClubDescriptionSection';
+import { useClubDetail } from '@/pages/user/ClubDetail/hooks/useClubDetail';
 import { ApplicationForm } from './components/ApplicationForm';
+import { RecruitClosedSection } from './components/RecruitClosedSection';
 import { useApplicationForm } from './hooks/useApplicationForm';
+
+// 모집중일 때만 마운트되어 지원폼을 조회한다(모집 기간 외에는 폼 API를 호출하지 않는다).
+const ApplicationFormContent = ({ clubId }: { clubId: number }) => {
+  const formData = useApplicationForm(clubId);
+
+  return (
+    <ContentContainer>
+      <ClubDescription title={formData.title} description={formData?.description ?? ''} />
+      <ApplicationForm questions={formData.formQuestions} clubName={formData.title} />
+    </ContentContainer>
+  );
+};
 
 export const ClubApplicationPage = () => {
   const { clubId } = useParams();
-
-  const formData = useApplicationForm(Number(clubId));
+  const club = useClubDetail(Number(clubId));
+  const isRecruiting = club.recruitStatus === '모집중';
 
   return (
     <Layout>
-      <ContentContainer>
-        <ClubDescription title={formData.title} description={formData?.description ?? ''} />
-        <ApplicationForm questions={formData.formQuestions} clubName={formData.title} />
-      </ContentContainer>
+      {isRecruiting ? (
+        <ApplicationFormContent clubId={Number(clubId)} />
+      ) : (
+        <RecruitClosedSection clubId={Number(clubId)} />
+      )}
     </Layout>
   );
 };

--- a/src/pages/user/Apply/components/RecruitClosedSection/index.styled.ts
+++ b/src/pages/user/Apply/components/RecruitClosedSection/index.styled.ts
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '70vh',
+  textAlign: 'center',
+  color: theme.colors.textPrimary,
+}));
+
+export const Logo = styled.img(() => ({
+  width: '200px',
+  marginBottom: '24px',
+}));
+
+export const Message = styled.h2(({ theme }) => ({
+  fontSize: theme.font.size.lg,
+  fontWeight: theme.font.weight.bold,
+  marginBottom: '12px',
+  color: theme.colors.textPrimary,
+}));
+
+export const SubText = styled.p(({ theme }) => ({
+  fontSize: theme.font.size.base,
+  color: theme.colors.gray500,
+  marginBottom: '24px',
+}));

--- a/src/pages/user/Apply/components/RecruitClosedSection/index.tsx
+++ b/src/pages/user/Apply/components/RecruitClosedSection/index.tsx
@@ -1,0 +1,19 @@
+import { Button } from '@/shared/components/Button';
+import * as S from './index.styled';
+
+type Props = {
+  clubId: number;
+};
+
+export const RecruitClosedSection = ({ clubId }: Props) => {
+  return (
+    <S.Container>
+      <S.Logo src='/assets/logo.png' alt='Dongari-um 로고' />
+      <S.Message>지금은 지원 기간이 아니에요.</S.Message>
+      <S.SubText>모집이 시작되면 동아리 상세 페이지에서 다시 지원할 수 있어요.</S.SubText>
+      <Button to={`/clubs/${clubId}`} width='15rem'>
+        동아리 상세로 돌아가기
+      </Button>
+    </S.Container>
+  );
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #500

## 📝작업 내용

모집 기간이 아닌 동아리의 지원폼 URL(`/clubs/:clubId/apply`)에 직접 접근하면 지원서 작성 폼이 그대로 노출되던 문제를 수정했습니다.

| 원인 | 해결 |
|------|------|
| 지원 페이지가 모집 상태 검증 없이 지원폼을 조회·렌더링 | 기존 `useClubDetail` 훅으로 `recruitStatus`를 확인해 `모집중`이 아니면 안내 화면(`RecruitClosedSection`)을 렌더링 |

- `RecruitClosedSection` 신규 추가 — 기존 `EmptyState`와 동일한 레이아웃·토큰(로고/메시지/서브텍스트) + 공유 `Button`으로 동아리 상세 복귀 동선 제공
- 모집 기간이 아닐 때는 지원폼 API(`GET /clubs/:clubId/apply`) 자체를 호출하지 않도록 폼 조회를 하위 컴포넌트로 분리 (백엔드가 추후 기간 검증 에러를 반환해도 안전)
- 모집 상태 판정은 서버가 내려주는 `recruitStatus` 기준이므로 클라이언트 시간 계산에 의존하지 않음

## 💬리뷰 요구사항(선택)

> 백엔드의 `GET /clubs/:clubId/apply`·`POST /clubs/:clubId/apply-submit`에도 모집 기간 검증이 있는지 별도 확인이 필요합니다. 프론트 차단은 UX 개선이며, 최종 방어는 서버 검증이 담당해야 합니다.