### PR TITLE
[FEAT] 메인 화면 동아리 카드에 실시간 인기 배지 연동 (#502, 503)

### DIFF
--- a/src/app/api/initInstance.ts
+++ b/src/app/api/initInstance.ts
@@ -25,6 +25,10 @@ export const apiInstance = initInstance({
   baseURL: import.meta.env.VITE_API_BASE_URL,
 });
 
+export const publicApiInstance = initInstance({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+});
+
 apiInstance.interceptors.request.use((config) => {
   const token = getAccessToken();
   if (token) {

--- a/src/app/mocks/handler/club.ts
+++ b/src/app/mocks/handler/club.ts
@@ -1,11 +1,16 @@
 import { http, HttpResponse, type PathParams } from 'msw';
 import { ApplicationRepository } from '@/app/mocks/repositories/application.ts';
-import { clubRepository, clubReviewRepository } from '../repositories/club';
+import { clubRepository, clubReviewRepository, popularClubRepository } from '../repositories/club';
 
 const getClubsResolver = ({ request }: { request: Request }) => {
   const url = new URL(request.url);
   const categoryName = url.searchParams.get('category') ?? 'all';
   const clubs = clubRepository.getClubsByCategory(categoryName);
+  return HttpResponse.json({ clubs }, { status: 200 });
+};
+
+const getPopularClubsResolver = () => {
+  const clubs = popularClubRepository.getPopularClubs();
   return HttpResponse.json({ clubs }, { status: 200 });
 };
 
@@ -121,6 +126,8 @@ const putClubImagesResolver = async ({
 
 export const clubHandlers = [
   http.get(import.meta.env.VITE_API_BASE_URL + '/clubs?category', getClubsResolver),
+  // '/clubs/:clubId'보다 반드시 앞에 등록한다. 뒤에 두면 popular가 clubId로 잡힌다.
+  http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/popular', getPopularClubsResolver),
   http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/:Id/apply', getClubApplicationResolver),
   http.post(
     import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/apply-submit',

--- a/src/app/mocks/repositories/club.ts
+++ b/src/app/mocks/repositories/club.ts
@@ -410,8 +410,6 @@ export const popularClubRepository = {
   getPopularClubs: (): PopularClub[] =>
     clubs
       .map((club) => {
-        // 일부 동아리만 인기 기준을 넘도록 id로 갈라둔다. 전부 배지가 붙으면 반환 필터도,
-        // 배지가 없는 카드의 레이아웃도 검증할 수 없다.
         const isRecentPopular = club.id % 3 === 0;
         const isActivePopular = club.id % 5 === 0;
 

--- a/src/app/mocks/repositories/club.ts
+++ b/src/app/mocks/repositories/club.ts
@@ -1,6 +1,7 @@
 import type { ClubDetail } from '@/pages/user/ClubDetail/types/clubDetail';
 import type { ClubReview, PostClubReviewRequest } from '@/pages/user/ClubDetail/types/review';
 import type { Club } from '@/pages/user/Main/types/club';
+import type { PopularClub } from '@/pages/user/Main/types/popularClub';
 
 export const clubs: Club[] = [
   // 문예
@@ -400,6 +401,33 @@ export const mockClubReviews: Record<number, ClubReview[]> = {
       createdAt: '2025-10-11T12:00:00Z',
     },
   ],
+};
+
+const RECENT_VIEWER_THRESHOLD = 10;
+const ACTIVE_VIEWER_THRESHOLD = 3;
+
+export const popularClubRepository = {
+  getPopularClubs: (): PopularClub[] =>
+    clubs
+      .map((club) => {
+        // 일부 동아리만 인기 기준을 넘도록 id로 갈라둔다. 전부 배지가 붙으면 반환 필터도,
+        // 배지가 없는 카드의 레이아웃도 검증할 수 없다.
+        const isRecentPopular = club.id % 3 === 0;
+        const isActivePopular = club.id % 5 === 0;
+
+        const recentViewerCount = isRecentPopular ? ((club.id * 7) % 40) + 10 : (club.id * 5) % 10;
+        const activeViewerCount = isActivePopular ? (club.id % 6) + 3 : club.id % 3;
+
+        return {
+          clubId: club.id,
+          recentViewerCount,
+          activeViewerCount,
+          recentViewerBadge: recentViewerCount >= RECENT_VIEWER_THRESHOLD,
+          activeViewerBadge: activeViewerCount >= ACTIVE_VIEWER_THRESHOLD,
+        };
+      })
+
+      .filter((club) => club.recentViewerBadge || club.activeViewerBadge),
 };
 
 export const clubRepository = {

--- a/src/pages/user/Main/api/popularClub.ts
+++ b/src/pages/user/Main/api/popularClub.ts
@@ -1,0 +1,16 @@
+import { publicApiInstance } from '@/app/api/initInstance';
+import { handleAxiosError } from '@/shared/utils/handleAxiosError';
+import type { PopularClub } from '@/pages/user/Main/types/popularClub';
+
+export type PopularClubsResponse = {
+  clubs: PopularClub[];
+};
+
+export const getPopularClubs = async (): Promise<PopularClubsResponse> => {
+  try {
+    const { data } = await publicApiInstance.get('/clubs/popular');
+    return data;
+  } catch (error: unknown) {
+    return handleAxiosError(error, '인기 동아리 조회 실패');
+  }
+};

--- a/src/pages/user/Main/components/ClubListSection/Club.styled.ts
+++ b/src/pages/user/Main/components/ClubListSection/Club.styled.ts
@@ -53,7 +53,7 @@ export const TodayViewCount = styled.div(({ theme }) => ({
   fontWeight: theme.font.weight.regular,
   color: theme.colors.gray500,
   whiteSpace: 'nowrap',
-  marginLeft: 'auto', // 보는 중 배지가 없어도 항상 우측 정렬
+  marginLeft: 'auto',
 }));
 
 export const ClubNameText = styled.div(({ theme }) => ({
@@ -140,8 +140,6 @@ export const Grid = styled.div(({ theme }) => ({
   display: 'grid',
   gap: 30,
   padding: '30px 0',
-  // 최소 폭 320px → 1200px 컨테이너에서 3열, 좁아지면 2열/1열로 자동 축소
-  // min(320px, 100%)로 감싸 초소형 화면에서 트랙이 넘치지 않도록 함
   gridTemplateColumns: 'repeat(auto-fill, minmax(min(320px, 100%), 1fr))',
   justifyContent: 'center',
   justifyItems: 'center',

--- a/src/pages/user/Main/components/ClubListSection/Club.styled.ts
+++ b/src/pages/user/Main/components/ClubListSection/Club.styled.ts
@@ -1,11 +1,60 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import type { RecruitStatus } from '@/pages/user/Main/types/club';
+
+export const ClubHeader = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '8px',
+});
 
 export const ClubNameContainer = styled.div({
   display: 'flex',
   alignItems: 'center',
   gap: '6px',
+  minWidth: 0,
 });
+
+const pulse = keyframes({
+  '0%': { transform: 'scale(1)', opacity: 1 },
+  '50%': { transform: 'scale(1.25)', opacity: 0.5 },
+  '100%': { transform: 'scale(1)', opacity: 1 },
+});
+
+export const LiveViewerBadge = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  flexShrink: 0,
+  fontSize: theme.font.size.xs,
+  fontWeight: theme.font.weight.medium,
+  color: theme.colors.textSecondary,
+  whiteSpace: 'nowrap',
+}));
+
+export const LiveDot = styled.span(({ theme }) => ({
+  width: '6px',
+  height: '6px',
+  borderRadius: '50%',
+  backgroundColor: theme.colors.primary600,
+  animation: `${pulse} 1.6s ease-in-out infinite`,
+  '@media (prefers-reduced-motion: reduce)': {
+    animation: 'none',
+  },
+}));
+
+export const TodayViewCount = styled.div(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+  flexShrink: 0,
+  fontSize: theme.font.size.xs,
+  fontWeight: theme.font.weight.regular,
+  color: theme.colors.gray500,
+  whiteSpace: 'nowrap',
+  marginLeft: 'auto', // 보는 중 배지가 없어도 항상 우측 정렬
+}));
 
 export const ClubNameText = styled.div(({ theme }) => ({
   fontSize: theme?.font?.size?.lg,
@@ -91,7 +140,9 @@ export const Grid = styled.div(({ theme }) => ({
   display: 'grid',
   gap: 30,
   padding: '30px 0',
-  gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+  // 최소 폭 320px → 1200px 컨테이너에서 3열, 좁아지면 2열/1열로 자동 축소
+  // min(320px, 100%)로 감싸 초소형 화면에서 트랙이 넘치지 않도록 함
+  gridTemplateColumns: 'repeat(auto-fill, minmax(min(320px, 100%), 1fr))',
   justifyContent: 'center',
   justifyItems: 'center',
 

--- a/src/pages/user/Main/components/ClubListSection/index.tsx
+++ b/src/pages/user/Main/components/ClubListSection/index.tsx
@@ -1,6 +1,7 @@
 import { BsEye, BsFillPatchCheckFill } from 'react-icons/bs';
 import { useNavigate } from 'react-router-dom';
 import { useClubFiltering } from '@/pages/user/Main/hooks/useClubFiltering.ts';
+import { usePopularClubs } from '@/pages/user/Main/hooks/usePopularClubs.ts';
 import { engToKorCategory } from '@/shared/utils/formatting.ts';
 import * as S from './Club.styled.ts';
 import NoSearchResult from './NoSearchResult.tsx';
@@ -22,6 +23,7 @@ export const ClubListSection = ({
 
   const filterStatus = recruitStatus === '전체' ? undefined : recruitStatus;
   const filteredClubs = useClubFiltering(categoryFilter, searchText, filterStatus);
+  const popularClubs = usePopularClubs();
 
   const isDefaultSort = !searchText && categoryFilter === 'ALL' && !filterStatus;
   const sortedClubs = isDefaultSort
@@ -34,47 +36,51 @@ export const ClubListSection = ({
   return (
     <S.ClubListContainer>
       <S.Grid>
-        {sortedClubs.map((club: Club) => (
-          <S.ClubItem onClick={() => navigate(`/clubs/${club.id}`)} key={club.id}>
-            <S.ClubHeader>
-              <S.ClubNameContainer>
-                <S.ClubNameText>{club.name}</S.ClubNameText>
-                {club.isRegistered && (
-                  <S.VerifiedBadge>
-                    <BsFillPatchCheckFill size={14} />
-                  </S.VerifiedBadge>
+        {sortedClubs.map((club: Club) => {
+          const popular = popularClubs.get(club.id);
+
+          return (
+            <S.ClubItem onClick={() => navigate(`/clubs/${club.id}`)} key={club.id}>
+              <S.ClubHeader>
+                <S.ClubNameContainer>
+                  <S.ClubNameText>{club.name}</S.ClubNameText>
+                  {club.isRegistered && (
+                    <S.VerifiedBadge>
+                      <BsFillPatchCheckFill size={14} />
+                    </S.VerifiedBadge>
+                  )}
+                </S.ClubNameContainer>
+                {popular?.activeViewerBadge && (
+                  <S.LiveViewerBadge title='현재 이 동아리를 보고 있는 사람 수'>
+                    <S.LiveDot />
+                    {popular.activeViewerCount}명
+                  </S.LiveViewerBadge>
                 )}
-              </S.ClubNameContainer>
-              {!!club.currentViewerCount && (
-                <S.LiveViewerBadge title='현재 이 동아리를 보고 있는 사람 수'>
-                  <S.LiveDot />
-                  {club.currentViewerCount}명
-                </S.LiveViewerBadge>
-              )}
-            </S.ClubHeader>
-            <S.ClubIntroduction>{club.shortIntroduction}</S.ClubIntroduction>
-            <S.StatusContainer>
-              <S.CategoryStatusBox>
-                <S.CategoryStatusText>
-                  {club.category in engToKorCategory
-                    ? engToKorCategory[club.category as ClubCategoryEng]
-                    : '전체'}
-                </S.CategoryStatusText>
-              </S.CategoryStatusBox>
-              <S.RecruitStatusBox status={club.recruitStatus}>
-                <S.RecruitStatusText status={club.recruitStatus}>
-                  {club.recruitStatus}
-                </S.RecruitStatusText>
-              </S.RecruitStatusBox>
-              {club.todayViewCount !== undefined && (
-                <S.TodayViewCount title='오늘 조회수'>
-                  <BsEye size={14} />
-                  오늘 {club.todayViewCount.toLocaleString()}
-                </S.TodayViewCount>
-              )}
-            </S.StatusContainer>
-          </S.ClubItem>
-        ))}
+              </S.ClubHeader>
+              <S.ClubIntroduction>{club.shortIntroduction}</S.ClubIntroduction>
+              <S.StatusContainer>
+                <S.CategoryStatusBox>
+                  <S.CategoryStatusText>
+                    {club.category in engToKorCategory
+                      ? engToKorCategory[club.category as ClubCategoryEng]
+                      : '전체'}
+                  </S.CategoryStatusText>
+                </S.CategoryStatusBox>
+                <S.RecruitStatusBox status={club.recruitStatus}>
+                  <S.RecruitStatusText status={club.recruitStatus}>
+                    {club.recruitStatus}
+                  </S.RecruitStatusText>
+                </S.RecruitStatusBox>
+                {popular?.recentViewerBadge && (
+                  <S.TodayViewCount title='오늘 조회수'>
+                    <BsEye size={14} />
+                    오늘 {popular.recentViewerCount.toLocaleString()}
+                  </S.TodayViewCount>
+                )}
+              </S.StatusContainer>
+            </S.ClubItem>
+          );
+        })}
       </S.Grid>
     </S.ClubListContainer>
   );

--- a/src/pages/user/Main/components/ClubListSection/index.tsx
+++ b/src/pages/user/Main/components/ClubListSection/index.tsx
@@ -1,4 +1,4 @@
-import { BsFillPatchCheckFill } from 'react-icons/bs';
+import { BsEye, BsFillPatchCheckFill } from 'react-icons/bs';
 import { useNavigate } from 'react-router-dom';
 import { useClubFiltering } from '@/pages/user/Main/hooks/useClubFiltering.ts';
 import { engToKorCategory } from '@/shared/utils/formatting.ts';
@@ -36,14 +36,22 @@ export const ClubListSection = ({
       <S.Grid>
         {sortedClubs.map((club: Club) => (
           <S.ClubItem onClick={() => navigate(`/clubs/${club.id}`)} key={club.id}>
-            <S.ClubNameContainer>
-              <S.ClubNameText>{club.name}</S.ClubNameText>
-              {club.isRegistered && (
-                <S.VerifiedBadge>
-                  <BsFillPatchCheckFill size={14} />
-                </S.VerifiedBadge>
+            <S.ClubHeader>
+              <S.ClubNameContainer>
+                <S.ClubNameText>{club.name}</S.ClubNameText>
+                {club.isRegistered && (
+                  <S.VerifiedBadge>
+                    <BsFillPatchCheckFill size={14} />
+                  </S.VerifiedBadge>
+                )}
+              </S.ClubNameContainer>
+              {!!club.currentViewerCount && (
+                <S.LiveViewerBadge title='현재 이 동아리를 보고 있는 사람 수'>
+                  <S.LiveDot />
+                  {club.currentViewerCount}명
+                </S.LiveViewerBadge>
               )}
-            </S.ClubNameContainer>
+            </S.ClubHeader>
             <S.ClubIntroduction>{club.shortIntroduction}</S.ClubIntroduction>
             <S.StatusContainer>
               <S.CategoryStatusBox>
@@ -58,6 +66,12 @@ export const ClubListSection = ({
                   {club.recruitStatus}
                 </S.RecruitStatusText>
               </S.RecruitStatusBox>
+              {club.todayViewCount !== undefined && (
+                <S.TodayViewCount title='오늘 조회수'>
+                  <BsEye size={14} />
+                  오늘 {club.todayViewCount.toLocaleString()}
+                </S.TodayViewCount>
+              )}
             </S.StatusContainer>
           </S.ClubItem>
         ))}

--- a/src/pages/user/Main/hooks/usePopularClubs.ts
+++ b/src/pages/user/Main/hooks/usePopularClubs.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { getPopularClubs } from '@/pages/user/Main/api/popularClub';
+import type { PopularClub } from '@/pages/user/Main/types/popularClub';
+
+const POLLING_INTERVAL = 10_000;
+
+const EMPTY_POPULAR_CLUBS: ReadonlyMap<number, PopularClub> = new Map();
+
+export const usePopularClubs = (): ReadonlyMap<number, PopularClub> => {
+  const { data } = useQuery({
+    queryKey: ['popularClubs'],
+    queryFn: getPopularClubs,
+    refetchInterval: POLLING_INTERVAL,
+    staleTime: POLLING_INTERVAL,
+    // 10초 뒤 어차피 다시 호출되므로, 실패한 폴링이 요청 수를 배로 늘리지 않도록 재시도하지 않는다
+    retry: false,
+    select: (response) => new Map(response.clubs.map((club) => [club.clubId, club])),
+  });
+
+  return data ?? EMPTY_POPULAR_CLUBS;
+};

--- a/src/pages/user/Main/types/club.ts
+++ b/src/pages/user/Main/types/club.ts
@@ -7,8 +7,6 @@ export type Club = {
   shortIntroduction: string;
   recruitStatus: RecruitStatus;
   isRegistered?: boolean;
-  currentViewerCount?: number;
-  todayViewCount?: number;
 };
 
 export const RECRUIT_STATUS_MAP = {

--- a/src/pages/user/Main/types/club.ts
+++ b/src/pages/user/Main/types/club.ts
@@ -7,6 +7,8 @@ export type Club = {
   shortIntroduction: string;
   recruitStatus: RecruitStatus;
   isRegistered?: boolean;
+  currentViewerCount?: number;
+  todayViewCount?: number;
 };
 
 export const RECRUIT_STATUS_MAP = {

--- a/src/pages/user/Main/types/popularClub.ts
+++ b/src/pages/user/Main/types/popularClub.ts
@@ -1,0 +1,11 @@
+export type PopularClub = {
+  clubId: number;
+  /** 최근 24시간 동안 해당 동아리를 조회한 고유 사용자 수 */
+  recentViewerCount: number;
+  /** 최근 3분 안에 상세 진입 또는 조회 상태 갱신 요청을 보낸 고유 사용자 수 */
+  activeViewerCount: number;
+  /** 최근 24시간 고유 조회자가 기준치 이상이면 true */
+  recentViewerBadge: boolean;
+  /** 현재 활성 조회자가 기준치 이상이면 true */
+  activeViewerBadge: boolean;
+};

--- a/src/pages/user/Main/types/popularClub.ts
+++ b/src/pages/user/Main/types/popularClub.ts
@@ -1,11 +1,11 @@
 export type PopularClub = {
   clubId: number;
-  /** 최근 24시간 동안 해당 동아리를 조회한 고유 사용자 수 */
+  /** 최근 24시간 고유 조회자 수 */
   recentViewerCount: number;
-  /** 최근 3분 안에 상세 진입 또는 조회 상태 갱신 요청을 보낸 고유 사용자 수 */
+  /** 최근 3분 활성 조회자 수 */
   activeViewerCount: number;
-  /** 최근 24시간 고유 조회자가 기준치 이상이면 true */
+  /** 최근 24시간 조회자 수가 기준치 이상인지 */
   recentViewerBadge: boolean;
-  /** 현재 활성 조회자가 기준치 이상이면 true */
+  /** 현재 활성 조회자 수가 기준치 이상인지 */
   activeViewerBadge: boolean;
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #502 
closes #503 

## 📝 작업 내용

메인 화면 동아리 카드에 실시간 인기 배지를 표시합니다.

| 위치 | 표시 조건 | 내용 |
|---|---|---|
| 카드 우측 상단 | `activeViewerBadge` | ● `{activeViewerCount}명` |
| 태그 행 우측 | `recentViewerBadge` | 👁 `오늘 {recentViewerCount}` |

카운트가 0보다 큰지가 아니라 **배지 플래그로만** 판단합니다.


**1. `useQuery` 사용 (기존 컨벤션과 다른 지점)**

저장소의 모든 조회 훅은 `useSuspenseQuery`지만, 이 API에는 쓰지 않았습니다. 현재 프로젝트에 ErrorBoundary가 없어서 suspense 쿼리가 throw하면 메인 화면 전체가 언마운트됩니다. 10초마다 호출되는 공개 API가 한 번만 실패해도 화면이 백지가 됩니다.

`useQuery`는 실패를 트리로 던지지 않아 `data`가 `undefined`로 남고, 자연스럽게 "카드 유지 + 배지만 숨김" 동작이 됩니다.

**2. 인증 인터셉터 미적용**

기존 `apiInstance`는 응답의 `error_code`가 `EXPIRED_ACCESS_TOKEN`이면 토큰 재발급을 시도하고, 실패 시 `window.location.href`로 강제 이동시킵니다. 토큰이 만료된 사용자가 메인에 머무르면 10초마다 이 경로가 돌고 재발급 실패 순간 화면이 통째로 리다이렉트됩니다. 인터셉터가 없는 `publicApiInstance`를 별도로 두어 차단했습니다.

**3. 중복 요청 방지**

React Query가 동일 쿼리 키의 in-flight 요청을 dedupe하고, `refetchInterval`은 이전 요청이 진행 중이면 새 요청을 시작하지 않습니다. 별도 플래그 없이 체크리스트를 충족합니다. `refetchIntervalInBackground`를 켜지 않아 탭이 비활성이면 폴링이 멈춥니다.

**4. `retry: false`**

10초 뒤 어차피 재호출되므로, 기본값 `retry: 3`이 요청량을 4배로 키우는 것을 막습니다.

## 스크린샷 

<img width="1186" height="384" alt="image" src="https://github.com/user-attachments/assets/90970a49-7830-412b-927e-b2dff96f3f08" />
