### PR TITLE
[FEAT] 지원자 통계 UI 추가 (#507)

### DIFF
--- a/src/app/api/statistics.ts
+++ b/src/app/api/statistics.ts
@@ -1,0 +1,23 @@
+import { apiInstance } from '@/app/api/initInstance';
+import { handleAxiosError } from '@/shared/utils/handleAxiosError';
+import type {
+  ClubStatistics,
+  StatisticsDimension,
+  StatisticsScope,
+} from '@/shared/types/statistics';
+
+export const fetchClubStatistics = async (
+  clubId: number,
+  scope: StatisticsScope,
+  dimensions?: StatisticsDimension[],
+): Promise<ClubStatistics> => {
+  try {
+    const { data } = await apiInstance.get<ClubStatistics>(
+      `/clubs/${clubId}/statistics${scope === 'admin' ? '/admin' : ''}`,
+      dimensions?.length ? { params: { dimensions: dimensions.join(',') } } : undefined,
+    );
+    return data;
+  } catch (error: unknown) {
+    return handleAxiosError(error, '지원자 통계를 불러오지 못했습니다.');
+  }
+};

--- a/src/app/mocks/client.ts
+++ b/src/app/mocks/client.ts
@@ -5,6 +5,7 @@ import { noticeHandlers } from '@/app/mocks/handler/notice';
 import { applyFormHandlers } from './handler/applyForm';
 import { authHandlers } from './handler/auth';
 import { dashboardHandlers } from './handler/dashboard';
+import { statisticsHandlers } from './handler/statistics';
 
 export const client = setupWorker(
   ...clubHandlers,
@@ -13,4 +14,5 @@ export const client = setupWorker(
   ...applyFormHandlers,
   ...authHandlers,
   ...dashboardHandlers,
+  ...statisticsHandlers,
 );

--- a/src/app/mocks/handler/statistics.ts
+++ b/src/app/mocks/handler/statistics.ts
@@ -1,0 +1,23 @@
+import { http, HttpResponse, type HttpResponseResolver, type PathParams } from 'msw';
+import { statisticsRepository } from '@/app/mocks/repositories/statistics';
+import type { StatisticsDimension } from '@/shared/types/statistics';
+
+interface StatisticsParams extends PathParams {
+  clubId: string;
+}
+
+const getStatisticsResolver: HttpResponseResolver<StatisticsParams> = ({ params, request }) => {
+  const dimensions = (new URL(request.url).searchParams.get('dimensions')?.split(',') ??
+    []) as StatisticsDimension[];
+  const statistics = statisticsRepository.getStatistics(Number(params.clubId), dimensions);
+
+  return HttpResponse.json(statistics, { status: 200 });
+};
+
+export const statisticsHandlers = [
+  http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/statistics', getStatisticsResolver),
+  http.get(
+    import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/statistics/admin',
+    getStatisticsResolver,
+  ),
+];

--- a/src/app/mocks/repositories/statistics.ts
+++ b/src/app/mocks/repositories/statistics.ts
@@ -1,0 +1,95 @@
+import type {
+  ClubStatistics,
+  StatisticsBucket,
+  StatisticsDimension,
+  StatisticsDimensionResult,
+} from '@/shared/types/statistics';
+
+/** 지원자 3명 미만이라 통계가 비공개되는 상태를 확인하기 위한 동아리 */
+const MASKED_CLUB_ID = 2;
+
+const TOTAL_APPLICANTS = 214;
+const DAILY_START_DATE = '2026-03-02';
+const DAILY_COUNTS = [12, 24, 31, 18, 9, 5, 0, 7, 14, 22, 28, 19, 16, 9];
+
+const toBuckets = (entries: [key: string, label: string, count: number][]): StatisticsBucket[] =>
+  entries.map(([key, label, count]) => ({
+    key,
+    label,
+    count,
+    ratio: Number((count / TOTAL_APPLICANTS).toFixed(3)),
+  }));
+
+const toDailyBuckets = (): StatisticsBucket[] =>
+  DAILY_COUNTS.map((count, index) => {
+    const date = new Date(DAILY_START_DATE);
+    date.setDate(date.getDate() + index);
+
+    return {
+      key: date.toISOString().slice(0, 10),
+      label: `${date.getMonth() + 1}월 ${date.getDate()}일`,
+      count,
+    };
+  });
+
+const MOCK_RESULTS: StatisticsDimensionResult[] = [
+  {
+    dimension: 'GENDER',
+    type: 'CATEGORICAL',
+    buckets: toBuckets([
+      ['MALE', '남성', 121],
+      ['FEMALE', '여성', 91],
+      ['UNKNOWN', '미입력', 2],
+    ]),
+  },
+  {
+    dimension: 'ADMISSION_YEAR',
+    type: 'ORDINAL',
+    buckets: toBuckets([
+      ['OLDER', '그 이전', 12],
+      ['21', '21학번', 30],
+      ['22', '22학번', 58],
+      ['23', '23학번', 47],
+      ['24', '24학번', 40],
+      ['25', '25학번', 24],
+      ['UNKNOWN', '미입력', 3],
+    ]),
+  },
+  {
+    dimension: 'FACULTY',
+    type: 'CATEGORICAL',
+    buckets: toBuckets([
+      ['ENGINEERING', '공과대학', 74],
+      ['NATURAL_SCIENCES', '자연과학대학', 37],
+      ['SOCIAL_SCIENCES', '사회과학대학', 33],
+      ['HUMANITIES', '인문대학', 25],
+      ['BUSINESS', '경영대학', 20],
+      ['ETC', '기타', 20],
+      ['UNKNOWN', '미입력', 5],
+    ]),
+  },
+  {
+    dimension: 'DAILY_APPLICATIONS',
+    type: 'TIME_SERIES',
+    buckets: toDailyBuckets(),
+  },
+];
+
+export const statisticsRepository = {
+  getStatistics: (clubId: number, dimensions: StatisticsDimension[]): ClubStatistics => {
+    const isMasked = clubId === MASKED_CLUB_ID;
+
+    return {
+      clubApplyFormId: clubId,
+      totalApplicants: isMasked ? 2 : TOTAL_APPLICANTS,
+      snapshot: false,
+      masked: isMasked,
+      calculatedAt: new Date().toISOString(),
+      results: isMasked
+        ? []
+        : MOCK_RESULTS.filter(
+            (result) => dimensions.length === 0 || dimensions.includes(result.dimension),
+          ),
+    };
+  },
+};

--- a/src/pages/admin/Dashboard/Page.tsx
+++ b/src/pages/admin/Dashboard/Page.tsx
@@ -3,6 +3,7 @@ import { Suspense, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { OnboardingPopup } from '@/shared/components/OnboardingPopup';
+import { StatisticsSection } from '@/shared/components/Statistics';
 import { useOnboardingPopup } from '@/shared/hooks/useOnboardingPopup';
 import { ApplicantListSection } from './components/ApplicantListSection';
 import { DashboardSummarySection } from './components/DashboardSummarySection';
@@ -29,6 +30,9 @@ export const DashboardPage = () => {
       <Container>
         <Suspense fallback={<LoadingSpinner />}>
           <DashboardSummarySection />
+          <StatisticsWrapper>
+            <StatisticsSection clubId={Number(clubId)} scope='admin' />
+          </StatisticsWrapper>
           <ApplicantListSection
             stage={stage}
             setStage={setStage}
@@ -48,6 +52,10 @@ const Layout = styled.div({
   alignItems: 'flex-start',
   minHeight: '100vh',
   width: '100%',
+});
+
+const StatisticsWrapper = styled.div({
+  margin: '2.5rem 0',
 });
 
 const Container = styled.main({

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom';
 import { TwoColumnLayout } from '@/shared/components/Layout/TwoColumnLayout';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 import { PageHeader } from '@/shared/components/PageHeader';
+import { StatisticsSection } from '@/shared/components/Statistics';
 import { useKeyboardVisible } from '@/shared/hooks/useKeyboardVisible';
 import { engToKorCategory } from '@/shared/utils/formatting';
 import { ClubActivityPhotosSection } from './components/ClubActivityPhotosSection';
@@ -45,6 +46,7 @@ export const ClubDetailPage = () => {
               introductionActivity={club.introductionActivity}
               introductionIdeal={club.introductionIdeal}
             />
+            <StatisticsSection clubId={club.clubId} scope='public' />
             <Suspense fallback={<LoadingSpinner />}>
               <ClubReviewsSection clubId={club.clubId} />
             </Suspense>

--- a/src/shared/components/Statistics/BarChart.tsx
+++ b/src/shared/components/Statistics/BarChart.tsx
@@ -1,0 +1,84 @@
+import styled from '@emotion/styled';
+import type { StatisticsBucket } from '@/shared/types/statistics';
+
+const UNKNOWN_KEY = 'UNKNOWN';
+
+type Props = {
+  buckets: StatisticsBucket[];
+};
+
+const formatRatio = (ratio: number) => `${(ratio * 100).toFixed(1)}%`;
+
+export const BarChart = ({ buckets }: Props) => {
+  const maxCount = Math.max(...buckets.map((bucket) => bucket.count), 1);
+
+  return (
+    <List>
+      {buckets.map((bucket) => (
+        <Row key={bucket.key}>
+          <Label title={bucket.label}>{bucket.label}</Label>
+          <Track>
+            <Bar
+              isUnknown={bucket.key === UNKNOWN_KEY}
+              style={{ width: `${(bucket.count / maxCount) * 100}%` }}
+            />
+          </Track>
+          <Value>
+            {bucket.count}명
+            {bucket.ratio !== undefined && <Ratio>{formatRatio(bucket.ratio)}</Ratio>}
+          </Value>
+        </Row>
+      ))}
+    </List>
+  );
+};
+
+const List = styled.ul({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.6rem',
+  width: '100%',
+});
+
+const Row = styled.li({
+  display: 'grid',
+  gridTemplateColumns: '5.5rem 1fr 5rem',
+  alignItems: 'center',
+  gap: '0.75rem',
+});
+
+const Label = styled.span(({ theme }) => ({
+  fontSize: theme.font.size.sm,
+  color: theme.colors.textSecondary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}));
+
+const Track = styled.div(({ theme }) => ({
+  height: '0.75rem',
+  borderRadius: theme.radius.sm,
+  backgroundColor: theme.colors.gray100,
+  overflow: 'hidden',
+}));
+
+const Bar = styled.div<{ isUnknown: boolean }>(({ theme, isUnknown }) => ({
+  height: '100%',
+  borderRadius: theme.radius.sm,
+  backgroundColor: isUnknown ? theme.colors.gray300 : theme.colors.primary,
+  transition: 'width 0.3s ease',
+}));
+
+const Value = styled.span(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'baseline',
+  justifyContent: 'flex-end',
+  gap: '0.25rem',
+  fontSize: theme.font.size.sm,
+  color: theme.colors.textPrimary,
+}));
+
+const Ratio = styled.span(({ theme }) => ({
+  fontSize: theme.font.size.xs,
+  color: theme.colors.textSecondary,
+}));

--- a/src/shared/components/Statistics/TrendChart.tsx
+++ b/src/shared/components/Statistics/TrendChart.tsx
@@ -1,0 +1,116 @@
+import styled from '@emotion/styled';
+import type { StatisticsBucket } from '@/shared/types/statistics';
+
+const VIEW_BOX = { width: 640, height: 200 };
+const PADDING = { top: 16, right: 12, bottom: 26, left: 34 };
+const MAX_DOT_COUNT = 20;
+
+const INNER_WIDTH = VIEW_BOX.width - PADDING.left - PADDING.right;
+const INNER_HEIGHT = VIEW_BOX.height - PADDING.top - PADDING.bottom;
+
+type Props = {
+  buckets: StatisticsBucket[];
+};
+
+/** 첫날·중간·마지막 라벨만 노출해 x축이 빽빽해지지 않도록 한다. */
+const getVisibleLabelIndexes = (length: number) => {
+  if (length <= 1) return [0];
+  if (length === 2) return [0, 1];
+  return [0, Math.floor((length - 1) / 2), length - 1];
+};
+
+export const TrendChart = ({ buckets }: Props) => {
+  const maxCount = Math.max(...buckets.map((bucket) => bucket.count), 1);
+  const lastIndex = buckets.length - 1;
+
+  const points = buckets.map((bucket, index) => ({
+    x:
+      lastIndex === 0
+        ? PADDING.left + INNER_WIDTH / 2
+        : PADDING.left + (index / lastIndex) * INNER_WIDTH,
+    y: PADDING.top + INNER_HEIGHT - (bucket.count / maxCount) * INNER_HEIGHT,
+  }));
+
+  const line = points.map(({ x, y }) => `${x},${y}`).join(' ');
+  const baseline = PADDING.top + INNER_HEIGHT;
+  const area = `${points[0].x},${baseline} ${line} ${points[lastIndex].x},${baseline}`;
+  const visibleLabelIndexes = getVisibleLabelIndexes(buckets.length);
+  const totalCount = buckets.reduce((sum, bucket) => sum + bucket.count, 0);
+
+  return (
+    <Svg
+      viewBox={`0 0 ${VIEW_BOX.width} ${VIEW_BOX.height}`}
+      role='img'
+      aria-label={`일자별 지원 추이. 총 ${totalCount}명, 하루 최대 ${maxCount}명`}
+    >
+      <GridLine x1={PADDING.left} y1={baseline} x2={VIEW_BOX.width - PADDING.right} y2={baseline} />
+      <GridLine
+        x1={PADDING.left}
+        y1={PADDING.top}
+        x2={VIEW_BOX.width - PADDING.right}
+        y2={PADDING.top}
+      />
+
+      <AxisLabel x={PADDING.left - 8} y={baseline} textAnchor='end' dominantBaseline='middle'>
+        0
+      </AxisLabel>
+      <AxisLabel x={PADDING.left - 8} y={PADDING.top} textAnchor='end' dominantBaseline='middle'>
+        {maxCount}
+      </AxisLabel>
+
+      <Area points={area} />
+      <Line points={line} />
+
+      {buckets.length <= MAX_DOT_COUNT &&
+        points.map((point, index) => (
+          <Dot key={buckets[index].key} cx={point.x} cy={point.y} r={3} />
+        ))}
+
+      {visibleLabelIndexes.map((index) => (
+        <AxisLabel
+          key={buckets[index].key}
+          x={points[index].x}
+          y={baseline + 16}
+          textAnchor={index === 0 ? 'start' : index === lastIndex ? 'end' : 'middle'}
+        >
+          {buckets[index].label}
+        </AxisLabel>
+      ))}
+    </Svg>
+  );
+};
+
+const Svg = styled.svg({
+  width: '100%',
+  height: 'auto',
+});
+
+const GridLine = styled.line(({ theme }) => ({
+  stroke: theme.colors.gray100,
+  strokeWidth: 1,
+}));
+
+const Area = styled.polyline(({ theme }) => ({
+  fill: theme.colors.primary,
+  fillOpacity: 0.08,
+  stroke: 'none',
+}));
+
+const Line = styled.polyline(({ theme }) => ({
+  fill: 'none',
+  stroke: theme.colors.primary,
+  strokeWidth: 2,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+}));
+
+const Dot = styled.circle(({ theme }) => ({
+  fill: theme.colors.bg,
+  stroke: theme.colors.primary,
+  strokeWidth: 2,
+}));
+
+const AxisLabel = styled.text(({ theme }) => ({
+  fill: theme.colors.textSecondary,
+  fontSize: theme.font.size.xs,
+}));

--- a/src/shared/components/Statistics/constants.ts
+++ b/src/shared/components/Statistics/constants.ts
@@ -1,0 +1,24 @@
+import type { StatisticsDimension, StatisticsScope } from '@/shared/types/statistics';
+
+/**
+ * 지원자를 특정할 수 없도록 이 인원 미만이면 분포를 표시하지 않는다.
+ * 공개 통계는 서버가 masked로 내려주고, 관리자 통계는 마스킹이 적용되지 않으므로 화면에서 동일 기준을 적용한다.
+ */
+export const MIN_VISIBLE_APPLICANTS = 3;
+
+export const DIMENSION_TITLE: Record<StatisticsDimension, string> = {
+  GENDER: '성별',
+  ADMISSION_YEAR: '입학연도',
+  FACULTY: '학부',
+  DAILY_APPLICATIONS: '일자별 지원 추이',
+};
+
+export const SCOPE_TITLE: Record<StatisticsScope, string> = {
+  public: '지원 현황',
+  admin: '지원자 통계',
+};
+
+export const MASKED_MESSAGE: Record<StatisticsScope, string> = {
+  public: `지원자가 ${MIN_VISIBLE_APPLICANTS}명 이상 모이면 통계를 볼 수 있어요.`,
+  admin: `지원자가 ${MIN_VISIBLE_APPLICANTS}명 미만이라 지원자 보호를 위해 통계를 표시하지 않습니다.`,
+};

--- a/src/shared/components/Statistics/constants.ts
+++ b/src/shared/components/Statistics/constants.ts
@@ -1,8 +1,8 @@
 import type { StatisticsDimension, StatisticsScope } from '@/shared/types/statistics';
 
 /**
- * 지원자를 특정할 수 없도록 이 인원 미만이면 분포를 표시하지 않는다.
- * 공개 통계는 서버가 masked로 내려주고, 관리자 통계는 마스킹이 적용되지 않으므로 화면에서 동일 기준을 적용한다.
+ * 지원자를 특정할 수 없도록 공개 통계는 이 인원 미만이면 분포를 표시하지 않는다.
+ * 지원자 명단을 직접 관리하는 관리자 통계에는 적용하지 않고 원본을 그대로 노출한다.
  */
 export const MIN_VISIBLE_APPLICANTS = 3;
 
@@ -20,5 +20,10 @@ export const SCOPE_TITLE: Record<StatisticsScope, string> = {
 
 export const MASKED_MESSAGE: Record<StatisticsScope, string> = {
   public: `지원자가 ${MIN_VISIBLE_APPLICANTS}명 이상 모이면 통계를 볼 수 있어요.`,
-  admin: `지원자가 ${MIN_VISIBLE_APPLICANTS}명 미만이라 지원자 보호를 위해 통계를 표시하지 않습니다.`,
+  admin: '지원자 수가 적어 분포가 제공되지 않았습니다.',
+};
+
+export const EMPTY_MESSAGE: Record<StatisticsScope, string> = {
+  public: '아직 지원자가 없어요.',
+  admin: '아직 지원자가 없습니다.',
 };

--- a/src/shared/components/Statistics/index.styled.ts
+++ b/src/shared/components/Statistics/index.styled.ts
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled';
+
+export const Divider = styled.hr(({ theme }) => ({
+  border: 'none',
+  borderTop: `1px solid ${theme.colors.gray200}`,
+  width: '100%',
+}));
+
+export const Container = styled.section({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  width: '100%',
+});
+
+export const Header = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  gap: '0.35rem',
+});
+
+export const Caption = styled.p(({ theme }) => ({
+  fontSize: theme.font.size.xs,
+  color: theme.colors.textSecondary,
+}));
+
+export const Grid = styled.div(({ theme }) => ({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  gap: '1rem',
+
+  [`@media (max-width: ${theme.breakpoints.tablet})`]: {
+    gridTemplateColumns: '1fr',
+  },
+}));
+
+export const Card = styled.div<{ isWide?: boolean }>(({ theme, isWide }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.9rem',
+  padding: '1.1rem 1.25rem',
+  borderRadius: theme.radius.md,
+  border: `1px solid ${theme.colors.gray100}`,
+  backgroundColor: theme.colors.bg,
+  gridColumn: isWide ? '1 / -1' : 'auto',
+}));
+
+export const CardTitle = styled.h3(({ theme }) => ({
+  fontSize: theme.font.size.base,
+  fontWeight: theme.font.weight.medium,
+  color: theme.colors.textPrimary,
+}));
+
+export const Notice = styled.p(({ theme }) => ({
+  padding: '2rem 1rem',
+  borderRadius: theme.radius.md,
+  border: `1px solid ${theme.colors.gray100}`,
+  backgroundColor: theme.colors.gray00,
+  fontSize: theme.font.size.sm,
+  color: theme.colors.textSecondary,
+  textAlign: 'center',
+}));

--- a/src/shared/components/Statistics/index.test.tsx
+++ b/src/shared/components/Statistics/index.test.tsx
@@ -1,0 +1,112 @@
+import { ThemeProvider } from '@emotion/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchClubStatistics } from '@/app/api/statistics';
+import { theme } from '@/app/styles/theme';
+import { StatisticsSection } from './index';
+import type { ClubStatistics } from '@/shared/types/statistics';
+
+vi.mock('@/app/api/statistics');
+
+const mockedFetch = vi.mocked(fetchClubStatistics);
+
+const createStatistics = (overrides: Partial<ClubStatistics> = {}): ClubStatistics => ({
+  clubApplyFormId: 1,
+  totalApplicants: 10,
+  snapshot: false,
+  masked: false,
+  calculatedAt: '2026-03-14T23:59:30+09:00',
+  results: [
+    {
+      dimension: 'GENDER',
+      type: 'CATEGORICAL',
+      buckets: [
+        { key: 'MALE', label: '남성', count: 6, ratio: 0.6 },
+        { key: 'FEMALE', label: '여성', count: 3, ratio: 0.3 },
+        { key: 'UNKNOWN', label: '미입력', count: 1, ratio: 0.1 },
+      ],
+    },
+  ],
+  ...overrides,
+});
+
+const renderSection = (scope: 'public' | 'admin' = 'admin') => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <StatisticsSection clubId={1} scope={scope} />
+      </ThemeProvider>
+    </QueryClientProvider>,
+  );
+};
+
+describe('StatisticsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('지원자가 3명 이상이면 집계 항목과 버킷을 표시한다', async () => {
+    mockedFetch.mockResolvedValueOnce(createStatistics());
+
+    renderSection();
+
+    expect(await screen.findByText('성별')).toBeInTheDocument();
+    expect(screen.getByText('남성')).toBeInTheDocument();
+    expect(screen.getByText('미입력')).toBeInTheDocument();
+  });
+
+  it('일자별 지원 추이는 지원이 없는 날을 포함해 추이 차트로 표시한다', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      createStatistics({
+        results: [
+          {
+            dimension: 'DAILY_APPLICATIONS',
+            type: 'TIME_SERIES',
+            buckets: [
+              { key: '2026-03-02', label: '3월 2일', count: 4 },
+              { key: '2026-03-03', label: '3월 3일', count: 0 },
+              { key: '2026-03-04', label: '3월 4일', count: 6 },
+            ],
+          },
+        ],
+      }),
+    );
+
+    renderSection();
+
+    expect(await screen.findByText('일자별 지원 추이')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /총 10명, 하루 최대 6명/ })).toBeInTheDocument();
+    expect(screen.getByText('3월 2일')).toBeInTheDocument();
+    expect(screen.getByText('3월 4일')).toBeInTheDocument();
+  });
+
+  it('지원자가 3명 미만이면 분포 대신 안내 문구를 표시한다', async () => {
+    mockedFetch.mockResolvedValueOnce(createStatistics({ totalApplicants: 2 }));
+
+    renderSection();
+
+    expect(await screen.findByText(/3명 미만/)).toBeInTheDocument();
+    expect(screen.queryByText('성별')).not.toBeInTheDocument();
+  });
+
+  it('서버가 masked로 내려주면 안내 문구를 표시한다', async () => {
+    mockedFetch.mockResolvedValueOnce(
+      createStatistics({ totalApplicants: 2, masked: true, results: [] }),
+    );
+
+    renderSection('public');
+
+    expect(await screen.findByText(/3명 이상 모이면/)).toBeInTheDocument();
+  });
+
+  it('지원폼이 없어 조회에 실패하면 지원자 화면에는 섹션을 노출하지 않는다', async () => {
+    mockedFetch.mockRejectedValueOnce(new Error('지원폼이 존재하지 않습니다'));
+
+    const { container } = renderSection('public');
+
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+});

