### PR TITLE
[FEAT] 동아리 인기 지표 집계 연동 (조회 기록·heartbeat) (#505, #506)

### DIFF
--- a/src/app/mocks/handler/club.ts
+++ b/src/app/mocks/handler/club.ts
@@ -14,6 +14,8 @@ const getPopularClubsResolver = () => {
   return HttpResponse.json({ clubs }, { status: 200 });
 };
 
+const postClubHeartbeatResolver = () => new HttpResponse(null, { status: 204 });
+
 interface ClubApplicationParams extends PathParams {
   clubId: string;
 }
@@ -134,6 +136,10 @@ export const clubHandlers = [
     postApplicationSubmitResolver,
   ),
   http.post(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/views', postClubViewResolver),
+  http.post(
+    import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/heartbeat',
+    postClubHeartbeatResolver,
+  ),
   http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId', getClubDetailResolver),
   http.post(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId', postClubDetailResolver),
   http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/reviews', getClubReviewsResolver),

--- a/src/app/mocks/handler/club.ts
+++ b/src/app/mocks/handler/club.ts
@@ -133,6 +133,7 @@ export const clubHandlers = [
     import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/apply-submit',
     postApplicationSubmitResolver,
   ),
+  http.post(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/views', postClubViewResolver),
   http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId', getClubDetailResolver),
   http.post(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId', postClubDetailResolver),
   http.get(import.meta.env.VITE_API_BASE_URL + '/clubs/:clubId/reviews', getClubReviewsResolver),

--- a/src/app/mocks/handler/club.ts
+++ b/src/app/mocks/handler/club.ts
@@ -14,6 +14,8 @@ const getPopularClubsResolver = () => {
   return HttpResponse.json({ clubs }, { status: 200 });
 };
 
+const postClubViewResolver = () => new HttpResponse(null, { status: 204 });
+
 const postClubHeartbeatResolver = () => new HttpResponse(null, { status: 204 });
 
 interface ClubApplicationParams extends PathParams {

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -13,6 +13,7 @@ import { ClubInfoSidebarSection } from './components/ClubInfoSidebarSection';
 import ApplyButton from './components/ClubInfoSidebarSection/ApplyButton';
 import { ClubReviewsSection } from './components/ClubReviewsSection';
 import { useClubDetail } from './hooks/useClubDetail';
+import { useClubHeartbeat } from './hooks/useClubHeartbeat';
 import { useRecordClubView } from './hooks/useRecordClubView';
 
 import type { ClubCategoryEng } from '@/shared/types/club';
@@ -23,6 +24,7 @@ export const ClubDetailPage = () => {
   const isKeyboardVisible = useKeyboardVisible();
 
   useRecordClubView(club.clubId);
+  useClubHeartbeat(club.clubId);
 
   return (
     <>

--- a/src/pages/user/ClubDetail/Page.tsx
+++ b/src/pages/user/ClubDetail/Page.tsx
@@ -13,6 +13,7 @@ import { ClubInfoSidebarSection } from './components/ClubInfoSidebarSection';
 import ApplyButton from './components/ClubInfoSidebarSection/ApplyButton';
 import { ClubReviewsSection } from './components/ClubReviewsSection';
 import { useClubDetail } from './hooks/useClubDetail';
+import { useRecordClubView } from './hooks/useRecordClubView';
 
 import type { ClubCategoryEng } from '@/shared/types/club';
 
@@ -20,6 +21,8 @@ export const ClubDetailPage = () => {
   const { clubId } = useParams<{ clubId: string }>();
   const club = useClubDetail(Number(clubId));
   const isKeyboardVisible = useKeyboardVisible();
+
+  useRecordClubView(club.clubId);
 
   return (
     <>

--- a/src/pages/user/ClubDetail/api/clubHeartbeat.ts
+++ b/src/pages/user/ClubDetail/api/clubHeartbeat.ts
@@ -1,0 +1,10 @@
+import { apiInstance } from '@/app/api/initInstance';
+import { handleAxiosError } from '@/shared/utils/handleAxiosError';
+
+export const sendClubHeartbeat = async (clubId: number): Promise<void> => {
+  try {
+    await apiInstance.post(`/clubs/${clubId}/heartbeat`, null, { withCredentials: true });
+  } catch (error: unknown) {
+    return handleAxiosError(error, '동아리 조회 상태 갱신에 실패했습니다.');
+  }
+};

--- a/src/pages/user/ClubDetail/api/clubView.ts
+++ b/src/pages/user/ClubDetail/api/clubView.ts
@@ -1,0 +1,10 @@
+import { apiInstance } from '@/app/api/initInstance';
+import { handleAxiosError } from '@/shared/utils/handleAxiosError';
+
+export const recordClubView = async (clubId: number): Promise<void> => {
+  try {
+    await apiInstance.post(`/clubs/${clubId}/views`, null, { withCredentials: true });
+  } catch (error: unknown) {
+    return handleAxiosError(error, '동아리 조회 기록에 실패했습니다.');
+  }
+};

--- a/src/pages/user/ClubDetail/hooks/useClubHeartbeat.ts
+++ b/src/pages/user/ClubDetail/hooks/useClubHeartbeat.ts
@@ -1,0 +1,45 @@
+import { useMutation } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { sendClubHeartbeat } from '../api/clubHeartbeat';
+
+const HEARTBEAT_INTERVAL = 30_000;
+
+export const useClubHeartbeat = (clubId: number) => {
+  const { mutate } = useMutation({ mutationFn: sendClubHeartbeat });
+
+  useEffect(() => {
+    if (!Number.isFinite(clubId)) return;
+
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+
+    const stop = () => {
+      if (intervalId === undefined) return;
+
+      clearInterval(intervalId);
+      intervalId = undefined;
+    };
+
+    const start = () => {
+      stop();
+      intervalId = setInterval(() => mutate(clubId), HEARTBEAT_INTERVAL);
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') {
+        stop();
+        return;
+      }
+
+      mutate(clubId);
+      start();
+    };
+
+    if (document.visibilityState === 'visible') start();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [clubId, mutate]);
+};

--- a/src/pages/user/ClubDetail/hooks/useRecordClubView.ts
+++ b/src/pages/user/ClubDetail/hooks/useRecordClubView.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { recordClubView } from '../api/clubView';
+
+export const useRecordClubView = (clubId: number) => {
+  const recordedClubIdRef = useRef<number | null>(null);
+  const { mutate } = useMutation({ mutationFn: recordClubView });
+
+  useEffect(() => {
+    if (!Number.isFinite(clubId) || recordedClubIdRef.current === clubId) return;
+
+    recordedClubIdRef.current = clubId;
+    mutate(clubId);
+  }, [clubId, mutate]);
+};


### PR DESCRIPTION

## #️⃣ 연관된 이슈

>closes #505
>closes #506

## 📝 작업 내용

동아리 상세 페이지에서 실시간 인기 지표 집계에 필요한 데이터를 전송합니다.
| API | 역할 | 호출 시점 |
|---|---|---|
| `POST /clubs/{id}/views` | 상세 진입 기록 (최근 24시간 고유 조회자) | 상세 조회 성공 후 1회 |
| `POST /clubs/{id}/heartbeat` | 현재 조회 상태 갱신 (활성 사용자) | 상세 페이지가 보이는 동안 30초 주기 |

두 API 모두 응답이 `204 No Content`이고 화면에 표시되는 값이 없습니다. 수집된 데이터는 메인 화면 인기 배지(#502)에서 사용됩니다.

### 변경 파일

| 파일 | 내용 |
|---|---|
| `api/clubView.ts` | 신규 — 상세 진입 기록 |
| `api/clubHeartbeat.ts` | 신규 — 조회 상태 갱신 |
| `hooks/useRecordClubView.ts` | 신규 — 진입당 1회 호출 보장 |
| `hooks/useClubHeartbeat.ts` | 신규 — 30초 주기 + 탭 가시성 연동 |
| `ClubDetail/Page.tsx` | 두 훅 호출 |
| `mocks/handler/club.ts` | 204 목 핸들러 2개 |


### 1. 마운트 시점 즉시 전송 배제

명세의 백엔드 정책 1번대로, 상세 진입은 `/views`가 이미 활성 상태로 기록합니다. 여기서 heartbeat를 한 번 더 보내면 같은 시점에 중복 요청이 되어 20초 요청 제한에 그대로 걸립니다.
따라서 첫 heartbeat는 진입 30초 후이며, 즉시 전송은 **탭이 가려졌다가 다시 보일 때만** 발생합니다(호출 규칙 4).

배경 탭에서 열린 경우도 처리됩니다. 마운트 시 `hidden`이면 인터벌을 시작하지 않고, 사용자가 해당 탭으로 전환하는 순간 즉시 1회 전송 + 주기 시작으로 이어집니다.

### 2. 중복 호출 방지

- **조회 기록**: `recordedClubIdRef` 가드로 리렌더와 StrictMode의 이펙트 중복 실행을 걸러 진입당 1회만 호출합니다. 재진입·새로고침 시에는 컴포넌트가 다시 마운트되며 ref가 초기화되어 정상적으로 다시 기록됩니다.
- **heartbeat**: `visibilitychange`로 인터벌을 시작·중단하고, 언마운트 시 인터벌과 리스너를 모두 해제합니다.

### 3. 호출 시점 보장

`useClubDetail`이 suspense 쿼리라 `ClubDetailPage`가 렌더되는 시점은 항상 `GET /clubs/{id}` 성공 이후입니다.
또한 URL 파라미터가 아니라 응답의 `clubId`를 사용하므로 파라미터 파싱 실패 케이스가 자동으로 배제됩니다.