--- a/src/shared/components/Statistics/index.test.tsx
+++ b/src/shared/components/Statistics/index.test.tsx
@@ -83,12 +83,30 @@ describe('StatisticsSection', () => {
     expect(screen.getByText('3월 4일')).toBeInTheDocument();
   });
 
-  it('지원자가 3명 미만이면 분포 대신 안내 문구를 표시한다', async () => {
+  it('공개 통계는 지원자가 3명 미만이면 분포 대신 안내 문구를 표시한다', async () => {
     mockedFetch.mockResolvedValueOnce(createStatistics({ totalApplicants: 2 }));
 
-    renderSection();
+    renderSection('public');
 
-    expect(await screen.findByText(/3명 미만/)).toBeInTheDocument();
+    expect(await screen.findByText(/3명 이상 모이면/)).toBeInTheDocument();
+    expect(screen.queryByText('성별')).not.toBeInTheDocument();
+  });
+
+  it('관리자 통계는 지원자가 3명 미만이어도 원본 분포를 그대로 표시한다', async () => {
+    mockedFetch.mockResolvedValueOnce(createStatistics({ totalApplicants: 2 }));
+
+    renderSection('admin');
+
+    expect(await screen.findByText('성별')).toBeInTheDocument();
+    expect(screen.getByText('남성')).toBeInTheDocument();
+  });
+
+  it('지원자가 없으면 빈 차트 대신 안내 문구를 표시한다', async () => {
+    mockedFetch.mockResolvedValueOnce(createStatistics({ totalApplicants: 0 }));
+
+    renderSection('admin');
+
+    expect(await screen.findByText('아직 지원자가 없습니다.')).toBeInTheDocument();
     expect(screen.queryByText('성별')).not.toBeInTheDocument();
   });
 

--- a/src/shared/components/Statistics/index.tsx
+++ b/src/shared/components/Statistics/index.tsx
@@ -3,7 +3,13 @@ import { SectionHeading } from '@/shared/components/SectionHeading';
 import { useClubStatistics } from '@/shared/hooks/useClubStatistics';
 import { formatHourMinute } from '@/shared/utils/dateUtils';
 import { BarChart } from './BarChart';
-import { DIMENSION_TITLE, MASKED_MESSAGE, MIN_VISIBLE_APPLICANTS, SCOPE_TITLE } from './constants';
+import {
+  DIMENSION_TITLE,
+  EMPTY_MESSAGE,
+  MASKED_MESSAGE,
+  MIN_VISIBLE_APPLICANTS,
+  SCOPE_TITLE,
+} from './constants';
 import * as S from './index.styled';
 import { TrendChart } from './TrendChart';
 import type { StatisticsScope } from '@/shared/types/statistics';
@@ -31,8 +37,18 @@ export const StatisticsSection = ({ clubId, scope }: Props) => {
   }
 
   const results = data.results.filter((result) => result.buckets.length > 0);
-  const isHidden =
-    data.masked || data.totalApplicants < MIN_VISIBLE_APPLICANTS || results.length === 0;
+
+  /** 최소 공개 기준은 공개 통계에만 적용하고, 관리자에게는 원본 수치를 그대로 보여준다. */
+  const isMasked =
+    data.masked || (scope === 'public' && data.totalApplicants < MIN_VISIBLE_APPLICANTS);
+
+  const getNoticeMessage = () => {
+    if (isMasked) return MASKED_MESSAGE[scope];
+    if (data.totalApplicants === 0 || results.length === 0) return EMPTY_MESSAGE[scope];
+    return null;
+  };
+
+  const noticeMessage = getNoticeMessage();
 
   return (
     <S.Container>
@@ -44,8 +60,8 @@ export const StatisticsSection = ({ clubId, scope }: Props) => {
         </S.Caption>
       </S.Header>
 
-      {isHidden ? (
-        <S.Notice>{MASKED_MESSAGE[scope]}</S.Notice>
+      {noticeMessage ? (
+        <S.Notice>{noticeMessage}</S.Notice>
       ) : (
         <S.Grid>
           {results.map((result) => (

--- a/src/shared/components/Statistics/index.tsx
+++ b/src/shared/components/Statistics/index.tsx
@@ -1,0 +1,65 @@
+import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
+import { SectionHeading } from '@/shared/components/SectionHeading';
+import { useClubStatistics } from '@/shared/hooks/useClubStatistics';
+import { formatHourMinute } from '@/shared/utils/dateUtils';
+import { BarChart } from './BarChart';
+import { DIMENSION_TITLE, MASKED_MESSAGE, MIN_VISIBLE_APPLICANTS, SCOPE_TITLE } from './constants';
+import * as S from './index.styled';
+import { TrendChart } from './TrendChart';
+import type { StatisticsScope } from '@/shared/types/statistics';
+
+type Props = {
+  clubId: number;
+  scope: StatisticsScope;
+};
+
+export const StatisticsSection = ({ clubId, scope }: Props) => {
+  const { data, isPending, isError } = useClubStatistics(clubId, scope);
+
+  if (isPending) {
+    return <LoadingSpinner />;
+  }
+
+  /** 지원폼이 없는 동아리는 404가 내려온다. 지원자가 보는 화면에서는 섹션 자체를 노출하지 않는다. */
+  if (isError || !data) {
+    return scope === 'admin' ? (
+      <S.Container>
+        <SectionHeading>{SCOPE_TITLE[scope]}</SectionHeading>
+        <S.Notice>통계를 불러오지 못했습니다.</S.Notice>
+      </S.Container>
+    ) : null;
+  }
+
+  const results = data.results.filter((result) => result.buckets.length > 0);
+  const isHidden =
+    data.masked || data.totalApplicants < MIN_VISIBLE_APPLICANTS || results.length === 0;
+
+  return (
+    <S.Container>
+      {scope === 'public' && <S.Divider />}
+      <S.Header>
+        <SectionHeading>{SCOPE_TITLE[scope]}</SectionHeading>
+        <S.Caption>
+          총 지원자 {data.totalApplicants}명 · {formatHourMinute(data.calculatedAt)} 기준
+        </S.Caption>
+      </S.Header>
+
+      {isHidden ? (
+        <S.Notice>{MASKED_MESSAGE[scope]}</S.Notice>
+      ) : (
+        <S.Grid>
+          {results.map((result) => (
+            <S.Card key={result.dimension} isWide={result.type === 'TIME_SERIES'}>
+              <S.CardTitle>{DIMENSION_TITLE[result.dimension]}</S.CardTitle>
+              {result.type === 'TIME_SERIES' ? (
+                <TrendChart buckets={result.buckets} />
+              ) : (
+                <BarChart buckets={result.buckets} />
+              )}
+            </S.Card>
+          ))}
+        </S.Grid>
+      )}
+    </S.Container>
+  );
+};

--- a/src/shared/hooks/useClubStatistics.ts
+++ b/src/shared/hooks/useClubStatistics.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchClubStatistics } from '@/app/api/statistics';
+import type { StatisticsScope } from '@/shared/types/statistics';
+
+/** 공개 통계는 서버에서 30분간 캐시되므로 동일 주기로, 관리자 통계는 실시간이므로 짧게 유지한다. */
+const STALE_TIME: Record<StatisticsScope, number> = {
+  public: 1000 * 60 * 30,
+  admin: 1000 * 60,
+};
+
+/**
+ * 지원폼이 없는 동아리는 404가 내려오므로 useSuspenseQuery 대신 useQuery를 사용한다.
+ * 통계 조회 실패가 페이지 전체를 중단시키지 않고 섹션 단위로만 처리되도록 한다.
+ */
+export const useClubStatistics = (clubId: number, scope: StatisticsScope) => {
+  return useQuery({
+    queryKey: ['clubStatistics', clubId, scope],
+    queryFn: () => fetchClubStatistics(clubId, scope),
+    staleTime: STALE_TIME[scope],
+    enabled: Number.isFinite(clubId),
+    retry: false,
+  });
+};

--- a/src/shared/types/statistics.ts
+++ b/src/shared/types/statistics.ts
@@ -1,0 +1,27 @@
+export type StatisticsDimension = 'GENDER' | 'ADMISSION_YEAR' | 'FACULTY' | 'DAILY_APPLICATIONS';
+
+export type StatisticsDimensionType = 'CATEGORICAL' | 'ORDINAL' | 'TIME_SERIES';
+
+export type StatisticsScope = 'public' | 'admin';
+
+export type StatisticsBucket = {
+  key: string;
+  label: string;
+  count: number;
+  ratio?: number;
+};
+
+export type StatisticsDimensionResult = {
+  dimension: StatisticsDimension;
+  type: StatisticsDimensionType;
+  buckets: StatisticsBucket[];
+};
+
+export type ClubStatistics = {
+  clubApplyFormId: number;
+  totalApplicants: number;
+  snapshot: boolean;
+  masked: boolean;
+  calculatedAt: string;
+  results: StatisticsDimensionResult[];
+};

--- a/src/shared/utils/dateUtils.ts
+++ b/src/shared/utils/dateUtils.ts
@@ -12,6 +12,13 @@ export const formatDateWithoutYear = (date: string | Date) => {
 
 export const formatTime = (time: string) => time.split(':').slice(0, 2).join(':');
 
+export const formatHourMinute = (date: string | Date) => {
+  const dateObj = typeof date === 'string' ? new Date(date) : date;
+  const hours = dateObj.getHours().toString().padStart(2, '0');
+  const minutes = dateObj.getMinutes().toString().padStart(2, '0');
+  return `${hours}:${minutes}`;
+};
+
 export const formatDateTime = (date: string | Date) => {
   const dateObj = typeof date === 'string' ? new Date(date) : date;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

close #507

백엔드 요청 이슈: kakao-tech-campus-3rd-step3/Team18_BE#355 (clubId 기반 경로로 반영 완료)

## 📝작업 내용

지원자 통계 API를 연동해 성별·입학연도·학부 분포와 일자별 지원 추이를 관리자 대시보드와 동아리 상세 페이지에 표시합니다.

```
GET /api/clubs/{clubId}/statistics         # 공개(비로그인 허용, 마스킹 적용, 30분 캐시)
GET /api/clubs/{clubId}/statistics/admin   # 관리자(원본·실시간)
```

**공통 모듈** — 두 화면이 같은 응답을 쓰기 때문에 `scope`만 다르게 넘겨 재사용합니다.

- `shared/types/statistics.ts` — 응답 타입
- `app/api/statistics.ts` — 공개/관리자 분기, `dimensions` 쿼리 지원
- `shared/hooks/useClubStatistics.ts` — 조회 훅
- `shared/components/Statistics/` — 섹션 셸 + `BarChart`(CATEGORICAL·ORDINAL) + `TrendChart`(TIME_SERIES)

```tsx
<StatisticsSection clubId={clubId} scope='admin' />   // 대시보드
<StatisticsSection clubId={club.clubId} scope='public' />  // 동아리 상세
```

**지원자 보호 기준** — 공개 통계는 지원자를 특정할 수 없도록 전체 지원자 3명 미만이면 분포를 표시하지 않습니다(서버가 `masked: true`로 내려주는 기준과 동일). 지원자 명단을 직접 관리하는 관리자 통계에는 이 기준을 적용하지 않고 원본 수치를 그대로 노출합니다. API 문서에 정의된 세 가지 상태를 구분해 표시합니다.

| 의미 | 응답 | 화면 |
| --- | --- | --- |
| 소수라 비공개 | `masked: true`, `results: []` | 비공개 안내 문구 |
| 실제 0명 | 버킷 `count: 0` | 0으로 표시 (추이 차트에도 그대로 반영) |
| 값 미기입 | `key: "UNKNOWN"` | "미입력" 버킷을 회색으로 구분해 표시 |

**차트** — 외부 라이브러리 없이 Emotion + SVG로 직접 구현했습니다. 필요한 형태가 막대·라인 수준이고, 디자인토큰(`theme.colors.primary`, `gray100`, `radius`, `font`)을 그대로 쓰기 위해서입니다. 번들 크기 변화도 없습니다.

**MSW** — `dev:msw`로 확인할 수 있도록 핸들러를 추가했습니다. `clubId=2`는 지원자 2명(비공개) 상태로 응답해 마스킹 분기를 확인할 수 있습니다.

### 스크린샷 (선택)

<!-- 대시보드 / 동아리 상세 캡처 첨부 예정 -->

## 💬리뷰 요구사항(선택)

**1. 통계 조회만 `useQuery`를 사용했습니다.** 다른 화면은 `useSuspenseQuery`로 통일돼 있지만, 지원폼이 없는 동아리는 이 API가 404(`FORM_NOT_FOUND`)를 내려줍니다. 프로젝트에 ErrorBoundary가 없어 `useSuspenseQuery`를 쓰면 동아리 상세 페이지 전체가 중단되므로, 통계 섹션만 조용히 숨겨지도록 `useQuery` + `retry: false`로 처리했습니다. ErrorBoundary 도입 후 통일하는 방향이 맞을지 의견 주시면 좋겠습니다.

**2. 지원자가 0명일 때는 값이 모두 0인 차트 대신 안내 문구를 보여줍니다.** 모집 시작 직후 빈 차트가 그려지는 것보다 낫다고 판단했는데, 추이 차트만이라도 그리는 편이 낫다면 알려주세요.

**3. 대시보드 배치** — 요약 카드 바로 아래에 넣어 `요약 → 분포 → 개별 지원자` 흐름이 되도록 했습니다. 지원자 목록이 아래로 밀리는 게 불편하다면 목록 하단으로 옮기겠습니다.
